### PR TITLE
feat: Return none when friendship status not found and paginate friendship requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@dcl/platform-crypto-middleware": "^1.1.0",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-12933824416.commit-ed8c3aa.tgz",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-13021146556.commit-7327e37.tgz",
     "@dcl/rpc": "^1.1.2",
     "@dcl/schemas": "^15.6.0",
     "@well-known-components/env-config-provider": "^1.2.0",

--- a/src/adapters/rpc-server/services/get-friendship-status.ts
+++ b/src/adapters/rpc-server/services/get-friendship-status.ts
@@ -27,17 +27,6 @@ export function getFriendshipStatusService({ components: { logs, db } }: RPCServ
 
       const lastFriendshipAction = await db.getLastFriendshipActionByUsers(loggedUserAddress, userAddress)
 
-      if (!lastFriendshipAction) {
-        return {
-          response: {
-            $case: 'internalServerError',
-            internalServerError: {
-              message: 'No friendship found'
-            }
-          }
-        }
-      }
-
       return {
         response: {
           $case: 'accepted',

--- a/src/adapters/rpc-server/services/get-sent-friendship-requests.ts
+++ b/src/adapters/rpc-server/services/get-sent-friendship-requests.ts
@@ -4,6 +4,7 @@ import {
   PaginatedFriendshipRequestsResponse,
   GetFriendshipRequestsPayload
 } from '@dcl/protocol/out-js/decentraland/social_service/v2/social_service_v2.gen'
+import { getPage } from '../../../utils/pagination'
 
 export async function getSentFriendshipRequestsService({
   components: { logs, db, catalystClient, config }
@@ -16,9 +17,13 @@ export async function getSentFriendshipRequestsService({
     context: RpcServerContext
   ): Promise<PaginatedFriendshipRequestsResponse> {
     try {
-      const sentRequests = await db.getSentFriendshipRequests(context.address, request.pagination)
-      const sentRequestsAddresses = sentRequests.map(({ address }) => address)
+      const { limit, offset } = request.pagination || {}
+      const [sentRequests, sentRequestsCount] = await Promise.all([
+        db.getSentFriendshipRequests(context.address, request.pagination),
+        db.getSentFriendshipRequestsCount(context.address)
+      ])
 
+      const sentRequestsAddresses = sentRequests.map(({ address }) => address)
       const sentRequestedProfiles = await catalystClient.getEntitiesByPointers(sentRequestsAddresses)
 
       const requests = parseFriendshipRequestsToFriendshipRequestResponses(
@@ -33,6 +38,10 @@ export async function getSentFriendshipRequestsService({
           requests: {
             requests
           }
+        },
+        paginationData: {
+          total: sentRequestsCount,
+          page: getPage(limit ?? sentRequestsCount, offset)
         }
       }
     } catch (error: any) {

--- a/src/logic/friendships.ts
+++ b/src/logic/friendships.ts
@@ -211,9 +211,11 @@ export function parseEmittedUpdateToFriendConnectivityUpdate(
 }
 
 export function getFriendshipRequestStatus(
-  friendshipAction: Pick<FriendshipAction, 'action' | 'acting_user'>,
+  friendshipAction: Pick<FriendshipAction, 'action' | 'acting_user'> | undefined,
   loggedUserAddress: string
 ): FriendshipRequestStatus {
+  if (!friendshipAction) return FriendshipRequestStatus.UNRECOGNIZED
+
   const { action, acting_user } = friendshipAction
   const statusResolver = FRIENDSHIP_STATUS_BY_ACTION[action]
   return statusResolver?.(acting_user, loggedUserAddress) ?? FriendshipRequestStatus.UNRECOGNIZED

--- a/src/logic/friendships.ts
+++ b/src/logic/friendships.ts
@@ -214,7 +214,7 @@ export function getFriendshipRequestStatus(
   friendshipAction: Pick<FriendshipAction, 'action' | 'acting_user'> | undefined,
   loggedUserAddress: string
 ): FriendshipRequestStatus {
-  if (!friendshipAction) return FriendshipRequestStatus.UNRECOGNIZED
+  if (!friendshipAction) return FriendshipRequestStatus.NONE
 
   const { action, acting_user } = friendshipAction
   const statusResolver = FRIENDSHIP_STATUS_BY_ACTION[action]

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,9 @@ export interface IDatabaseComponent {
     txClient?: PoolClient
   ): Promise<string>
   getReceivedFriendshipRequests(userAddress: string, pagination?: Pagination): Promise<FriendshipRequest[]>
+  getReceivedFriendshipRequestsCount(userAddress: string): Promise<number>
   getSentFriendshipRequests(userAddress: string, pagination?: Pagination): Promise<FriendshipRequest[]>
+  getSentFriendshipRequestsCount(userAddress: string): Promise<number>
   getOnlineFriends(userAddress: string, potentialFriends: string[]): Promise<Friend[]>
   executeTx<T>(cb: (client: PoolClient) => Promise<T>): Promise<T>
 }

--- a/test/mocks/components/db.ts
+++ b/test/mocks/components/db.ts
@@ -13,6 +13,8 @@ export const mockDb: jest.Mocked<IDatabaseComponent> = {
   getLastFriendshipActionByUsers: jest.fn(),
   recordFriendshipAction: jest.fn(),
   getReceivedFriendshipRequests: jest.fn(),
+  getReceivedFriendshipRequestsCount: jest.fn(),
   getSentFriendshipRequests: jest.fn(),
+  getSentFriendshipRequestsCount: jest.fn(),
   executeTx: jest.fn()
 }

--- a/test/unit/adapters/db.spec.ts
+++ b/test/unit/adapters/db.spec.ts
@@ -285,6 +285,17 @@ describe('db', () => {
     })
   })
 
+  describe('getReceivedFriendshipRequestsCount', () => {
+    it('should return the count of received friendship requests', async () => {
+      const mockCount = 5
+      mockPg.query.mockResolvedValueOnce({ rows: [{ count: mockCount }], rowCount: 1 })
+
+      const result = await dbComponent.getReceivedFriendshipRequestsCount('0x456')
+
+      expect(result).toBe(mockCount)
+    })
+  })
+
   describe('getSentFriendshipRequests', () => {
     it('should retrieve sent friendship requests', async () => {
       const mockRequests = [
@@ -314,6 +325,17 @@ describe('db', () => {
         })
       )
       expectPaginatedQueryToHaveBeenCalledWithProperLimitAndOffset(10, 5)
+    })
+  })
+
+  describe('getSentFriendshipRequestsCount', () => {
+    it('should return the count of sent friendship requests', async () => {
+      const mockCount = 5
+      mockPg.query.mockResolvedValueOnce({ rows: [{ count: mockCount }], rowCount: 1 })
+
+      const result = await dbComponent.getSentFriendshipRequestsCount('0x123')
+
+      expect(result).toBe(mockCount)
     })
   })
 
@@ -426,8 +448,7 @@ describe('db', () => {
   })
 
   // Helpers
-
-  function expectPaginatedQueryToHaveBeenCalledWithProperLimitAndOffset(limit, offset) {
+  function expectPaginatedQueryToHaveBeenCalledWithProperLimitAndOffset(limit: number, offset: number) {
     expect(mockPg.query).toHaveBeenCalledWith(
       expect.objectContaining({
         text: expect.stringContaining('LIMIT'),

--- a/test/unit/adapters/rpc-server/services/get-friendship-status.spec.ts
+++ b/test/unit/adapters/rpc-server/services/get-friendship-status.spec.ts
@@ -51,7 +51,7 @@ describe('getFriendshipStatusService', () => {
     })
   })
 
-  it('should return unrecognized if no friendship action is found', async () => {
+  it('should return none if no friendship action is found', async () => {
     mockDb.getLastFriendshipActionByUsers.mockResolvedValueOnce(null)
 
     const result: GetFriendshipStatusResponse = await getFriendshipStatus(mockRequest, rpcContext)
@@ -61,7 +61,7 @@ describe('getFriendshipStatusService', () => {
       response: {
         $case: 'accepted',
         accepted: {
-          status: FriendshipStatus.UNRECOGNIZED
+          status: FriendshipStatus.NONE
         }
       }
     })

--- a/test/unit/adapters/rpc-server/services/get-friendship-status.spec.ts
+++ b/test/unit/adapters/rpc-server/services/get-friendship-status.spec.ts
@@ -51,7 +51,7 @@ describe('getFriendshipStatusService', () => {
     })
   })
 
-  it('should return internalServerError if no friendship action is found', async () => {
+  it('should return unrecognized if no friendship action is found', async () => {
     mockDb.getLastFriendshipActionByUsers.mockResolvedValueOnce(null)
 
     const result: GetFriendshipStatusResponse = await getFriendshipStatus(mockRequest, rpcContext)
@@ -59,9 +59,9 @@ describe('getFriendshipStatusService', () => {
     expect(mockDb.getLastFriendshipActionByUsers).toHaveBeenCalledWith('0x123', '0x456')
     expect(result).toEqual({
       response: {
-        $case: 'internalServerError',
-        internalServerError: {
-          message: 'No friendship found'
+        $case: 'accepted',
+        accepted: {
+          status: FriendshipStatus.UNRECOGNIZED
         }
       }
     })

--- a/test/unit/adapters/rpc-server/services/get-pending-friendship-requests.spec.ts
+++ b/test/unit/adapters/rpc-server/services/get-pending-friendship-requests.spec.ts
@@ -30,6 +30,7 @@ describe('getPendingFriendshipRequestsService', () => {
     const mockProfiles = mockPendingRequests.map(({ address }) => createMockProfile(address))
 
     mockDb.getReceivedFriendshipRequests.mockResolvedValueOnce(mockPendingRequests)
+    mockDb.getReceivedFriendshipRequestsCount.mockResolvedValueOnce(mockPendingRequests.length)
     mockCatalystClient.getEntitiesByPointers.mockResolvedValueOnce(mockProfiles)
     const result: PaginatedFriendshipRequestsResponse = await getPendingRequests(emptyRequest, rpcContext)
 
@@ -42,12 +43,19 @@ describe('getPendingFriendshipRequestsService', () => {
             createMockExpectedFriendshipRequest('id2', '0x789', mockProfiles[1], '2025-01-02T00:00:00Z')
           ]
         }
+      },
+      paginationData: {
+        total: mockPendingRequests.length,
+        page: 1
       }
     })
   })
 
-  it('should handle database errors gracefully', async () => {
-    mockDb.getReceivedFriendshipRequests.mockImplementationOnce(() => {
+  it.each([
+    ['getReceivedFriendshipRequests', mockDb.getReceivedFriendshipRequests],
+    ['getReceivedFriendshipRequestsCount', mockDb.getReceivedFriendshipRequestsCount]
+  ])('should handle database errors in the %s method gracefully', async (_methodName, method) => {
+    method.mockImplementationOnce(() => {
       throw new Error('Database error')
     })
 
@@ -66,6 +74,7 @@ describe('getPendingFriendshipRequestsService', () => {
     const mockProfiles = mockPendingRequests.map(({ address }) => createMockProfile(address))
 
     mockDb.getReceivedFriendshipRequests.mockResolvedValueOnce(mockPendingRequests)
+    mockDb.getReceivedFriendshipRequestsCount.mockResolvedValueOnce(mockPendingRequests.length)
     mockCatalystClient.getEntitiesByPointers.mockResolvedValueOnce(mockProfiles)
 
     const result: PaginatedFriendshipRequestsResponse = await getPendingRequests(emptyRequest, rpcContext)
@@ -76,6 +85,10 @@ describe('getPendingFriendshipRequestsService', () => {
         requests: {
           requests: [createMockExpectedFriendshipRequest('id1', '0x456', mockProfiles[0], '2025-01-01T00:00:00Z', '')]
         }
+      },
+      paginationData: {
+        total: mockPendingRequests.length,
+        page: 1
       }
     })
   })

--- a/test/unit/adapters/rpc-server/services/get-sent-friendship-requests.spec.ts
+++ b/test/unit/adapters/rpc-server/services/get-sent-friendship-requests.spec.ts
@@ -30,6 +30,7 @@ describe('getSentFriendshipRequestsService', () => {
     const mockProfiles = mockSentRequests.map(({ address }) => createMockProfile(address))
 
     mockDb.getSentFriendshipRequests.mockResolvedValueOnce(mockSentRequests)
+    mockDb.getSentFriendshipRequestsCount.mockResolvedValueOnce(mockSentRequests.length)
     mockCatalystClient.getEntitiesByPointers.mockResolvedValueOnce(mockProfiles)
 
     const result: PaginatedFriendshipRequestsResponse = await getSentRequests(emptyRequest, rpcContext)
@@ -43,12 +44,19 @@ describe('getSentFriendshipRequestsService', () => {
             createMockExpectedFriendshipRequest('id2', '0x789', mockProfiles[1], '2025-01-02T00:00:00Z')
           ]
         }
+      },
+      paginationData: {
+        total: mockSentRequests.length,
+        page: 1
       }
     })
   })
 
-  it('should handle database errors gracefully', async () => {
-    mockDb.getSentFriendshipRequests.mockImplementationOnce(() => {
+  it.each([
+    ['getSentFriendshipRequests', mockDb.getSentFriendshipRequests],
+    ['getSentFriendshipRequestsCount', mockDb.getSentFriendshipRequestsCount]
+  ])('should handle database errors in the %s method gracefully', async (_methodName, method) => {
+    method.mockImplementationOnce(() => {
       throw new Error('Database error')
     })
 
@@ -67,6 +75,7 @@ describe('getSentFriendshipRequestsService', () => {
     const mockProfiles = mockSentRequests.map(({ address }) => createMockProfile(address))
 
     mockDb.getSentFriendshipRequests.mockResolvedValueOnce(mockSentRequests)
+    mockDb.getSentFriendshipRequestsCount.mockResolvedValueOnce(mockSentRequests.length)
     mockCatalystClient.getEntitiesByPointers.mockResolvedValueOnce(mockProfiles)
 
     const result: PaginatedFriendshipRequestsResponse = await getSentRequests(emptyRequest, rpcContext)
@@ -77,6 +86,10 @@ describe('getSentFriendshipRequestsService', () => {
         requests: {
           requests: [createMockExpectedFriendshipRequest('id1', '0x456', mockProfiles[0], '2025-01-01T00:00:00Z')]
         }
+      },
+      paginationData: {
+        total: mockSentRequests.length,
+        page: 1
       }
     })
   })

--- a/test/unit/logic/friendships.spec.ts
+++ b/test/unit/logic/friendships.spec.ts
@@ -573,8 +573,8 @@ describe('getFriendshipRequestStatus()', () => {
     expect(getFriendshipRequestStatus({ ...friendshipAction, action }, '0x123')).toBe(expected)
   })
 
-  test('when the last action is undefined it should return unrecognized', () => {
-    expect(getFriendshipRequestStatus(undefined, '0x123')).toBe(FriendshipRequestStatus.UNRECOGNIZED)
+  test('when the last action is undefined it should return none', () => {
+    expect(getFriendshipRequestStatus(undefined, '0x123')).toBe(FriendshipRequestStatus.NONE)
   })
 
   test('when the last action is request and the acting user is the logged user it should return request sent', () => {

--- a/test/unit/logic/friendships.spec.ts
+++ b/test/unit/logic/friendships.spec.ts
@@ -573,6 +573,10 @@ describe('getFriendshipRequestStatus()', () => {
     expect(getFriendshipRequestStatus({ ...friendshipAction, action }, '0x123')).toBe(expected)
   })
 
+  test('when the last action is undefined it should return unrecognized', () => {
+    expect(getFriendshipRequestStatus(undefined, '0x123')).toBe(FriendshipRequestStatus.UNRECOGNIZED)
+  })
+
   test('when the last action is request and the acting user is the logged user it should return request sent', () => {
     expect(getFriendshipRequestStatus({ ...friendshipAction, action: Action.REQUEST }, '0x123')).toBe(
       FriendshipRequestStatus.REQUEST_SENT

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,15 +354,15 @@
     "@well-known-components/fetch-component" "^2.0.2"
     "@well-known-components/interfaces" "^1.4.2"
 
-"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-12916692077.commit-190ed21.tgz":
-  version "1.0.0-12916692077.commit-190ed21"
-  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-12916692077.commit-190ed21.tgz#32741f275d43b610db3ffcc702381672cfa9acbc"
-  dependencies:
-    "@dcl/ts-proto" "1.154.0"
-
 "@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-12933824416.commit-ed8c3aa.tgz":
   version "1.0.0-12933824416.commit-ed8c3aa"
   resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-12933824416.commit-ed8c3aa.tgz#68fcc57917b601b0d9f5d257215a7bf51a1dc9a6"
+  dependencies:
+    "@dcl/ts-proto" "1.154.0"
+
+"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-13021146556.commit-7327e37.tgz":
+  version "1.0.0-13021146556.commit-7327e37"
+  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-13021146556.commit-7327e37.tgz#9f0e1ee50633bba35736beb90cb6c7c7300d8e58"
   dependencies:
     "@dcl/ts-proto" "1.154.0"
 


### PR DESCRIPTION
- Added proper `None` status response when checking friendship status between two users with no existing relationship
- Enhanced `get_sent_friendship_requests` endpoint to include pagination data in response
- Enhanced `get_pending_friendship_requests` endpoint to include pagination data in response