### PR TITLE
feat: Add the privacy-settings endpoint

### DIFF
--- a/src/adapters/rpc-server/services/get-private-messages-settings.ts
+++ b/src/adapters/rpc-server/services/get-private-messages-settings.ts
@@ -20,7 +20,7 @@ export function getPrivateMessagesSettingsService({ components: { logs, db } }: 
       // Create base message privacy settings map
       const privacySettings = userAddresses.reduce(
         (acc, address) => {
-          acc[address] = PrivateMessagePrivacySetting.ONLY_FRIENDS
+          acc[address] = PrivateMessagePrivacySetting.ALL
           return acc
         },
         {} as Record<string, PrivateMessagePrivacySetting>

--- a/src/controllers/handlers/privacy-handler.ts
+++ b/src/controllers/handlers/privacy-handler.ts
@@ -1,0 +1,45 @@
+import { HttpRequest, HttpResponse } from '@well-known-components/uws-http-server'
+import { AppComponents, PrivateMessagesPrivacy } from '../../types'
+import { isErrorWithMessage } from '../../utils/errors'
+import { isValidAddress } from '../../utils/address'
+
+export async function createPrivacyHandler(components: Pick<AppComponents, 'db' | 'logs'>) {
+  const { db, logs } = components
+  const logger = logs.getLogger('privacy-handler')
+
+  return {
+    path: '/v1/users/:address/privacy-settings',
+    f: async (_: HttpResponse, req: HttpRequest) => {
+      const address = req.getParameter(0)?.toLowerCase()
+      logger.info(`Getting privacy settings for address: ${address}`)
+
+      if (!isValidAddress(address)) {
+        return {
+          status: 400,
+          body: { error: 'Invalid address' }
+        }
+      }
+
+      try {
+        const settings = await db.getSocialSettings([address])
+
+        return {
+          status: 200,
+          body: {
+            private_messages_privacy: settings[0]?.private_messages_privacy ?? PrivateMessagesPrivacy.ALL
+          }
+        }
+      } catch (error) {
+        logger.error(
+          `Error getting privacy settings for address: ${address}, error: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
+        )
+        return {
+          status: 500,
+          body: {
+            error: isErrorWithMessage(error) ? error.message : 'Unknown error'
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -8,6 +8,7 @@ import {
 import { AppComponents, IHandler, TestComponents } from '../types'
 import { createStatusHandler } from './handlers/status-handler'
 import { registerWsHandler } from './handlers/ws-handler'
+import { createPrivacyHandler } from './handlers/privacy-handler'
 
 export async function setupRoutes(components: AppComponents | TestComponents): Promise<void> {
   const { metrics, server } = components
@@ -15,11 +16,17 @@ export async function setupRoutes(components: AppComponents | TestComponents): P
   function wrap(h: IHandler) {
     return async (res: HttpResponse, req: HttpRequest) => {
       const { labels, end } = onRequestStart(metrics, req.getMethod(), h.path)
+      res.onAborted(() => {
+        res.aborted = true
+      })
       let status = 500
       try {
         const result = await h.f(res, req)
+
         status = result.status ?? 200
-        res.writeStatus(`${status}`)
+        if (!res.aborted) {
+          res.writeStatus(`${status}`)
+        }
 
         const headers = new Headers(result.headers ?? {})
 
@@ -27,19 +34,23 @@ export async function setupRoutes(components: AppComponents | TestComponents): P
           headers.set('Access-Control-Allow-Origin', '*')
         }
 
-        headers.forEach((v, k) => res.writeHeader(k, v))
+        headers.forEach((v, k) => !res.aborted && res.writeHeader(k, v))
 
-        if (result.body === undefined) {
-          res.end()
-        } else if (typeof result.body === 'string') {
-          res.end(result.body)
-        } else {
-          res.writeHeader('content-type', 'application/json')
-          res.end(JSON.stringify(result.body))
+        if (!res.aborted) {
+          if (result.body === undefined) {
+            res.end()
+          } else if (typeof result.body === 'string') {
+            res.end(result.body)
+          } else {
+            res.writeHeader('content-type', 'application/json')
+            res.end(JSON.stringify(result.body))
+          }
         }
       } catch (err) {
-        res.writeStatus(`${status}`)
-        res.end()
+        if (!res.aborted) {
+          res.writeStatus(`${status}`)
+          res.end()
+        }
       } finally {
         onRequestEnd(metrics, labels, status, end)
       }
@@ -57,6 +68,9 @@ export async function setupRoutes(components: AppComponents | TestComponents): P
     const { path, handler } = await createMetricsHandler(components, metrics.registry!)
     server.app.get(path, handler)
   }
+
+  const privacyHandler = await createPrivacyHandler(components)
+  server.app.get(privacyHandler.path, wrap(privacyHandler))
 
   server.app.any('/health/live', (res, req) => {
     const { end, labels } = onRequestStart(metrics, req.getMethod(), '/health/live')

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,3 +1,7 @@
 export function normalizeAddress(address: string) {
   return address.toLowerCase()
 }
+
+export function isValidAddress(address: string): boolean {
+  return /^0x[a-fA-F0-9]{40}$/.test(address)
+}

--- a/test/integration/privacy-controller.spec.ts
+++ b/test/integration/privacy-controller.spec.ts
@@ -1,0 +1,70 @@
+import { test } from '../components'
+import { PrivateMessagesPrivacy } from '../../src/types'
+import { createOrUpdateSocialSettings } from './utils/friendships'
+
+test('Privacy Controller', function ({ components, spyComponents }) {
+  describe('when checking the privacy settings', () => {
+    let address: string
+
+    describe('and there are privacy settings set for the address', () => {
+      beforeEach(async () => {
+        address = '0xa8b0cc8d68b3708df1a2ea3aef330d0e42681df8'
+        await createOrUpdateSocialSettings(components.db, address, PrivateMessagesPrivacy.ONLY_FRIENDS)
+      })
+
+      it('should respond with a 200 status code and the privacy settings', async () => {
+        const { localFetch } = components
+
+        const response = await localFetch.fetch(`/v1/users/${address}/privacy-settings`)
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+          private_messages_privacy: PrivateMessagesPrivacy.ONLY_FRIENDS
+        })
+      })
+    })
+
+    describe('and there are no privacy settings set for the address', () => {
+      beforeAll(async () => {
+        address = '0x0000000000000000000000000000000000000000'
+      })
+
+      it('should respond with a 200 status code and the default privacy settings', async () => {
+        const { localFetch } = components
+
+        const response = await localFetch.fetch(`/v1/users/${address}/privacy-settings`)
+        expect(response.status).toBe(200)
+        expect(await response.json()).toEqual({
+          private_messages_privacy: PrivateMessagesPrivacy.ALL
+        })
+      })
+    })
+
+    describe('and the address is not valid', () => {
+      beforeAll(async () => {
+        address = '0x'
+      })
+
+      it('should respond with a 400 status code and a message saying that the address is invalid', async () => {
+        const { localFetch } = components
+
+        const response = await localFetch.fetch(`/v1/users/${address}/privacy-settings`)
+        expect(response.status).toBe(400)
+        expect(await response.json()).toEqual({ error: 'Invalid address' })
+      })
+    })
+
+    describe('and getting the privacy settings from the DB fails', () => {
+      beforeEach(() => {
+        spyComponents.db.getSocialSettings.mockRejectedValueOnce(new Error('Failed to get privacy settings'))
+        address = '0xa8b0cc8d68b3708df1a2ea3aef330d0e42681df8'
+      })
+
+      it('should respond with a 500 status code and an error message', async () => {
+        const { localFetch } = components
+        const response = await localFetch.fetch(`/v1/users/${address}/privacy-settings`)
+        expect(response.status).toBe(500)
+        expect(await response.json()).toEqual({ error: 'Failed to get privacy settings' })
+      })
+    })
+  })
+})

--- a/test/integration/utils/auth.ts
+++ b/test/integration/utils/auth.ts
@@ -1,6 +1,5 @@
 import { Authenticator, AuthIdentity, IdentityType } from '@dcl/crypto'
 import { createUnsafeIdentity } from '@dcl/crypto/dist/crypto'
-import { AUTH_CHAIN_HEADER_PREFIX, AUTH_METADATA_HEADER, AUTH_TIMESTAMP_HEADER } from '@dcl/platform-crypto-middleware'
 import { signedHeaderFactory } from 'decentraland-crypto-fetch'
 
 export type Identity = {

--- a/test/integration/utils/friendships.ts
+++ b/test/integration/utils/friendships.ts
@@ -1,4 +1,4 @@
-import { IDatabaseComponent } from '../../../src/types'
+import { IDatabaseComponent, PrivateMessagesPrivacy } from '../../../src/types'
 import { Action } from '../../../src/types'
 
 export async function createFriendshipRequest(
@@ -38,4 +38,14 @@ export async function createPendingFriendshipRequest(db: IDatabaseComponent, use
 export async function removeFriendship(db: IDatabaseComponent, id: string, actingUser: string) {
   await db.updateFriendshipStatus(id, false)
   await db.recordFriendshipAction(id, actingUser, Action.DELETE, null)
+}
+
+export async function createOrUpdateSocialSettings(
+  db: IDatabaseComponent,
+  address: string,
+  privacySettings: PrivateMessagesPrivacy
+) {
+  await db.upsertSocialSettings(address, {
+    private_messages_privacy: privacySettings
+  })
 }

--- a/test/unit/adapters/rpc-server/services/get-private-messages-settings.spec.ts
+++ b/test/unit/adapters/rpc-server/services/get-private-messages-settings.spec.ts
@@ -85,7 +85,7 @@ describe('getPrivateMessagesSettingsService', () => {
     const mockSettings: DBSocialSettings[] = [
       {
         address: testAddress1,
-        private_messages_privacy: DBPrivateMessagesPrivacy.ALL,
+        private_messages_privacy: DBPrivateMessagesPrivacy.ONLY_FRIENDS,
         blocked_users_messages_visibility: DBBlockedUsersMessagesVisibilitySetting.DO_NOT_SHOW_MESSAGES
       }
     ]
@@ -103,12 +103,12 @@ describe('getPrivateMessagesSettingsService', () => {
       expect(result.response.ok.settings).toHaveLength(2)
       expect(result.response.ok.settings).toContainEqual({
         user: { address: testAddress1 },
-        privateMessagesPrivacy: PrivateMessagePrivacySetting.ALL
+        privateMessagesPrivacy: PrivateMessagePrivacySetting.ONLY_FRIENDS
       })
       // The second user has no saved settings, check that the default setting is returned
       expect(result.response.ok.settings).toContainEqual({
         user: { address: testAddress2 },
-        privateMessagesPrivacy: PrivateMessagePrivacySetting.ONLY_FRIENDS
+        privateMessagesPrivacy: PrivateMessagePrivacySetting.ALL
       })
     }
   })

--- a/test/unit/utils/address.spec.ts
+++ b/test/unit/utils/address.spec.ts
@@ -1,4 +1,4 @@
-import { normalizeAddress } from '../../../src/utils/address'
+import { isValidAddress, normalizeAddress } from '../../../src/utils/address'
 
 describe('normalizeAddress', () => {
   it.each([
@@ -8,5 +8,49 @@ describe('normalizeAddress', () => {
   ])('should convert %s to %s', (address, expected) => {
     const normalized = normalizeAddress(address)
     expect(normalized).toBe(expected)
+  })
+})
+
+describe('when checking if an address is valid', () => {
+  let address: string
+
+  describe('and the address does not have the correct length', () => {
+    beforeEach(() => {
+      address = '0x000'
+    })
+
+    it('should return false', () => {
+      expect(isValidAddress(address)).toBe(false)
+    })
+  })
+
+  describe('and the address does not start with 0x', () => {
+    beforeEach(() => {
+      address = 'abcdef1234567890'
+    })
+
+    it('should return false', () => {
+      expect(isValidAddress(address)).toBe(false)
+    })
+  })
+
+  describe('and the address has invalid characters', () => {
+    beforeEach(() => {
+      address = '0x000000000000000000000000000000000X0J0000'
+    })
+
+    it('should return false', () => {
+      expect(isValidAddress(address)).toBe(false)
+    })
+  })
+
+  describe('and the address contains the correct characters, length and prefix', () => {
+    beforeEach(() => {
+      address = '0x0000000000000000000000000000000000000000'
+    })
+
+    it('should return true', () => {
+      expect(isValidAddress(address)).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
This PR adds the the privacy-settings endpoint, which allows anyone to request the public privacy social privacy settings of a user. In this case, the only social privacy setting we currently have is if the user allows or disallows non-friends from contacting them via DMs.
This PR also changes the default value of the private messages privacy settings to `all`, making it possible for anyone to contact you via DM.