### PR TITLE
feat: Add end call request

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@aws-sdk/client-sns": "^3.734.0",
     "@dcl/platform-crypto-middleware": "^1.1.0",
     "@dcl/platform-server-commons": "^0.1.0",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15449846569.commit-8c3e14b.tgz",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15451333525.commit-5ef2fd2.tgz",
     "@dcl/rpc": "^1.1.2",
     "@dcl/schemas": "^16.0.0",
     "@sentry/node": "^9.12.0",

--- a/src/adapters/rpc-server/rpc-server.ts
+++ b/src/adapters/rpc-server/rpc-server.ts
@@ -29,6 +29,7 @@ import { createRpcServerMetricsWrapper, ServiceType } from './metrics-wrapper'
 import { startPrivateVoiceChatService } from './services/start-private-voice-chat'
 import { acceptPrivateVoiceChatService } from './services/accept-private-voice-chat'
 import { rejectPrivateVoiceChatService } from './services/reject-private-voice-chat'
+import { endPrivateVoiceChatService } from './services/end-private-voice-chat'
 
 export async function createRpcServerComponent({
   logs,
@@ -154,6 +155,10 @@ export async function createRpcServerComponent({
     },
     rejectPrivateVoiceChat: {
       creator: rejectPrivateVoiceChatService({ components: { logs, voice } }),
+      type: ServiceType.CALL
+    },
+    endPrivateVoiceChat: {
+      creator: endPrivateVoiceChatService({ components: { logs, voice } }),
       type: ServiceType.CALL
     }
   }

--- a/src/adapters/rpc-server/services/end-private-voice-chat.ts
+++ b/src/adapters/rpc-server/services/end-private-voice-chat.ts
@@ -1,0 +1,52 @@
+import {
+  EndPrivateVoiceChatPayload,
+  EndPrivateVoiceChatResponse
+} from '@dcl/protocol/out-ts/decentraland/social_service/v2/social_service_v2.gen'
+import { RpcServerContext, RPCServiceContext } from '../../../types'
+import { isErrorWithMessage } from '../../../utils/errors'
+import { VoiceChatNotFoundError } from '../../../logic/voice/errors'
+
+export function endPrivateVoiceChatService({ components: { logs, voice } }: RPCServiceContext<'logs' | 'voice'>) {
+  const logger = logs.getLogger('end-private-voice-chat-service')
+
+  return async function (
+    request: EndPrivateVoiceChatPayload,
+    context: RpcServerContext
+  ): Promise<EndPrivateVoiceChatResponse> {
+    try {
+      await voice.endPrivateVoiceChat(request.callId, context.address)
+
+      return {
+        response: {
+          $case: 'ok',
+          ok: {
+            callId: request.callId
+          }
+        }
+      }
+    } catch (error) {
+      const errorMessage = isErrorWithMessage(error) ? error.message : 'Unknown error'
+      logger.error(`Error ending private voice chat: ${errorMessage}`)
+
+      if (error instanceof VoiceChatNotFoundError) {
+        return {
+          response: {
+            $case: 'notFound',
+            notFound: {
+              message: errorMessage
+            }
+          }
+        }
+      }
+
+      return {
+        response: {
+          $case: 'internalServerError',
+          internalServerError: {
+            message: errorMessage
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/logic/voice/types.ts
+++ b/src/logic/voice/types.ts
@@ -7,10 +7,12 @@ export interface IVoiceComponent {
   startPrivateVoiceChat(callerAddress: string, calleeAddress: string): Promise<string>
   acceptPrivateVoiceChat(callId: string, calleeAddress: string): Promise<AcceptPrivateVoiceChatResult>
   rejectPrivateVoiceChat(callId: string, calleeAddress: string): Promise<void>
+  endPrivateVoiceChat(callId: string, address: string): Promise<void>
 }
 
 export enum VoiceChatStatus {
   REQUESTED = 'requested',
   ACCEPTED = 'accepted',
-  REJECTED = 'rejected'
+  REJECTED = 'rejected',
+  ENDED = 'ended'
 }

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -252,6 +252,7 @@ export type ICommsGatekeeperComponent = {
     user: string,
     privateMessagesPrivacy: PrivateMessagesPrivacy
   ) => Promise<void>
+  endPrivateVoiceChat: (callId: string, address: string) => Promise<void>
 }
 
 export type IWebSocketComponent = IBaseComponent & {

--- a/yarn.lock
+++ b/yarn.lock
@@ -766,15 +766,15 @@
     "@well-known-components/interfaces" "^1.4.3"
     node-fetch "^2.7.0"
 
-"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15449666581.commit-6ea172e.tgz":
-  version "1.0.0-15449666581.commit-6ea172e"
-  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15449666581.commit-6ea172e.tgz#8b40740765f189c5db26fc158d4c3e4eef4d9a75"
+"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15451069534.commit-b59db67.tgz":
+  version "1.0.0-15451069534.commit-b59db67"
+  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15451069534.commit-b59db67.tgz#cdfcafc2549085d19899339c4d49a154036393e8"
   dependencies:
     "@dcl/ts-proto" "1.154.0"
 
-"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15449846569.commit-8c3e14b.tgz":
-  version "1.0.0-15449846569.commit-8c3e14b"
-  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15449846569.commit-8c3e14b.tgz#d31bf80b64b8828b7f911bc3ce062889dfe089ae"
+"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15451333525.commit-5ef2fd2.tgz":
+  version "1.0.0-15451333525.commit-5ef2fd2"
+  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15451333525.commit-5ef2fd2.tgz#70faee60c340dbf91e3747a7387a4900defcd890"
   dependencies:
     "@dcl/ts-proto" "1.154.0"
 


### PR DESCRIPTION
This PR adds the end call request, which can be called by the callee or the caller. This request will act differently depending on the moment it's called:
- When called by the caller before the private voice chat is accepted or rejected, it will cancel it.
- When called by the callee or the caller after the call was accepted, it will terminate the call via LiveKit.

The end call request allows the caller to cancel the call at any time, even if it gets accepted in mid ending process, avoiding the case where the caller cancels the call and if it got accepted just before being cancelled, the caller ends up getting into the call anyway.