### PR TITLE
feat: Improve actions to prevent race conditions

### DIFF
--- a/src/adapters/comms-gatekeeper.ts
+++ b/src/adapters/comms-gatekeeper.ts
@@ -98,7 +98,32 @@ export const createCommsGatekeeperComponent = async ({
     }
   }
 
+  async function endPrivateVoiceChat(callId: string, address: string): Promise<void> {
+    try {
+      const response = await fetch(`${commsUrl}/private-voice-chat/${callId}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${commsGateKeeperToken}`
+        },
+        body: JSON.stringify({
+          address
+        })
+      })
+
+      if (!response.ok) {
+        throw new Error(`Server responded with status ${response.status}`)
+      }
+    } catch (error) {
+      logger.error(
+        `Failed to end private voice chat for call ${callId} and address ${address}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
+      )
+      throw error
+    }
+  }
+
   return {
+    endPrivateVoiceChat,
     updateUserPrivateMessagePrivacyMetadata,
     isUserInAVoiceChat,
     getPrivateVoiceChatCredentials

--- a/src/adapters/voice-db.ts
+++ b/src/adapters/voice-db.ts
@@ -37,11 +37,12 @@ export async function createVoiceDBComponent(
       const results = await pg.query<PrivateVoiceChat>(query)
       return results.rows[0] ?? null
     },
-    async deletePrivateVoiceChat(callId: string): Promise<void> {
+    async deletePrivateVoiceChat(callId: string): Promise<PrivateVoiceChat | null> {
       const query = SQL`
-        DELETE FROM private_voice_chats WHERE id = ${callId}
+        DELETE FROM private_voice_chats WHERE id = ${callId} RETURNING *;
       `
-      await pg.query(query)
+      const results = await pg.query<PrivateVoiceChat>(query)
+      return results.rows[0] ?? null
     }
   }
 }

--- a/src/logic/voice/voice.ts
+++ b/src/logic/voice/voice.ts
@@ -144,6 +144,10 @@ export function createVoiceComponent({
         calleeAddress: privateVoiceChat.callee_address,
         status: VoiceChatStatus.REJECTED
       })
+    } else {
+      // If the voice chat was not deleted from the database, it means that the operation was not successful
+      // We need to notify the user that rejected the call
+      throw new VoiceChatNotFoundError(callId)
     }
   }
 

--- a/src/logic/voice/voice.ts
+++ b/src/logic/voice/voice.ts
@@ -90,25 +90,33 @@ export function createVoiceComponent({
       privateVoiceChat.caller_address
     )
 
-    // Notify the other user about the voice call being accepted
-    await pubsub.publishInChannel(PRIVATE_VOICE_CHAT_UPDATES_CHANNEL, {
-      callId,
-      callerAddress: privateVoiceChat.caller_address,
-      calleeAddress: privateVoiceChat.callee_address,
-      status: VoiceChatStatus.ACCEPTED,
-      // Credentials for the caller
-      credentials: {
-        token: credentials[privateVoiceChat.caller_address].token,
-        url: credentials[privateVoiceChat.caller_address].url
-      }
-    })
-
     // The call has been accepted, we can delete it from the database
-    await voiceDb.deletePrivateVoiceChat(callId)
+    const deletedVoiceChat = await voiceDb.deletePrivateVoiceChat(callId)
 
-    return {
-      token: credentials[privateVoiceChat.callee_address].token,
-      url: credentials[privateVoiceChat.callee_address].url
+    // In order to avoid race conditions, we need to check if the voice chat was deleted from the database
+    if (deletedVoiceChat) {
+      // Notify the other user about the voice call being accepted
+      await pubsub.publishInChannel(PRIVATE_VOICE_CHAT_UPDATES_CHANNEL, {
+        callId,
+        callerAddress: privateVoiceChat.caller_address,
+        calleeAddress: privateVoiceChat.callee_address,
+        status: VoiceChatStatus.ACCEPTED,
+        // Credentials for the caller
+        credentials: {
+          token: credentials[privateVoiceChat.caller_address].token,
+          url: credentials[privateVoiceChat.caller_address].url
+        }
+      })
+
+      return {
+        token: credentials[privateVoiceChat.callee_address].token,
+        url: credentials[privateVoiceChat.callee_address].url
+      }
+    } else {
+      // If the voice chat was not deleted from the database, it means that the call was rejected by the callee
+      // We need to notify the comms gatekeeper that the call has ended (reverting the call intent)
+      await commsGatekeeper.endPrivateVoiceChat(callId, calleeAddress)
+      throw new VoiceChatNotFoundError(callId)
     }
   }
 
@@ -124,14 +132,19 @@ export function createVoiceComponent({
       throw new VoiceChatExpiredError(callId)
     }
 
-    await pubsub.publishInChannel(PRIVATE_VOICE_CHAT_UPDATES_CHANNEL, {
-      callId,
-      callerAddress: privateVoiceChat.caller_address,
-      calleeAddress: privateVoiceChat.callee_address,
-      status: VoiceChatStatus.REJECTED
-    })
+    // Delete the voice chat from the database
+    const deletedVoiceChat = await voiceDb.deletePrivateVoiceChat(callId)
 
-    await voiceDb.deletePrivateVoiceChat(callId)
+    // In order to avoid race conditions, we need to check if the voice chat was deleted from the database
+    if (deletedVoiceChat) {
+      // Notify the other user that the call was rejected
+      await pubsub.publishInChannel(PRIVATE_VOICE_CHAT_UPDATES_CHANNEL, {
+        callId,
+        callerAddress: privateVoiceChat.caller_address,
+        calleeAddress: privateVoiceChat.callee_address,
+        status: VoiceChatStatus.REJECTED
+      })
+    }
   }
 
   return {

--- a/src/migrations/1749077198194_only-one-private-voice-chat-per-user.ts
+++ b/src/migrations/1749077198194_only-one-private-voice-chat-per-user.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // 1. A user can't call themselves
+  pgm.createConstraint('private_voice_chats', 'private_voice_chats_no_self_call_check', {
+    check: 'caller_address != callee_address'
+  })
+
+  // 2. A user can't be calling more than one user at the same time
+  pgm.createConstraint('private_voice_chats', 'private_voice_chats_unique_caller', {
+    unique: ['caller_address']
+  })
+
+  // 3. A user can't be receiving calls from more than one user at the same time
+  pgm.createConstraint('private_voice_chats', 'private_voice_chats_unique_callee', {
+    unique: ['callee_address']
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  // Drop constraints in reverse order
+  pgm.dropConstraint('private_voice_chats', 'private_voice_chats_unique_callee')
+  pgm.dropConstraint('private_voice_chats', 'private_voice_chats_unique_caller')
+  pgm.dropConstraint('private_voice_chats', 'private_voice_chats_no_self_call_check')
+}

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -153,20 +153,8 @@ export interface ICommunitiesDatabaseComponent {
 export interface IVoiceDatabaseComponent {
   areUsersBeingCalledOrCallingSomeone(userAddresses: string[]): Promise<boolean>
   createPrivateVoiceChat(callerAddress: string, calleeAddress: string): Promise<string>
-}
-
-export interface IVoiceDatabaseComponent {
-  areUsersBeingCalledOrCallingSomeone(userAddresses: string[]): Promise<boolean>
-  createPrivateVoiceChat(callerAddress: string, calleeAddress: string): Promise<string>
   getPrivateVoiceChat(callId: string): Promise<PrivateVoiceChat | null>
-  deletePrivateVoiceChat(callId: string): Promise<void>
-}
-
-export interface IVoiceDatabaseComponent {
-  areUsersBeingCalledOrCallingSomeone(userAddresses: string[]): Promise<boolean>
-  createPrivateVoiceChat(callerAddress: string, calleeAddress: string): Promise<string>
-  getPrivateVoiceChat(callId: string): Promise<PrivateVoiceChat | null>
-  deletePrivateVoiceChat(callId: string): Promise<void>
+  deletePrivateVoiceChat(callId: string): Promise<PrivateVoiceChat | null>
 }
 
 export interface IRedisComponent extends IBaseComponent {
@@ -252,6 +240,7 @@ export type ICommsGatekeeperComponent = {
     user: string,
     privateMessagesPrivacy: PrivateMessagesPrivacy
   ) => Promise<void>
+  endPrivateVoiceChat(callId: string, address: string): Promise<void>
 }
 
 export type IWebSocketComponent = IBaseComponent & {

--- a/test/mocks/components/comms-gatekeeper.ts
+++ b/test/mocks/components/comms-gatekeeper.ts
@@ -3,11 +3,13 @@ import { ICommsGatekeeperComponent } from '../../../src/types'
 export function createCommsGatekeeperMockedComponent({
   isUserInAVoiceChat = jest.fn(),
   updateUserPrivateMessagePrivacyMetadata = jest.fn(),
-  getPrivateVoiceChatCredentials = jest.fn()
+  getPrivateVoiceChatCredentials = jest.fn(),
+  endPrivateVoiceChat = jest.fn()
 }: Partial<jest.Mocked<ICommsGatekeeperComponent>>): jest.Mocked<ICommsGatekeeperComponent> {
   return {
     getPrivateVoiceChatCredentials,
     isUserInAVoiceChat,
-    updateUserPrivateMessagePrivacyMetadata
+    updateUserPrivateMessagePrivacyMetadata,
+    endPrivateVoiceChat
   }
 }

--- a/test/mocks/components/config.ts
+++ b/test/mocks/components/config.ts
@@ -6,3 +6,15 @@ export const mockConfig: jest.Mocked<IConfigComponent> = {
   requireNumber: jest.fn(),
   requireString: jest.fn()
 }
+
+export function createMockConfigComponent(
+  overrides: Partial<jest.Mocked<IConfigComponent>>
+): jest.Mocked<IConfigComponent> {
+  return {
+    getNumber: jest.fn(),
+    getString: jest.fn(),
+    requireNumber: jest.fn(),
+    requireString: jest.fn(),
+    ...overrides
+  }
+}

--- a/test/unit/adapters/commms-gatekeeper.spec.ts
+++ b/test/unit/adapters/commms-gatekeeper.spec.ts
@@ -234,11 +234,11 @@ describe('when ending a private voice chat', () => {
       })
     })
 
-    it('should resolve successfully', async () => {
+    it('should resolve to be undefined', async () => {
       await expect(commsGatekeeper.endPrivateVoiceChat(callId, address)).resolves.toBeUndefined()
     })
 
-    it('should make the correct API call', async () => {
+    it('should make the correct the API call to the configured URL in the config parameters using the configured auth token and the given address', async () => {
       await commsGatekeeper.endPrivateVoiceChat(callId, address)
       expect(fetchMock).toHaveBeenCalledWith('https://comms-gatekeeper.org/private-voice-chat/test-call-id-123', {
         method: 'DELETE',

--- a/test/unit/adapters/commms-gatekeepr.spec.ts
+++ b/test/unit/adapters/commms-gatekeepr.spec.ts
@@ -1,7 +1,7 @@
-import { ILoggerComponent, IFetchComponent } from '@well-known-components/interfaces'
+import { ILoggerComponent, IFetchComponent, IConfigComponent } from '@well-known-components/interfaces'
 import { createCommsGatekeeperComponent } from '../../../src/adapters/comms-gatekeeper'
 import { ICommsGatekeeperComponent, PrivateMessagesPrivacy } from '../../../src/types'
-import { mockConfig } from '../../mocks/components'
+import { createLogsMockedComponent, createMockConfigComponent, mockConfig } from '../../mocks/components'
 
 let fetchMock: jest.Mock
 let errorLogMock: jest.Mock
@@ -17,15 +17,24 @@ beforeEach(async () => {
   const fetcher: IFetchComponent = {
     fetch: fetchMock
   }
-  const logs: ILoggerComponent = {
-    getLogger: jest.fn().mockReturnValue({
-      error: errorLogMock,
-      warn: warnLogMock,
-      info: infoLogMock
+  const logs: ILoggerComponent = createLogsMockedComponent({
+    error: errorLogMock,
+    warn: warnLogMock,
+    info: infoLogMock
+  })
+  const config: IConfigComponent = createMockConfigComponent({
+    requireString: jest.fn().mockImplementation((name) => {
+      if (name === 'COMMS_GATEKEEPER_URL') {
+        return 'https://comms-gatekeeper.org'
+      }
+      if (name === 'COMMS_GATEKEEPER_AUTH_TOKEN') {
+        return 'comms-gatekeeper-token'
+      }
+      throw new Error(`Unknown config key: ${name}`)
     })
-  }
+  })
 
-  commsGatekeeper = await createCommsGatekeeperComponent({ logs, config: mockConfig, fetcher })
+  commsGatekeeper = await createCommsGatekeeperComponent({ logs, config, fetcher })
 })
 
 describe('when updating the user privacy message metadata', () => {
@@ -203,6 +212,75 @@ describe('when getting the private voice chat credentials', () => {
       ).rejects.toThrow('Network error')
       expect(errorLogMock).toHaveBeenCalledWith(
         `Failed to get private voice chat keys for user ${calleeAddress} and ${callerAddress}: Network error`
+      )
+    })
+  })
+})
+
+describe('when ending a private voice chat', () => {
+  let callId: string
+  let address: string
+
+  beforeEach(() => {
+    callId = 'test-call-id-123'
+    address = '0xBceaD48696C30eBfF0725D842116D334aAd585C1'
+  })
+
+  describe('and the request resolves with a 200 status code', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200
+      })
+    })
+
+    it('should resolve successfully', async () => {
+      await expect(commsGatekeeper.endPrivateVoiceChat(callId, address)).resolves.toBeUndefined()
+    })
+
+    it('should make the correct API call', async () => {
+      await commsGatekeeper.endPrivateVoiceChat(callId, address)
+      expect(fetchMock).toHaveBeenCalledWith('https://comms-gatekeeper.org/private-voice-chat/test-call-id-123', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer comms-gatekeeper-token'
+        },
+        body: JSON.stringify({
+          address: '0xBceaD48696C30eBfF0725D842116D334aAd585C1'
+        })
+      })
+    })
+  })
+
+  describe('and the request resolves with a non 200 status code', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request'
+      })
+    })
+
+    it('should log the error and reject with it', async () => {
+      await expect(commsGatekeeper.endPrivateVoiceChat(callId, address)).rejects.toThrow(
+        'Server responded with status 400'
+      )
+      expect(errorLogMock).toHaveBeenCalledWith(
+        `Failed to end private voice chat for call ${callId} and address ${address}: Server responded with status 400`
+      )
+    })
+  })
+
+  describe('and the request fails with a network error', () => {
+    beforeEach(() => {
+      fetchMock.mockRejectedValueOnce(new Error('Network error'))
+    })
+
+    it('should log the error and reject with it', async () => {
+      await expect(commsGatekeeper.endPrivateVoiceChat(callId, address)).rejects.toThrow('Network error')
+      expect(errorLogMock).toHaveBeenCalledWith(
+        `Failed to end private voice chat for call ${callId} and address ${address}: Network error`
       )
     })
   })

--- a/test/unit/logic/voice-logic.spec.ts
+++ b/test/unit/logic/voice-logic.spec.ts
@@ -491,8 +491,8 @@ describe('when rejecting a private voice chat', () => {
           deletePrivateVoiceChatMock.mockResolvedValueOnce(null)
         })
 
-        it('should not publish the voice chat rejected event', async () => {
-          await voice.rejectPrivateVoiceChat(callId, calleeAddress)
+        it('should not publish the voice chat rejected event and reject with a voice chat not found error', async () => {
+          await expect(voice.rejectPrivateVoiceChat(callId, calleeAddress)).rejects.toThrow(VoiceChatNotFoundError)
           expect(deletePrivateVoiceChatMock).toHaveBeenCalledWith(callId)
           expect(publishInChannelMock).not.toHaveBeenCalled()
         })


### PR DESCRIPTION
This PR adds functions that prevent race conditions by checking if the deletion of the private voice chat (which is done after the intent of a private voice chat is accepted or rejected) occurred. 
If it didn't occurred while:
- Accepting a private voice chat: It means it was rejected, meaning that we need to roll back accepting a voice chat.
- Rejecting a private voice chat: It means that it was already rejected (possible a doble reject or a cancelled call) and we need to not do anything to the call and notify the user executing the function about it.