### PR TITLE
feat: thumbnails retrieval

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -50,3 +50,5 @@ AWS_REGION=us-east-1
 # AWS_S3_BUCKET_PREFIX=social
 ## SNS
 AWS_SNS_ARN='arn:aws:sns:us-east-1:000000000000:events'
+
+CDN_URL=http://localhost:4566/social-service-ea

--- a/.env.default
+++ b/.env.default
@@ -51,4 +51,4 @@ AWS_REGION=us-east-1
 ## SNS
 AWS_SNS_ARN='arn:aws:sns:us-east-1:000000000000:events'
 
-CDN_URL=http://localhost:4566/social-service-ea
+CDN_URL=http://0.0.0.0:4566/social-service-ea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,8 @@ services:
       AWS_S3_BUCKET_ENDPOINT: 'http://localstack:4566'
       AWS_REGION: 'us-east-1'
       AWS_S3_BUCKET_PREFIX: 'social'
-      LOG_LEVEL: ALL
+      LOG_LEVEL: 'ALL'
+      CDN_URL: 'http://localhost:4566/social-service-ea'
     ports:
       - '3000:3000'
       - '3001:3001'

--- a/docs/communities-schemas.yaml
+++ b/docs/communities-schemas.yaml
@@ -88,7 +88,7 @@ components:
                         type: object
                         additionalProperties:
                           type: string
-                        description: 'A map of thumbnail types to URLs.'
+                        description: 'A map of thumbnail types to URLs. The key is the thumbnail type (e.g. "raw") and the value is the URL.'
                       friends:
                         type: array
                         items:
@@ -138,7 +138,7 @@ components:
               type: object
               additionalProperties:
                 type: string
-              description: 'A map of thumbnail types to URLs.'
+              description: 'A map of thumbnail types to URLs. The key is the thumbnail type (e.g. "raw") and the value is the URL.'
     GetCommunityById200OkResponse:
       type: object
       required:
@@ -177,7 +177,7 @@ components:
               type: object
               additionalProperties:
                 type: string
-              description: 'A map of thumbnail types to URLs.'
+              description: 'A map of thumbnail types to URLs. The key is the thumbnail type (e.g. "raw") and the value is the URL.'
     GetCommunityMembers200OkResponse:
       type: object
       required:

--- a/src/adapters/s3.ts
+++ b/src/adapters/s3.ts
@@ -22,7 +22,7 @@ export async function createS3Adapter({ config }: Pick<AppComponents, 'config'>)
       }
     })
 
