### PR TITLE
fix: Return the credentials url instead of token and url

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/lib-storage": "^3.826.0",
     "@dcl/platform-crypto-middleware": "^1.1.0",
     "@dcl/platform-server-commons": "^0.1.0",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15566887274.commit-72a1f9c.tgz",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15638769953.commit-8321656.tgz",
     "@dcl/rpc": "^1.1.2",
     "@dcl/schemas": "^16.0.0",
     "@sentry/node": "^9.12.0",

--- a/src/adapters/comms-gatekeeper.ts
+++ b/src/adapters/comms-gatekeeper.ts
@@ -25,7 +25,7 @@ export const createCommsGatekeeperComponent = async ({
   async function updateUserPrivateMessagePrivacyMetadata(
     address: string,
     privateMessagesPrivacy: PrivateMessagesPrivacy
-  ) {
+  ): Promise<void> {
     try {
       const response = await fetch(`${commsUrl}/users/${address}/private-messages-privacy`, {
         method: 'PATCH',
@@ -78,7 +78,7 @@ export const createCommsGatekeeperComponent = async ({
     roomId: string,
     calleeAddress: string,
     callerAddress: string
-  ): Promise<Record<string, { url: string; token: string }>> {
+  ): Promise<Record<string, { connectionUrl: string }>> {
     try {
       const response = await fetch(`${commsUrl}/private-voice-chat`, {
         method: 'POST',
@@ -96,7 +96,16 @@ export const createCommsGatekeeperComponent = async ({
         throw new Error(`Server responded with status ${response.status}`)
       }
 
-      return await response.json()
+      const body = (await response.json()) as Record<string, { connection_url: string }>
+
+      return Object.entries(body).reduce(
+        (acc, [address, { connection_url }]) => {
+          // Convert the connection_url to camel case
+          acc[address] = { connectionUrl: connection_url }
+          return acc
+        },
+        {} as Record<string, { connectionUrl: string }>
+      )
     } catch (error) {
       logger.error(
         `Failed to get private voice chat keys for user ${calleeAddress} and ${callerAddress}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`

--- a/src/adapters/rpc-server/services/accept-private-voice-chat.ts
+++ b/src/adapters/rpc-server/services/accept-private-voice-chat.ts
@@ -14,7 +14,7 @@ export function acceptPrivateVoiceChatService({ components: { logs, voice } }: R
     context: RpcServerContext
   ): Promise<AcceptPrivateVoiceChatResponse> {
     try {
-      const { token, url } = await voice.acceptPrivateVoiceChat(request.callId, context.address)
+      const { connectionUrl } = await voice.acceptPrivateVoiceChat(request.callId, context.address)
 
       return {
         response: {
@@ -22,8 +22,7 @@ export function acceptPrivateVoiceChatService({ components: { logs, voice } }: R
           ok: {
             callId: request.callId,
             credentials: {
-              token,
-              url
+              connectionUrl
             }
           }
         }

--- a/src/adapters/rpc-server/services/subscribe-to-private-voice-chat-updates.ts
+++ b/src/adapters/rpc-server/services/subscribe-to-private-voice-chat-updates.ts
@@ -42,8 +42,7 @@ function parseEmittedUpdateToPrivateVoiceChatUpdate(
         : undefined,
     credentials: update.credentials
       ? PrivateVoiceChatCredentials.create({
-          url: update.credentials.url,
-          token: update.credentials.token
+          connectionUrl: update.credentials.connectionUrl
         })
       : undefined
   }

--- a/src/logic/voice/types.ts
+++ b/src/logic/voice/types.ts
@@ -1,8 +1,7 @@
 import { PrivateVoiceChat } from '../../types'
 
 export interface AcceptPrivateVoiceChatResult {
-  token: string
-  url: string
+  connectionUrl: string
 }
 
 export interface IVoiceComponent {

--- a/src/logic/voice/voice.ts
+++ b/src/logic/voice/voice.ts
@@ -105,14 +105,12 @@ export function createVoiceComponent({
         status: VoiceChatStatus.ACCEPTED,
         // Credentials for the caller
         credentials: {
-          token: credentials[privateVoiceChat.caller_address].token,
-          url: credentials[privateVoiceChat.caller_address].url
+          connectionUrl: credentials[privateVoiceChat.caller_address].connectionUrl
         }
       })
 
       return {
-        token: credentials[privateVoiceChat.callee_address].token,
-        url: credentials[privateVoiceChat.callee_address].url
+        connectionUrl: credentials[privateVoiceChat.callee_address].connectionUrl
       }
     } else {
       // If the voice chat was not deleted from the database, it means that the call was rejected by the callee

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -252,7 +252,7 @@ export type ICommsGatekeeperComponent = {
     roomId: string,
     calleeAddress: string,
     callerAddress: string
-  ) => Promise<Record<string, { url: string; token: string }>>
+  ) => Promise<Record<string, { connectionUrl: string }>>
   isUserInAVoiceChat: (address: string) => Promise<boolean>
   updateUserPrivateMessagePrivacyMetadata: (
     user: string,

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -36,8 +36,7 @@ export type SubscriptionEventsEmitter = {
     callerAddress?: string
     calleeAddress?: string
     credentials?: {
-      url: string
-      token: string
+      connectionUrl: string
     }
   }
 }

--- a/test/unit/adapters/commms-gatekeeper.spec.ts
+++ b/test/unit/adapters/commms-gatekeeper.spec.ts
@@ -159,15 +159,14 @@ describe('when getting the private voice chat credentials', () => {
   describe('and the request resolves with a 200 status code', () => {
     let response: {
       [key: string]: {
-        url: string
-        token: string
+        connection_url: string
       }
     }
 
     beforeEach(() => {
       response = {
-        [calleeAddress]: { url: 'https://url.com', token: 'token' },
-        [callerAddress]: { url: 'https://another-url.com', token: 'another-token' }
+        [calleeAddress]: { connection_url: 'livekit:https://url.com?access_token=token' },
+        [callerAddress]: { connection_url: 'livekit:https://another-url.com?access_token=token' }
       }
       fetchMock.mockResolvedValueOnce({
         ok: true,
@@ -186,7 +185,10 @@ describe('when getting the private voice chat credentials', () => {
         },
         body: JSON.stringify({ room_id: roomId, user_addresses: [calleeAddress, callerAddress] })
       })
-      expect(credentials).toEqual(response)
+      expect(credentials).toEqual({
+        [calleeAddress]: { connectionUrl: response[calleeAddress].connection_url },
+        [callerAddress]: { connectionUrl: response[callerAddress].connection_url }
+      })
     })
   })
 

--- a/test/unit/adapters/rpc-server/services/accept-private-voice-chat.spec.ts
+++ b/test/unit/adapters/rpc-server/services/accept-private-voice-chat.spec.ts
@@ -35,8 +35,7 @@ describe('when accepting a private voice chat', () => {
 
     beforeEach(() => {
       acceptPrivateVoiceChatMock.mockResolvedValue({
-        token,
-        url
+        connectionUrl: 'livekit:https://voice.decentraland.org?access_token=1234567890'
       })
     })
 
@@ -56,8 +55,7 @@ describe('when accepting a private voice chat', () => {
         expect(result.response.ok).toEqual({
           callId,
           credentials: {
-            token,
-            url
+            connectionUrl: 'livekit:https://voice.decentraland.org?access_token=1234567890'
           }
         })
       }

--- a/test/unit/adapters/rpc-server/services/subscribe-to-private-voice-chat-updates.spec.ts
+++ b/test/unit/adapters/rpc-server/services/subscribe-to-private-voice-chat-updates.spec.ts
@@ -59,8 +59,7 @@ describe('when subscribing to private voice chat updates', () => {
         callId,
         status: PrivateVoiceChatStatus.VOICE_CHAT_ACCEPTED,
         credentials: {
-          url: 'https://voice.decentraland.org',
-          token: '1234567890'
+          connectionUrl: 'livekit:https://voice.decentraland.org?access_token=1234567890'
         }
       }
 
@@ -120,8 +119,7 @@ describe('when subscribing to private voice chat updates', () => {
           callerAddress,
           status: VoiceChatStatus.ACCEPTED,
           credentials: {
-            url: 'https://voice.decentraland.org',
-            token: '1234567890'
+            connectionUrl: 'livekit:https://voice.decentraland.org?access_token=1234567890'
           }
         }
 
@@ -139,8 +137,7 @@ describe('when subscribing to private voice chat updates', () => {
           callId,
           status: PrivateVoiceChatStatus.VOICE_CHAT_ACCEPTED,
           credentials: {
-            url: 'https://voice.decentraland.org',
-            token: '1234567890'
+            connectionUrl: 'livekit:https://voice.decentraland.org?access_token=1234567890'
           }
         })
       })

--- a/test/unit/logic/updates.spec.ts
+++ b/test/unit/logic/updates.spec.ts
@@ -285,6 +285,9 @@ describe('updates handlers', () => {
         id: callId,
         callerAddress,
         calleeAddress,
+        credentials: {
+          connectionUrl: 'livekit:https://voice.decentraland.org?access_token=1234567890'
+        },
         status: VoiceChatStatus.REQUESTED, // Default status, will be overridden in specific tests
         timestamp: Date.now()
       }

--- a/test/unit/logic/voice-logic.spec.ts
+++ b/test/unit/logic/voice-logic.spec.ts
@@ -364,12 +364,12 @@ describe('when accepting a private voice chat', () => {
       })
 
       describe('and getting the private voice chat credentials succeeds', () => {
-        let calleeCredentials: { token: string; url: string }
-        let callerCredentials: { token: string; url: string }
+        let calleeCredentials: { connectionUrl: string }
+        let callerCredentials: { connectionUrl: string }
 
         beforeEach(() => {
-          calleeCredentials = { token: 'token', url: 'url' }
-          callerCredentials = { token: 'another-token', url: 'another-url' }
+          calleeCredentials = { connectionUrl: 'livekit:https://url.com?access_token=token' }
+          callerCredentials = { connectionUrl: 'livekit:https://another-url.com?access_token=token' }
 
           getPrivateVoiceChatCredentialsMock.mockResolvedValueOnce({
             [calleeAddress]: calleeCredentials,
@@ -390,14 +390,12 @@ describe('when accepting a private voice chat', () => {
               calleeAddress,
               status: 'accepted',
               credentials: {
-                token: callerCredentials.token,
-                url: callerCredentials.url
+                connectionUrl: callerCredentials.connectionUrl
               }
             })
             expect(deletePrivateVoiceChatMock).toHaveBeenCalledWith(callId)
             expect(result).toEqual({
-              token: calleeCredentials.token,
-              url: calleeCredentials.url
+              connectionUrl: calleeCredentials.connectionUrl
             })
           })
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,6 +1302,13 @@
     "@dcl/ts-proto" "1.154.0"
     protobufjs "7.2.4"
 
+"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15638769953.commit-8321656.tgz":
+  version "1.0.0-15638769953.commit-8321656"
+  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-15638769953.commit-8321656.tgz#50f7d70821dba807fe34f6b074b97b6e05ad7e74"
+  dependencies:
+    "@dcl/ts-proto" "1.154.0"
+    protobufjs "7.2.4"
+
 "@dcl/rpc@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@dcl/rpc/-/rpc-1.1.2.tgz#789f4f24c8d432a48df3e786b77d017883dda11a"


### PR DESCRIPTION
This PR changes the credentials returned for the voice chat so they return whole built credentials url.