### PR TITLE
fix: Send auth token when creating private voice chat credentials

### DIFF
--- a/src/adapters/comms-gatekeeper.ts
+++ b/src/adapters/comms-gatekeeper.ts
@@ -83,7 +83,8 @@ export const createCommsGatekeeperComponent = async ({
       const response = await fetch(`${commsUrl}/private-voice-chat`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${commsGateKeeperToken}`
         },
         body: JSON.stringify({
           room_id: roomId,

--- a/test/unit/adapters/commms-gatekeeper.spec.ts
+++ b/test/unit/adapters/commms-gatekeeper.spec.ts
@@ -181,7 +181,8 @@ describe('when getting the private voice chat credentials', () => {
       expect(fetchMock).toHaveBeenCalledWith('https://comms-gatekeeper.org/private-voice-chat', {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer comms-gatekeeper-token'
         },
         body: JSON.stringify({ room_id: roomId, user_addresses: [calleeAddress, callerAddress] })
       })


### PR DESCRIPTION
This PR fixes an issue where the comms-gatekeeper adapter wasn't sending the credentials via the header.