### PR TITLE
fix: Use the User type as the callee

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@aws-sdk/client-sns": "^3.734.0",
     "@dcl/platform-crypto-middleware": "^1.1.0",
     "@dcl/platform-server-commons": "^0.1.0",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15424156118.commit-52cb9c6.tgz",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15449846569.commit-8c3e14b.tgz",
     "@dcl/rpc": "^1.1.2",
     "@dcl/schemas": "^16.0.0",
     "@sentry/node": "^9.12.0",

--- a/src/adapters/rpc-server/services/start-private-voice-chat.ts
+++ b/src/adapters/rpc-server/services/start-private-voice-chat.ts
@@ -18,7 +18,16 @@ export function startPrivateVoiceChatService({ components: { logs, voice } }: RP
     context: RpcServerContext
   ): Promise<StartPrivateVoiceChatResponse> {
     try {
-      const callId = await voice.startPrivateVoiceChat(context.address, request.calleeAddress)
+      if (!request.callee?.address) {
+        return {
+          response: {
+            $case: 'invalidRequest',
+            invalidRequest: { message: 'Callee address is missing in the request payload' }
+          }
+        }
+      }
+
+      const callId = await voice.startPrivateVoiceChat(context.address, request.callee.address)
 
       return {
         response: {

--- a/test/unit/adapters/rpc-server/services/start-private-voice-chat.spec.ts
+++ b/test/unit/adapters/rpc-server/services/start-private-voice-chat.spec.ts
@@ -42,7 +42,7 @@ describe('when starting a private voice chat', () => {
     it('should resolve with an ok response and the call id', async () => {
       const result = await service(
         StartPrivateVoiceChatPayload.create({
-          calleeAddress: calleeAddress
+          callee: { address: calleeAddress }
         }),
         {
           address: callerAddress,
@@ -65,7 +65,7 @@ describe('when starting a private voice chat', () => {
     it('should resolve with a forbidden request response', async () => {
       const result = await service(
         StartPrivateVoiceChatPayload.create({
-          calleeAddress: calleeAddress
+          callee: { address: calleeAddress }
         }),
         {
           address: callerAddress,
@@ -90,7 +90,7 @@ describe('when starting a private voice chat', () => {
     it('should resolve with an invalid request response', async () => {
       const result = await service(
         StartPrivateVoiceChatPayload.create({
-          calleeAddress: calleeAddress
+          callee: { address: calleeAddress }
         }),
         {
           address: callerAddress,
@@ -113,7 +113,7 @@ describe('when starting a private voice chat', () => {
     it('should resolve with a conflicting request response', async () => {
       const result = await service(
         StartPrivateVoiceChatPayload.create({
-          calleeAddress: calleeAddress
+          callee: { address: calleeAddress }
         }),
         {
           address: callerAddress,
@@ -141,7 +141,7 @@ describe('when starting a private voice chat', () => {
     it('should resolve with an internal server error response', async () => {
       const result = await service(
         StartPrivateVoiceChatPayload.create({
-          calleeAddress: calleeAddress
+          callee: { address: calleeAddress }
         }),
         {
           address: callerAddress,

--- a/yarn.lock
+++ b/yarn.lock
@@ -766,15 +766,15 @@
     "@well-known-components/interfaces" "^1.4.3"
     node-fetch "^2.7.0"
 
-"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15423343169.commit-c5a740a.tgz":
-  version "1.0.0-15423343169.commit-c5a740a"
-  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15423343169.commit-c5a740a.tgz#a22b895c1be11a6fba31ef03ee712af9a70c09ab"
+"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15449666581.commit-6ea172e.tgz":
+  version "1.0.0-15449666581.commit-6ea172e"
+  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15449666581.commit-6ea172e.tgz#8b40740765f189c5db26fc158d4c3e4eef4d9a75"
   dependencies:
     "@dcl/ts-proto" "1.154.0"
 
-"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15424156118.commit-52cb9c6.tgz":
-  version "1.0.0-15424156118.commit-52cb9c6"
-  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15424156118.commit-52cb9c6.tgz#a86cae1f9eb2b8889343bb6f28e32521da58cd93"
+"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15449846569.commit-8c3e14b.tgz":
+  version "1.0.0-15449846569.commit-8c3e14b"
+  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15449846569.commit-8c3e14b.tgz#d31bf80b64b8828b7f911bc3ce062889dfe089ae"
   dependencies:
     "@dcl/ts-proto" "1.154.0"
 


### PR DESCRIPTION
This PR changes the `callee` parameter in the `start-private-voice-chat` service handler to use the `User` type instead of the string one, keeping up with the standard.