### PR TITLE
feat: Normalize DB addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,3 +264,4 @@ The project uses GitHub Actions for:
 
 - **Development**: Automatic deployments on main branch
 - **Production**: Manual deployments via GitHub releases
+

--- a/src/logic/queries.ts
+++ b/src/logic/queries.ts
@@ -71,15 +71,15 @@ function getUserFriendsCTE(userAddress: string) {
   return {
     query: SQL`SELECT DISTINCT
     CASE
-      WHEN LOWER(f.address_requester) = ${normalizedUserAddress} 
+      WHEN f.address_requester = ${normalizedUserAddress} 
       THEN f.address_requested
       ELSE f.address_requester
     END as address, created_at
   FROM friendships f
   WHERE f.is_active = true
     AND (
-      LOWER(f.address_requester) = ${normalizedUserAddress}
-      OR LOWER(f.address_requested) = ${normalizedUserAddress}
+      f.address_requester = ${normalizedUserAddress}
+      OR f.address_requested = ${normalizedUserAddress}
     )`,
     name: 'user_friends'
   }
@@ -89,13 +89,13 @@ function getBlockedForUserCTE(userAddress: string) {
   const normalizedUserAddress = normalizeAddress(userAddress)
   return {
     query: SQL`SELECT DISTINCT 
-      CASE WHEN LOWER(b.blocker_address) = ${normalizedUserAddress}
+      CASE WHEN b.blocker_address = ${normalizedUserAddress}
       THEN b.blocked_address
       ELSE b.blocker_address
     END as address
     FROM blocks b
-    WHERE LOWER(b.blocker_address) = ${normalizedUserAddress}
-      OR LOWER(b.blocked_address) = ${normalizedUserAddress}`,
+    WHERE b.blocker_address = ${normalizedUserAddress}
+      OR b.blocked_address = ${normalizedUserAddress}`,
     name: 'blocked_for_user'
   }
 }

--- a/src/logic/queries.ts
+++ b/src/logic/queries.ts
@@ -9,9 +9,9 @@ function withAlias(tableAlias?: string): string {
 export function getFriendAddressCase(userAddress: string, tableAlias?: string): SQLStatement {
   const normalizedUserAddress = normalizeAddress(userAddress)
   return SQL`CASE
-    WHEN LOWER(`
+    WHEN `
     .append(withAlias(tableAlias))
-    .append(SQL`address_requester) = ${normalizedUserAddress} THEN `)
+    .append(SQL`address_requester = ${normalizedUserAddress} THEN `)
     .append(withAlias(tableAlias))
     .append(
       SQL`address_requested
@@ -23,11 +23,11 @@ export function getFriendAddressCase(userAddress: string, tableAlias?: string): 
 
 export function getFriendshipCondition(userAddress: string, tableAlias: string): SQLStatement {
   const normalizedUserAddress = normalizeAddress(userAddress)
-  return SQL`(LOWER(`
+  return SQL`(`
     .append(tableAlias)
-    .append(SQL`.address_requester) = ${normalizedUserAddress} OR LOWER(`)
+    .append(SQL`.address_requester = ${normalizedUserAddress} OR `)
     .append(tableAlias)
-    .append(SQL`.address_requested) = ${normalizedUserAddress})`)
+    .append(SQL`.address_requested = ${normalizedUserAddress})`)
 }
 
 export function getBlockingCondition(

--- a/src/migrations/1736277138587_add-indexes.ts
+++ b/src/migrations/1736277138587_add-indexes.ts
@@ -5,7 +5,6 @@ export const shorthands: ColumnDefinitions | undefined = undefined
 export async function up(pgm: MigrationBuilder): Promise<void> {
   // Address indexes + constraints
   pgm.createIndex('friendships', 'address_requester', { name: 'friendships_address_requester', method: 'hash' })
-  pgm.createIndex('friendships', 'address_requested', { name: 'friendships_address_requested', method: 'hash' })
 
   pgm.createConstraint('friendships', 'unique_addresses', {
     unique: ['address_requester', 'address_requested']
@@ -16,10 +15,6 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     name: 'friendships_address_requester_lower',
     method: 'btree'
   })
-  pgm.createIndex('friendships', 'LOWER(address_requested) text_pattern_ops', {
-    name: 'friendships_address_requested_lower',
-    method: 'btree'
-  })
 
   // Friendship history index
   pgm.createIndex('friendship_actions', 'friendship_id', { name: 'friendship_actions_friendship_id' })
@@ -27,9 +22,7 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
   pgm.dropIndex('friendships', 'friendships_address_requester')
-  pgm.dropIndex('friendships', 'friendships_address_requested')
   pgm.dropConstraint('friendships', 'unique_addresses')
-  pgm.dropIndex('friendships', 'friendships_address_requester_lower')
   pgm.dropIndex('friendships', 'friendships_address_requested_lower')
   pgm.dropIndex('friendship_actions', 'friendship_actions_friendship_id')
 }

--- a/src/migrations/1737745803297_add-blocks.ts
+++ b/src/migrations/1737745803297_add-blocks.ts
@@ -22,13 +22,11 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     }
   })
 
-  pgm.createIndex('blocks', ['blocker_address'])
   pgm.createIndex('blocks', ['blocked_address'])
   pgm.createIndex('blocks', ['blocker_address', 'blocked_address'], { unique: true })
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
-  pgm.dropIndex('blocks', ['blocker_address'])
   pgm.dropIndex('blocks', ['blocked_address'])
   pgm.dropIndex('blocks', ['blocker_address', 'blocked_address'])
   pgm.dropTable('blocks')

--- a/src/migrations/1745258886310_normalize-address-in-friendships.ts
+++ b/src/migrations/1745258886310_normalize-address-in-friendships.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Normalize address in friendships
+  pgm.sql(
+    `UPDATE friendships SET address_requester = LOWER(address_requester), address_requested = LOWER(address_requested) WHERE address_requester ~ '[[:upper:]]' OR address_requested ~ '[[:upper:]]'`
+  )
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.createIndex('friendships', 'LOWER(address_requester) text_pattern_ops', {
+    name: 'friendships_address_requester_lower',
+    method: 'btree'
+  })
+}

--- a/src/migrations/1745258886310_normalize-address-in-friendships.ts
+++ b/src/migrations/1745258886310_normalize-address-in-friendships.ts
@@ -11,8 +11,5 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
-  pgm.createIndex('friendships', 'LOWER(address_requester) text_pattern_ops', {
-    name: 'friendships_address_requester_lower',
-    method: 'btree'
-  })
+  pgm.dropIndex('friendships', 'friendships_address_requester_lower')
 }


### PR DESCRIPTION
This PR does the following changes:
- Adds a migration to drop lowercased indexes and lowercase addresses that have uppercase.
- Removes the usage of `LOWER` from addresses on every query.