### PR TITLE
feat: make thumbnail optional for community creation

### DIFF
--- a/src/controllers/handlers/create-community-handler.ts
+++ b/src/controllers/handlers/create-community-handler.ts
@@ -21,7 +21,7 @@ export async function createCommunityHandler(
 
     const thumbnailFile = formData?.files?.['thumbnail']
 
-    if (!name || !description || !thumbnailFile) {
+    if (!name || !description) {
       logger.error('Invalid request body while creating Community', {
         name,
         description,
@@ -42,7 +42,7 @@ export async function createCommunityHandler(
         description,
         ownerAddress: address
       },
-      thumbnailFile.value
+      thumbnailFile?.value
     )
 
     logger.info('Community created', {

--- a/src/logic/community/community.ts
+++ b/src/logic/community/community.ts
@@ -189,7 +189,7 @@ export function createCommunityComponent(
 
     createCommunity: async (
       community: Omit<Community, 'id' | 'active' | 'privacy' | 'thumbnails'>,
-      thumbnail: Buffer
+      thumbnail?: Buffer
     ): Promise<Community> => {
       const ownedNames = await catalystClient.getOwnedNames(community.ownerAddress, {
         pageSize: '1'
@@ -208,9 +208,11 @@ export function createCommunityComponent(
 
       logger.info('Community created', { communityId: newCommunity.id, name: newCommunity.name })
 
-      const thumbnailUrl = await storage.storeFile(thumbnail, `communities/${newCommunity.id}/raw-thumbnail.png`)
+      if (thumbnail) {
+        const thumbnailUrl = await storage.storeFile(thumbnail, `communities/${newCommunity.id}/raw-thumbnail.png`)
 
-      logger.info('Thumbnail stored', { thumbnailUrl, communityId: newCommunity.id })
+        logger.info('Thumbnail stored', { thumbnailUrl, communityId: newCommunity.id })
+      }
 
       await communitiesDb.addCommunityMember({
         communityId: newCommunity.id,

--- a/test/integration/create-community.spec.ts
+++ b/test/integration/create-community.spec.ts
@@ -48,19 +48,6 @@ test('Create Community Controller', async function ({ components, stubComponents
           )
           expect(response.status).toBe(400)
         })
-
-        it('should respond with a 400 status code when missing thumbnails', async () => {
-          const response = await makeMultipartRequest(
-            identity,
-            '/v1/communities',
-            {
-              name: 'Test Community',
-              description: 'Test Description'
-            }
-          )
-
-          expect(response.status).toBe(400)
-        })
       })
 
       describe('and the body is valid', () => {
@@ -94,6 +81,25 @@ test('Create Community Controller', async function ({ components, stubComponents
             const body = await response.json()
             communityId = body.id
   
+            expect(response.status).toBe(201)
+            expect(body).toMatchObject({
+              data: {
+                id: expect.any(String),
+                name: 'Test Community',
+                description: 'Test Description',
+                active: true,
+                ownerAddress: identity.realAccount.address.toLowerCase(),
+                privacy: 'public'
+              },
+              message: 'Community created successfully'
+            })
+          })
+
+          it('should create community even when the thumbnail is not provided', async () => {
+            const response = await makeMultipartRequest(identity, '/v1/communities', validBody)
+            const body = await response.json()
+            communityId = body.id
+
             expect(response.status).toBe(201)
             expect(body).toMatchObject({
               data: {


### PR DESCRIPTION
Now, the thumbnail is optional while creating a community.