-    return await upload.done().then(() => `${bucketEndpoint}/${bucket}/${key}`)
+    return await upload.done().then(() => `${bucketEndpoint}/${bucket}/${bucketPrefix}/${key}`)
   }
 
   async function exists(key: string): Promise<boolean> {

--- a/src/adapters/s3.ts
+++ b/src/adapters/s3.ts
@@ -1,4 +1,4 @@
-import { S3Client } from '@aws-sdk/client-s3'
+import { HeadObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
 
 import { AppComponents, IStorageComponent } from '../types'
@@ -25,5 +25,19 @@ export async function createS3Adapter({ config }: Pick<AppComponents, 'config'>)
     return await upload.done().then(() => `${bucketEndpoint}/${bucket}/${key}`)
   }
 
-  return { storeFile }
+  async function exists(key: string): Promise<boolean> {
+    const command = new HeadObjectCommand({
+      Bucket: bucket,
+      Key: `${bucketPrefix}/${key}`
+    })
+
+    try {
+      await s3.send(command) // throws if file doesn't exist
+      return true
+    } catch (error: any) {
+      return false
+    }
+  }
+
+  return { storeFile, exists }
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -127,13 +127,14 @@ export async function initComponents(): Promise<AppComponents> {
   const peersSynchronizer = await createPeersSynchronizerComponent({ logs, archipelagoStats, redis, config })
   const peerTracking = await createPeerTrackingComponent({ logs, pubsub, nats, redis, config, worldsStats })
   const communityRoles = createCommunityRolesComponent({ communitiesDb, logs })
-  const community = createCommunityComponent({
+  const community = await createCommunityComponent({
     communitiesDb,
     catalystClient,
     communityRoles,
     logs,
     peersStats,
-    storage
+    storage,
+    config
   })
 
   return {

--- a/src/logic/community/community.ts
+++ b/src/logic/community/community.ts
@@ -295,6 +295,9 @@ export async function createCommunityComponent(
         const thumbnailUrl = await storage.storeFile(thumbnail, `communities/${newCommunity.id}/raw-thumbnail.png`)
 
         logger.info('Thumbnail stored', { thumbnailUrl, communityId: newCommunity.id })
+        newCommunity.thumbnails = {
+          raw: thumbnailUrl
+        }
       }
 
       await communitiesDb.addCommunityMember({

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -279,3 +279,7 @@ export interface IStorageComponent {
   storeFile: (file: Buffer, key: string) => Promise<string>
   exists: (key: string) => Promise<boolean>
 }
+
+export interface IStorageHelperComponent {
+  removeFile: (key: string) => Promise<void>
+}

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -277,4 +277,5 @@ export interface ICommunitiesDbHelperComponent {
 
 export interface IStorageComponent {
   storeFile: (file: Buffer, key: string) => Promise<string>
+  exists: (key: string) => Promise<boolean>
 }

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -30,7 +30,8 @@ import {
   IPgComponent,
   ICommunitiesDbHelperComponent,
   IVoiceDatabaseComponent,
-  IStorageComponent
+  IStorageComponent,
+  IStorageHelperComponent
 } from './components'
 import { ICommunityComponent, ICommunityRolesComponent } from '../logic/community'
 import { ISettingsComponent } from '../logic/settings'
@@ -86,4 +87,5 @@ export type TestComponents = BaseComponents & {
   localHttpFetch: IFetchComponent
   rpcClient: IRpcClient
   communitiesDbHelper: ICommunitiesDbHelperComponent
+  storageHelper: IStorageHelperComponent
 }

--- a/test/components.ts
+++ b/test/components.ts
@@ -133,13 +133,14 @@ async function initComponents(): Promise<TestComponents> {
   const wsPool = await createWSPoolComponent({ metrics, config, redis, logs })
   const peerTracking = await createPeerTrackingComponent({ logs, pubsub, nats, redis, config, worldsStats })
   const communityRoles = createCommunityRolesComponent({ communitiesDb, logs })
-  const community = createCommunityComponent({
+  const community = await createCommunityComponent({
     communitiesDb,
     catalystClient,
     communityRoles,
     logs,
     peersStats,
-    storage
+    storage,
+    config
   })
 
   const localUwsFetch = await createLocalFetchComponent(uwsHttpServerConfig)

--- a/test/components.ts
+++ b/test/components.ts
@@ -42,6 +42,7 @@ import { createDbHelper } from './helpers/community-db-helper'
 import { createVoiceComponent } from '../src/logic/voice'
 import { createSettingsComponent } from '../src/logic/settings'
 import { createPeersStatsComponent } from '../src/logic/peers-stats'
+import { createStorageHelper } from './integration/utils/storage'
 
 /**
  * Behaves like Jest "describe" function, used to describe a test for a
@@ -150,6 +151,8 @@ async function initComponents(): Promise<TestComponents> {
 
   const communitiesDbHelper = createDbHelper(pg)
 
+  const storageHelper = await createStorageHelper({ config })
+
   return {
     archipelagoStats,
     catalystClient,
@@ -185,6 +188,7 @@ async function initComponents(): Promise<TestComponents> {
     communitiesDbHelper,
     settings,
     voice,
-    voiceDb
+    voiceDb,
+    storageHelper
   }
 }

--- a/test/integration/create-community.spec.ts
+++ b/test/integration/create-community.spec.ts
@@ -14,10 +14,8 @@ test('Create Community Controller', async function ({ components, stubComponents
 
     describe('and the request is not signed', () => {
       it('should respond with a 400 status code', async () => {
-        const { localHttpFetch } = components        
-        const response = await localHttpFetch.fetch(`/v1/communities`, {
-          method: 'POST'
-        })
+        const { localHttpFetch } = components
+        const response = await localHttpFetch.fetch(`/v1/communities`, { method: 'POST' })
         expect(response.status).toBe(400)
       })
     })
@@ -25,37 +23,28 @@ test('Create Community Controller', async function ({ components, stubComponents
     describe('and the request is signed', () => {
       describe('but the body is invalid', () => {
         it('should respond with a 400 status code when missing name', async () => {
-          const response = await makeMultipartRequest(
-            identity,
-            '/v1/communities',
-            {
-              description: 'Test Description',
-              thumbnailPath: require('path').join(__dirname, 'fixtures/example.png')
-            }
-          )
+          const response = await makeMultipartRequest(identity, '/v1/communities', {
+            description: 'Test Description',
+            thumbnailPath: require('path').join(__dirname, 'fixtures/example.png')
+          })
 
           expect(response.status).toBe(400)
         })
 
         it('should respond with a 400 status code when missing description', async () => {
-          const response = await makeMultipartRequest(
-            identity,
-            '/v1/communities',
-            {
-              name: 'Test Community',
-              thumbnailPath: require('path').join(__dirname, 'fixtures/example.png')
-            }
-          )
+          const response = await makeMultipartRequest(identity, '/v1/communities', {
+            name: 'Test Community',
+            thumbnailPath: require('path').join(__dirname, 'fixtures/example.png')
+          })
           expect(response.status).toBe(400)
         })
       })
 
       describe('and the body is valid', () => {
         let communityId: string
-        let validBody: { name: string; description: string; thumbnailPath: string } = {
+        let validBody: { name: string; description: string; thumbnailPath?: string } = {
           name: 'Test Community',
-          description: 'Test Description',
-          thumbnailPath: require('path').join(__dirname, 'fixtures/example.png')
+          description: 'Test Description'
         }
 
         afterEach(async () => {
@@ -64,53 +53,78 @@ test('Create Community Controller', async function ({ components, stubComponents
 
         describe('when the user owns a name', () => {
           beforeEach(async () => {
-            stubComponents.catalystClient.getOwnedNames.onFirstCall().resolves([{
-              id: '1',
-              name: 'testOwnedName',
-              contractAddress: '0x0000000000000000000000000000000000000000',
-              tokenId: '1'
-            }])
+            stubComponents.catalystClient.getOwnedNames
+              .onFirstCall()
+              .resolves([
+                {
+                  id: '1',
+                  name: 'testOwnedName',
+                  contractAddress: '0x0000000000000000000000000000000000000000',
+                  tokenId: '1'
+                }
+              ])
           })
 
-          it('should respond with a 201 status code', async () => {
-            const response = await makeMultipartRequest(
-              identity,
-              '/v1/communities',
-              validBody
-            )
-            const body = await response.json()
-            communityId = body.id
-  
-            expect(response.status).toBe(201)
-            expect(body).toMatchObject({
-              data: {
-                id: expect.any(String),
-                name: 'Test Community',
-                description: 'Test Description',
-                active: true,
-                ownerAddress: identity.realAccount.address.toLowerCase(),
-                privacy: 'public'
-              },
-              message: 'Community created successfully'
+          describe('and thumbnail is provided', () => {
+            const validBodyWithThumbnail = {
+              ...validBody,
+              thumbnailPath: require('path').join(__dirname, 'fixtures/example.png')
+            }
+
+            let expectedCdn: string
+
+            beforeEach(async () => {
+              expectedCdn = await components.config.requireString('CDN_URL')
+            })
+
+            it('should respond with a 201 status code', async () => {
+              const response = await makeMultipartRequest(identity, '/v1/communities', validBodyWithThumbnail)
+              const body = await response.json()
+              communityId = body.id
+
+              expect(response.status).toBe(201)
+              expect(body).toMatchObject({
+                data: {
+                  id: expect.any(String),
+                  name: 'Test Community',
+                  description: 'Test Description',
+                  active: true,
+                  ownerAddress: identity.realAccount.address.toLowerCase(),
+                  privacy: 'public'
+                },
+                message: 'Community created successfully'
+              })
+            })
+
+            it('should return thumbnail raw url in the response', async () => {
+              const response = await makeMultipartRequest(identity, '/v1/communities', validBodyWithThumbnail)
+              const body = await response.json()
+              communityId = body.data.id
+
+              expect(body.data.thumbnails.raw).toBe(
+                `${expectedCdn}/social/communities/${communityId}/raw-thumbnail.png`
+              )
             })
           })
 
-          it('should create community even when the thumbnail is not provided', async () => {
-            const response = await makeMultipartRequest(identity, '/v1/communities', validBody)
-            const body = await response.json()
-            communityId = body.id
+          describe('and thumbnail is not provided', () => {
+            it('should create community even when the thumbnail is not provided', async () => {
+              const response = await makeMultipartRequest(identity, '/v1/communities', validBody)
+              const body = await response.json()
+              communityId = body.id
 
-            expect(response.status).toBe(201)
-            expect(body).toMatchObject({
-              data: {
-                id: expect.any(String),
-                name: 'Test Community',
-                description: 'Test Description',
-                active: true,
-                ownerAddress: identity.realAccount.address.toLowerCase(),
-                privacy: 'public'
-              },
-              message: 'Community created successfully'
+              expect(response.status).toBe(201)
+              expect(body).toMatchObject({
+                data: {
+                  id: expect.any(String),
+                  name: 'Test Community',
+                  description: 'Test Description',
+                  active: true,
+                  ownerAddress: identity.realAccount.address.toLowerCase(),
+                  privacy: 'public'
+                },
+                message: 'Community created successfully'
+              })
             })
           })
 
@@ -118,14 +132,12 @@ test('Create Community Controller', async function ({ components, stubComponents
             beforeEach(async () => {
               stubComponents.catalystClient.getOwnedNames.onFirstCall().rejects(new Error('Failed to fetch names'))
             })
-            
+
             it('should respond with a 500 status code', async () => {
               const response = await makeMultipartRequest(identity, '/v1/communities', validBody)
 
               expect(response.status).toBe(500)
-              expect(await response.json()).toMatchObject({
-                message: 'Failed to fetch names'
-              })
+              expect(await response.json()).toMatchObject({ message: 'Failed to fetch names' })
             })
           })
         })
@@ -134,7 +146,7 @@ test('Create Community Controller', async function ({ components, stubComponents
           beforeEach(async () => {
             stubComponents.catalystClient.getOwnedNames.onFirstCall().resolves([])
           })
-          
+
           it('should respond with a 401 status code', async () => {
             const response = await makeMultipartRequest(identity, '/v1/communities', validBody)
 

--- a/test/integration/get-communities-controller.spec.ts
+++ b/test/integration/get-communities-controller.spec.ts
@@ -257,8 +257,8 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
         it('should return the thumbnail raw url in the response', async () => {
           const response = await makeRequest(identity, '/v1/communities')
           const body = await response.json()
-          expect(body.data.results[0].thumbnails.raw).toBe(`http://localhost:4566/social-service-ea/social/communities/${communityId1}/raw-thumbnail.png`)
-          expect(body.data.results[1].thumbnails.raw).toBe(`http://localhost:4566/social-service-ea/social/communities/${communityId2}/raw-thumbnail.png`)
+          expect(body.data.results[0].thumbnails.raw).toBe(`http://0.0.0.0:4566/social-service-ea/social/communities/${communityId1}/raw-thumbnail.png`)
+          expect(body.data.results[1].thumbnails.raw).toBe(`http://0.0.0.0:4566/social-service-ea/social/communities/${communityId2}/raw-thumbnail.png`)
         })
       })
     })

--- a/test/integration/get-communities-controller.spec.ts
+++ b/test/integration/get-communities-controller.spec.ts
@@ -242,6 +242,25 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
           expect(response.status).toBe(500)
         })
       })
+
+      describe('and communities have thumbnails', () => {
+        beforeEach(async () => {
+          await components.storage.storeFile(Buffer.from('test'), `communities/${communityId1}/raw-thumbnail.png`)
+          await components.storage.storeFile(Buffer.from('test'), `communities/${communityId2}/raw-thumbnail.png`)
+        })
+
+        afterEach(async () => {
+          await components.storageHelper.removeFile(`communities/${communityId1}/raw-thumbnail.png`)
+          await components.storageHelper.removeFile(`communities/${communityId2}/raw-thumbnail.png`)
+        })
+
+        it('should return the thumbnail raw url in the response', async () => {
+          const response = await makeRequest(identity, '/v1/communities')
+          const body = await response.json()
+          expect(body.data.results[0].thumbnails.raw).toBe(`http://localhost:4566/social-service-ea/social/communities/${communityId1}/raw-thumbnail.png`)
+          expect(body.data.results[1].thumbnails.raw).toBe(`http://localhost:4566/social-service-ea/social/communities/${communityId2}/raw-thumbnail.png`)
+        })
+      })
     })
   })
 })

--- a/test/integration/get-community-controller.spec.ts
+++ b/test/integration/get-community-controller.spec.ts
@@ -64,6 +64,24 @@ test('Get Community Controller', function ({ components, spyComponents }) {
               }
             })
           })
+
+          describe('and the community has a thumbnail', () => {
+            let expectedCdn: string
+            beforeEach(async () => {
+              expectedCdn = await components.config.requireString('CDN_URL')
+              await components.storage.storeFile(Buffer.from('test'), `communities/${communityId}/raw-thumbnail.png`)
+            })
+
+            afterEach(async () => {
+              await components.storageHelper.removeFile(`communities/${communityId}/raw-thumbnail.png`)
+            })
+
+            it('should return the thumbnail raw url in the response', async () => {
+              const response = await makeRequest(identity, `/v1/communities/${communityId}`)
+              const body = await response.json()
+              expect(body.data.thumbnails.raw).toBe(`${expectedCdn}/social/communities/${communityId}/raw-thumbnail.png`)
+            })
+          })
         })
 
         describe('and the community is inactive', () => {

--- a/test/integration/utils/storage.ts
+++ b/test/integration/utils/storage.ts
@@ -1,0 +1,22 @@
+import { DeleteObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { AppComponents } from '../../../src/types'
+import { IStorageHelperComponent } from '../../../src/types/components'
+
+export async function createStorageHelper({ config }: Pick<AppComponents, 'config'>): Promise<IStorageHelperComponent> { 
+    const bucket = await config.requireString('AWS_S3_BUCKET')
+    const bucketEndpoint = (await config.getString('AWS_S3_BUCKET_ENDPOINT')) || 'https://s3.amazonaws.com'
+    const region = (await config.getString('AWS_REGION')) || 'us-east-1'
+    const bucketPrefix = (await config.getString('AWS_S3_BUCKET_PREFIX')) || 'social' // service only has access to social directory
+  
+    const s3 = new S3Client({ region, endpoint: bucketEndpoint })
+    
+    return {
+        removeFile: async (key: string) => {
+            const command = new DeleteObjectCommand({
+                Bucket: bucket,
+                Key: `${bucketPrefix}/${key}`
+            })
+            await s3.send(command)
+        }
+    }
+}

--- a/test/mocks/components/s3.ts
+++ b/test/mocks/components/s3.ts
@@ -2,6 +2,7 @@ import { IStorageComponent } from "../../../src/types";
 
 export function createS3ComponentMock(): IStorageComponent {
     return {
-        storeFile: jest.fn()
+        storeFile: jest.fn(),
+        exists: jest.fn()
     }
 }

--- a/test/unit/logic/community.spec.ts
+++ b/test/unit/logic/community.spec.ts
@@ -16,14 +16,13 @@ import { mockCatalystClient } from '../../mocks/components/catalyst-client'
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 import { createMockProfile } from '../../mocks/profile'
 import {
-  CommunityMemberProfile,
   CommunityWithMembersCountAndFriends,
   ICommunityRolesComponent
 } from '../../../src/logic/community/types'
 import { parseExpectedFriends } from '../../mocks/friend'
 import { MemberCommunity } from '../../../src/logic/community/types'
 import { createCommunityRolesComponent } from '../../../src/logic/community/roles'
-import { mockLogs } from '../../mocks/components'
+import { createMockConfigComponent, mockConfig, mockLogs } from '../../mocks/components'
 import { mapMembersWithProfiles } from '../../../src/logic/community/utils'
 import { Action } from '../../../src/types/entities'
 import { FriendshipStatus } from '@dcl/protocol/out-js/decentraland/social_service/v2/social_service_v2.gen'
@@ -39,7 +38,7 @@ describe('when handling community operations', () => {
   let mockMembersCount: number
   let mockPeersStats: jest.Mocked<IPeersStatsComponent>
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockCommunity = {
       id: 'test-id',
       name: 'Test Community',
@@ -55,13 +54,14 @@ describe('when handling community operations', () => {
       getConnectedPeers: jest.fn().mockResolvedValue([])
     })
     mockCommunityRoles = createCommunityRolesComponent({ communitiesDb: mockCommunitiesDB, logs: mockLogs })
-    communityComponent = createCommunityComponent({
+    communityComponent = await createCommunityComponent({
       communitiesDb: mockCommunitiesDB,
       catalystClient: mockCatalystClient,
       communityRoles: mockCommunityRoles,
       logs: mockLogs,
       peersStats: mockPeersStats,
-      storage: createS3ComponentMock()
+      storage: createS3ComponentMock(),
+      config: mockConfig
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1295,13 +1295,6 @@
     "@well-known-components/interfaces" "^1.4.3"
     node-fetch "^2.7.0"
 
-"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15538666462.commit-a5c3d1b.tgz":
-  version "1.0.0-15538666462.commit-a5c3d1b"
-  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15538666462.commit-a5c3d1b.tgz#452ed6dc47896e24d70e232de3a329a168efffe8"
-  dependencies:
-    "@dcl/ts-proto" "1.154.0"
-    protobufjs "7.2.4"
-
 "@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15566887274.commit-72a1f9c.tgz":
   version "1.0.0-15566887274.commit-72a1f9c"
   resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15566887274.commit-72a1f9c.tgz#29e82f2e558e5f82817ea996610ce2eabb0de6f0"


### PR DESCRIPTION
# PR Description

## Overview
This PR updates the community endpoints to include thumbnail URLs in the response.

## Changes Made
- Updated the endpoints that return communities to include the thumbnail URLs for each community that has one

## Benefits
- Provides users with direct access to community thumbnails when fetching community data (HTOA approach, we provide the links).
- Enhances the user experience by displaying visual representations of communities.

## Usage
- When creating a community, ensure that a thumbnail is uploaded.
- Fetching communities will now include the `thumbnails` property with the URL of the uploaded thumbnail. 