### PR TITLE
fix: Update node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM node:18-alpine AS builderenv
+FROM node:20-alpine AS builderenv
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ RUN yarn install --prod --frozen-lockfile
 
 ########################## END OF BUILD STAGE ##########################
 
-FROM node:18-alpine
+FROM node:20-alpine
 
 RUN apk update && \
     apk add --no-cache wget tini libstdc++ gcompat && \


### PR DESCRIPTION
This PR updates the server's node version to 20, the maximum node version working for the UWS dependency.