### PR TITLE
feat: update community endpoint

### DIFF
--- a/docs/communities-openapi.yaml
+++ b/docs/communities-openapi.yaml
@@ -164,6 +164,73 @@ paths:
                 $ref: './communities-schemas.yaml#/components/schemas/ErrorResponse'
       tags:
         - Communities
+    put:
+      summary: Update a community
+      description: |
+        Updates a community's details including name, description, privacy settings, and thumbnail.
+        This endpoint requires Signed Fetch authentication and only community owners can update.
+      security:
+        - SignedFetch: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The unique identifier of the community.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: 'Community name'
+                description:
+                  type: string
+                  description: 'Community description'
+                placeIds:
+                  type: string
+                  description: 'JSON array of place IDs to replace all current community places'
+                thumbnail:
+                  type: string
+                  format: binary
+                  description: 'Community thumbnail image'
+      responses:
+        '200':
+          description: Community updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: './communities-schemas.yaml#/components/schemas/UpdateCommunity200OkResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: './communities-schemas.yaml#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized - Signed Fetch required or not owner
+          content:
+            application/json:
+              schema:
+                $ref: './communities-schemas.yaml#/components/schemas/ErrorResponse'
+        '404':
+          description: Community not found
+          content:
+            application/json:
+              schema:
+                $ref: './communities-schemas.yaml#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: './communities-schemas.yaml#/components/schemas/ErrorResponse'
+      tags:
+        - Communities
     delete:
       summary: Delete a community
       description: |

--- a/docs/communities-schemas.yaml
+++ b/docs/communities-schemas.yaml
@@ -139,6 +139,43 @@ components:
               additionalProperties:
                 type: string
               description: 'A map of thumbnail types to URLs. The key is the thumbnail type (e.g. "raw") and the value is the URL.'
+    UpdateCommunity200OkResponse:
+      type: object
+      required:
+        - message
+        - data
+      properties:
+        message:
+          type: string
+          description: 'A message describing the result'
+        data:
+          type: object
+          required:
+            - id
+            - name
+            - description
+            - ownerAddress
+            - privacy
+            - active
+          properties:
+            id:
+              type: string
+            name:
+              type: string
+            description:
+              type: string
+            ownerAddress:
+              type: string
+            privacy:
+              type: string
+              enum: [public, private]
+            active:
+              type: boolean
+            thumbnails:
+              type: object
+              additionalProperties:
+                type: string
+              description: 'A map of thumbnail types to URLs. The key is the thumbnail type (e.g. "raw") and the value is the URL.'
     GetCommunityById200OkResponse:
       type: object
       required:

--- a/src/adapters/communities-db.ts
+++ b/src/adapters/communities-db.ts
@@ -517,6 +517,72 @@ export function createCommunitiesDBComponent(
         WHERE community_id = ${communityId} AND member_address = ${normalizeAddress(memberAddress)}
       `
       await pg.query(query)
+    },
+
+    async updateCommunity(
+      communityId: string,
+      updates: Partial<Pick<CommunityDB, 'name' | 'description' | 'private'>>
+    ): Promise<Community> {
+      if (Object.keys(updates).length === 0) {
+        // No fields to update, return current community
+        const community = await this.getCommunity(communityId)
+        if (!community) {
+          throw new Error(`Community with id ${communityId} not found`)
+        }
+        return {
+          id: community.id,
+          name: community.name,
+          description: community.description,
+          ownerAddress: community.ownerAddress,
+          privacy: community.privacy,
+          active: community.active
+        }
+      }
+
+      let query = SQL`UPDATE communities SET `
+      const setClauses: ReturnType<typeof SQL>[] = []
+
+      if (updates.name !== undefined) {
+        setClauses.push(SQL`name = ${updates.name}`)
+      }
+
+      if (updates.description !== undefined) {
+        setClauses.push(SQL`description = ${updates.description}`)
+      }
+
+      if (updates.private !== undefined) {
+        setClauses.push(SQL`private = ${updates.private}`)
+      }
+
+      setClauses.push(SQL`updated_at = now()`)
+
+      // Join the SET clauses
+      for (let i = 0; i < setClauses.length; i++) {
+        query = query.append(setClauses[i])
+        if (i < setClauses.length - 1) {
+          query = query.append(SQL`, `)
+        }
+      }
+
+      query = query
+        .append(SQL` WHERE id = ${communityId} AND active = true`)
+        .append(SQL` RETURNING id, name, description, owner_address, private, active, created_at, updated_at`)
+
+      const result = await pg.query<CommunityDB>(query)
+      const row = result.rows[0]
+
+      if (!row) {
+        throw new Error(`Community with id ${communityId} not found`)
+      }
+
+      return {
+        id: row.id!,
+        name: row.name,
+        description: row.description,
+        ownerAddress: row.owner_address,
+        privacy: row.private ? 'private' : 'public',
+        active: row.active
+      }
     }
   }
 }

--- a/src/adapters/communities-db.ts
+++ b/src/adapters/communities-db.ts
@@ -523,22 +523,6 @@ export function createCommunitiesDBComponent(
       communityId: string,
       updates: Partial<Pick<CommunityDB, 'name' | 'description' | 'private'>>
     ): Promise<Community> {
-      if (Object.keys(updates).length === 0) {
-        // No fields to update, return current community
-        const community = await this.getCommunity(communityId)
-        if (!community) {
-          throw new Error(`Community with id ${communityId} not found`)
-        }
-        return {
-          id: community.id,
-          name: community.name,
-          description: community.description,
-          ownerAddress: community.ownerAddress,
-          privacy: community.privacy,
-          active: community.active
-        }
-      }
-
       let query = SQL`UPDATE communities SET `
       const setClauses: ReturnType<typeof SQL>[] = []
 

--- a/src/controllers/handlers/update-community-handler.ts
+++ b/src/controllers/handlers/update-community-handler.ts
@@ -3,56 +3,7 @@ import { FormHandlerContextWithPath, HTTPResponse } from '../../types/http'
 import { InvalidRequestError, NotAuthorizedError } from '@dcl/platform-server-commons'
 import { errorMessageOrDefault } from '../../utils/errors'
 import { CommunityNotFoundError } from '../../logic/community'
-import fileType from 'file-type'
-
-async function validateFields(formData: any, thumbnailBuffer?: Buffer) {
-  const name: string | undefined = formData.fields.name?.value
-  const description: string | undefined = formData.fields.description?.value
-  const placeIdsField: string | undefined = formData.fields.placeIds?.value
-
-  let placeIds: string[] | undefined = undefined
-  if (placeIdsField) {
-    try {
-      placeIds = JSON.parse(placeIdsField)
-      if (!Array.isArray(placeIds)) {
-        throw new InvalidRequestError('placeIds must be a valid JSON array')
-      }
-    } catch (error) {
-      throw new InvalidRequestError('placeIds must be a valid JSON array')
-    }
-  }
-
-  if (name === undefined && description === undefined && !thumbnailBuffer && placeIds === undefined) {
-    throw new InvalidRequestError('At least one field must be provided for update')
-  }
-
-  if (name !== undefined && (typeof name !== 'string' || name.trim().length === 0)) {
-    throw new InvalidRequestError('Name must be a non-empty string')
-  }
-
-  if (description !== undefined && (typeof description !== 'string' || description.trim().length === 0)) {
-    throw new InvalidRequestError('Description must be a non-empty string')
-  }
-
-  if (thumbnailBuffer) {
-    const type = await fileType.fromBuffer(thumbnailBuffer)
-    if (!type || !type.mime.startsWith('image/')) {
-      throw new InvalidRequestError('Thumbnail must be a valid image file')
-    }
-
-    const size = thumbnailBuffer.length
-    if (size < 1024 || size > 500 * 1024) {
-      throw new InvalidRequestError('Thumbnail size must be between 1KB and 500KB')
-    }
-  }
-
-  return {
-    name,
-    description,
-    placeIds,
-    thumbnailBuffer
-  }
-}
+import { validateCommunityFields } from '../../utils/community-validation'
 
 export async function updateCommunityHandler(
   context: FormHandlerContextWithPath<'community' | 'logs', '/v1/communities/:id'> & DecentralandSignatureContext<any>
@@ -77,7 +28,7 @@ export async function updateCommunityHandler(
       description,
       placeIds,
       thumbnailBuffer: validatedThumbnail
-    } = await validateFields(formData, thumbnailBuffer)
+    } = await validateCommunityFields(formData, thumbnailBuffer)
 
     logger.info('Updating community', {
       communityId,

--- a/src/controllers/handlers/update-community-handler.ts
+++ b/src/controllers/handlers/update-community-handler.ts
@@ -1,0 +1,122 @@
+import { DecentralandSignatureContext } from '@dcl/platform-crypto-middleware'
+import { FormHandlerContextWithPath, HTTPResponse } from '../../types/http'
+import { InvalidRequestError, NotAuthorizedError } from '@dcl/platform-server-commons'
+import { errorMessageOrDefault } from '../../utils/errors'
+import { CommunityNotFoundError } from '../../logic/community'
+import fileType from 'file-type'
+
+async function validateFields(formData: any, thumbnailBuffer?: Buffer) {
+  const name: string | undefined = formData.fields.name?.value
+  const description: string | undefined = formData.fields.description?.value
+  const placeIdsField: string | undefined = formData.fields.placeIds?.value
+
+  let placeIds: string[] | undefined = undefined
+  if (placeIdsField) {
+    try {
+      placeIds = JSON.parse(placeIdsField)
+      if (!Array.isArray(placeIds)) {
+        throw new InvalidRequestError('placeIds must be a valid JSON array')
+      }
+    } catch (error) {
+      throw new InvalidRequestError('placeIds must be a valid JSON array')
+    }
+  }
+
+  if (name === undefined && description === undefined && !thumbnailBuffer && placeIds === undefined) {
+    throw new InvalidRequestError('At least one field must be provided for update')
+  }
+
+  if (name !== undefined && (typeof name !== 'string' || name.trim().length === 0)) {
+    throw new InvalidRequestError('Name must be a non-empty string')
+  }
+
+  if (description !== undefined && (typeof description !== 'string' || description.trim().length === 0)) {
+    throw new InvalidRequestError('Description must be a non-empty string')
+  }
+
+  if (thumbnailBuffer) {
+    const type = await fileType.fromBuffer(thumbnailBuffer)
+    if (!type || !type.mime.startsWith('image/')) {
+      throw new InvalidRequestError('Thumbnail must be a valid image file')
+    }
+
+    const size = thumbnailBuffer.length
+    if (size < 1024 || size > 500 * 1024) {
+      throw new InvalidRequestError('Thumbnail size must be between 1KB and 500KB')
+    }
+  }
+
+  return {
+    name,
+    description,
+    placeIds,
+    thumbnailBuffer
+  }
+}
+
+export async function updateCommunityHandler(
+  context: FormHandlerContextWithPath<'community' | 'logs', '/v1/communities/:id'> & DecentralandSignatureContext<any>
+): Promise<HTTPResponse> {
+  const {
+    components: { community, logs },
+    verification,
+    formData,
+    params
+  } = context
+
+  const logger = logs.getLogger('update-community-handler')
+  const { id: communityId } = params
+  const userAddress = verification!.auth.toLowerCase()
+
+  try {
+    const thumbnailFile = formData?.files?.['thumbnail']
+    const thumbnailBuffer = thumbnailFile?.value
+
+    const {
+      name,
+      description,
+      placeIds,
+      thumbnailBuffer: validatedThumbnail
+    } = await validateFields(formData, thumbnailBuffer)
+
+    logger.info('Updating community', {
+      communityId,
+      userAddress,
+      updates: JSON.stringify({ name, description, placeIds }),
+      hasThumbnail: validatedThumbnail ? 'true' : 'false'
+    })
+
+    const updatedCommunity = await community.updateCommunity(communityId, userAddress, {
+      name,
+      description,
+      placeIds,
+      thumbnailBuffer: validatedThumbnail
+    })
+
+    return {
+      status: 200,
+      body: {
+        message: 'Community updated successfully',
+        data: updatedCommunity
+      }
+    }
+  } catch (error) {
+    const message = errorMessageOrDefault(error)
+    logger.error(`Error updating community ${communityId}: ${message}`)
+
+    if (
+      error instanceof CommunityNotFoundError ||
+      error instanceof NotAuthorizedError ||
+      error instanceof InvalidRequestError
+    ) {
+      throw error
+    }
+
+    return {
+      status: 500,
+      body: {
+        message
+      }
+    }
+  }
+}

--- a/src/controllers/routes/http.routes.ts
+++ b/src/controllers/routes/http.routes.ts
@@ -21,6 +21,7 @@ import { multipartParserWrapper } from '@well-known-components/multipart-wrapper
 import { getCommunityPlacesHandler } from '../handlers/get-community-places-handler'
 import { addCommunityPlacesHandler } from '../handlers/add-community-places-handler'
 import { removeCommunityPlaceHandler } from '../handlers/remove-community-place-handler'
+import { updateCommunityHandler } from '../handlers/update-community-handler'
 
 export async function setupHttpRoutes(context: GlobalContext): Promise<Router<GlobalContext>> {
   const {
@@ -56,6 +57,7 @@ export async function setupHttpRoutes(context: GlobalContext): Promise<Router<Gl
   router.get('/v1/members/:address/communities', signedFetchMiddleware(), getMemberCommunitiesHandler)
 
   router.post('/v1/communities', signedFetchMiddleware(), multipartParserWrapper(createCommunityHandler))
+  router.put('/v1/communities/:id', signedFetchMiddleware(), multipartParserWrapper(updateCommunityHandler))
   router.delete('/v1/communities/:id', signedFetchMiddleware(), deleteCommunityHandler)
 
   router.get('/v1/communities/:id/places', signedFetchMiddleware({ optional: true }), getCommunityPlacesHandler)

--- a/src/logic/community/community.ts
+++ b/src/logic/community/community.ts
@@ -499,6 +499,17 @@ export async function createCommunityComponent(
         throw new CommunityNotFoundError(communityId)
       }
 
+      if (Object.keys(updates).length === 0) {
+        return {
+          id: community.id,
+          name: community.name,
+          description: community.description,
+          ownerAddress: community.ownerAddress,
+          privacy: community.privacy,
+          active: community.active
+        }
+      }
+
       const canEdit = await communityRoles.canEditCommunity(communityId, userAddress)
 
       if (!canEdit) {

--- a/src/logic/community/roles.ts
+++ b/src/logic/community/roles.ts
@@ -135,6 +135,11 @@ export function createCommunityRolesComponent(
     async canRemovePlacesFromCommunity(communityId: string, removerAddress: string): Promise<boolean> {
       const role = await communitiesDb.getCommunityMemberRole(communityId, removerAddress)
       return role && hasPermission(role, 'remove_places')
+    },
+
+    async canEditCommunity(communityId: string, editorAddress: string): Promise<boolean> {
+      const role = await communitiesDb.getCommunityMemberRole(communityId, editorAddress)
+      return role && hasPermission(role, 'edit_info')
     }
   }
 }

--- a/src/logic/community/types.ts
+++ b/src/logic/community/types.ts
@@ -56,6 +56,7 @@ export interface ICommunityComponent {
       pagination: PaginatedParameters
     }
   ): Promise<{ places: Pick<CommunityPlace, 'id'>[]; totalPlaces: number }>
+  updateCommunity(communityId: string, userAddress: EthAddress, updates: CommunityUpdates): Promise<Community>
 }
 
 export type ICommunityRolesComponent = {
@@ -84,6 +85,7 @@ export type ICommunityRolesComponent = {
   ) => Promise<boolean>
   canAddPlacesToCommunity: (communityId: string, adderAddress: string) => Promise<boolean>
   canRemovePlacesFromCommunity: (communityId: string, removerAddress: string) => Promise<boolean>
+  canEditCommunity: (communityId: string, editorAddress: string) => Promise<boolean>
 }
 
 export type ICommunityPlacesComponent = {
@@ -93,6 +95,7 @@ export type ICommunityPlacesComponent = {
   ): Promise<{ places: Pick<CommunityPlace, 'id'>[]; totalPlaces: number }>
   addPlaces(communityId: string, userAddress: EthAddress, placeIds: string[]): Promise<void>
   removePlace(communityId: string, userAddress: EthAddress, placeId: string): Promise<void>
+  updatePlaces(communityId: string, userAddress: EthAddress, placeIds: string[]): Promise<void>
 }
 
 export type CommunityDB = {
@@ -104,6 +107,13 @@ export type CommunityDB = {
   active: boolean
   created_at?: string
   updated_at?: string
+}
+
+export type CommunityUpdates = {
+  name?: string
+  description?: string
+  placeIds?: string[]
+  thumbnailBuffer?: Buffer
 }
 
 export type Community = {

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -159,6 +159,10 @@ export interface ICommunitiesDatabaseComponent {
   isMemberBanned(communityId: string, bannedMemberAddress: EthAddress): Promise<boolean>
   getBannedMembers(communityId: string, userAddress: EthAddress, pagination: Pagination): Promise<BannedMember[]>
   getBannedMembersCount(communityId: string): Promise<number>
+  updateCommunity(
+    communityId: string,
+    updates: Partial<Pick<CommunityDB, 'name' | 'description' | 'private'>>
+  ): Promise<Community>
 }
 
 export interface IVoiceDatabaseComponent {

--- a/src/utils/community-validation.ts
+++ b/src/utils/community-validation.ts
@@ -1,0 +1,75 @@
+import { InvalidRequestError } from '@dcl/platform-server-commons'
+import fileType from 'file-type'
+
+export interface CommunityValidationFields {
+  name?: string
+  description?: string
+  placeIds?: string[]
+  thumbnailBuffer?: Buffer
+}
+
+export interface CommunityValidationOptions {
+  requireName?: boolean
+  requireDescription?: boolean
+}
+
+export async function validateCommunityFields(
+  formData: any,
+  thumbnailBuffer?: Buffer,
+  options: CommunityValidationOptions = {}
+): Promise<CommunityValidationFields> {
+  const { requireName = false, requireDescription = false } = options
+
+  const name: string | undefined = formData.fields.name?.value
+  const description: string | undefined = formData.fields.description?.value
+  const placeIdsField: string | undefined = formData.fields.placeIds?.value
+
+  let placeIds: string[] | undefined = undefined
+  if (placeIdsField) {
+    try {
+      placeIds = JSON.parse(placeIdsField)
+      if (!Array.isArray(placeIds)) {
+        throw new InvalidRequestError('placeIds must be a valid JSON array')
+      }
+    } catch (error) {
+      throw new InvalidRequestError('placeIds must be a valid JSON array')
+    }
+  }
+
+  if (requireName || name !== undefined) {
+    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+      throw new InvalidRequestError('Name must be a non-empty string')
+    }
+  }
+
+  if (requireDescription || description !== undefined) {
+    if (!description || typeof description !== 'string' || description.trim().length === 0) {
+      throw new InvalidRequestError('Description must be a non-empty string')
+    }
+  }
+
+  // Always require at least one field for updates
+  if (name === undefined && description === undefined && !thumbnailBuffer && placeIds === undefined) {
+    throw new InvalidRequestError('At least one field must be provided for update')
+  }
+
+  // Validate thumbnail if provided
+  if (thumbnailBuffer) {
+    const type = await fileType.fromBuffer(thumbnailBuffer)
+    if (!type || !type.mime.startsWith('image/')) {
+      throw new InvalidRequestError('Thumbnail must be a valid image file')
+    }
+
+    const size = thumbnailBuffer.length
+    if (size < 1024 || size > 500 * 1024) {
+      throw new InvalidRequestError('Thumbnail size must be between 1KB and 500KB')
+    }
+  }
+
+  return {
+    name,
+    description,
+    placeIds,
+    thumbnailBuffer
+  }
+}

--- a/test/integration/update-community-controller.spec.ts
+++ b/test/integration/update-community-controller.spec.ts
@@ -37,7 +37,7 @@ test('Update Community Controller', async function ({ components, stubComponents
         headers: createHeaders,
         body: createForm as any
       })
-      
+
       const createBody = await createResponse.json()
       communityId = createBody.data.id
     })
@@ -269,4 +269,4 @@ test('Update Community Controller', async function ({ components, stubComponents
       })
     })
   })
-}) 
+})

--- a/test/integration/update-community-controller.spec.ts
+++ b/test/integration/update-community-controller.spec.ts
@@ -1,0 +1,272 @@
+import { test } from '../components'
+import { createTestIdentity, Identity, makeAuthenticatedRequest, createAuthHeaders, makeAuthenticatedMultipartRequest } from './utils/auth'
+import { randomUUID } from 'crypto'
+import FormData from 'form-data'
+
+test('Update Community Controller', async function ({ components, stubComponents }) {
+  const makeMultipartRequest = makeAuthenticatedMultipartRequest(components)
+  const makeRequest = makeAuthenticatedRequest(components)
+
+  describe('when updating a community', () => {
+    let identity: Identity
+    let communityId: string
+
+    beforeEach(async () => {
+      identity = await createTestIdentity()
+      
+      // Create a test community first
+      stubComponents.catalystClient.getOwnedNames.onFirstCall().resolves([
+        {
+          id: '1',
+          name: 'testOwnedName',
+          contractAddress: '0x0000000000000000000000000000000000000000',
+          tokenId: '1'
+        }
+      ])
+
+      const createForm = new FormData()
+      createForm.append('name', 'Original Community')
+      createForm.append('description', 'Original Description')
+      
+      const createHeaders = {
+        ...createAuthHeaders('POST', '/v1/communities', {}, identity)
+      }
+
+      const createResponse = await components.localHttpFetch.fetch('/v1/communities', {
+        method: 'POST',
+        headers: createHeaders,
+        body: createForm as any
+      })
+      
+      const createBody = await createResponse.json()
+      communityId = createBody.data.id
+    })
+
+    afterEach(async () => {
+      if (communityId) {
+        await components.communitiesDb.deleteCommunity(communityId)
+        await components.communitiesDbHelper.forceCommunityMemberRemoval(communityId, [identity.realAccount.address])
+        const places = await components.communitiesDb.getCommunityPlaces(communityId, {
+          limit: 1000,
+          offset: 0
+        })
+        for (const place of places) {
+          await components.communitiesDb.removeCommunityPlace(communityId, place.id)
+        }
+      }
+    })
+
+    describe('and the request is not signed', () => {
+      it('should respond with a 400 status code', async () => {
+        const { localHttpFetch } = components
+        const response = await localHttpFetch.fetch(`/v1/communities/${communityId}`, { method: 'PUT' })
+        expect(response.status).toBe(400)
+      })
+    })
+
+    describe('and the request is signed', () => {
+      describe('and valid fields are provided', () => {
+        describe('when updating name only', () => {
+          it('should update the community name', async () => {
+            const response = await makeMultipartRequest(identity, `/v1/communities/${communityId}`, {
+              name: 'Updated Community Name'
+            }, 'PUT')
+
+            expect(response.status).toBe(200)
+            const body = await response.json()
+            expect(body.data.name).toBe('Updated Community Name')
+            expect(body.data.description).toBe('Original Description')
+            expect(body.message).toBe('Community updated successfully')
+          })
+        })
+
+        describe('when updating description only', () => {
+          it('should update the community description', async () => {
+            const response = await makeMultipartRequest(identity, `/v1/communities/${communityId}`, {
+              description: 'Updated Description'
+            }, 'PUT')
+
+            expect(response.status).toBe(200)
+            const body = await response.json()
+            expect(body.data.name).toBe('Original Community')
+            expect(body.data.description).toBe('Updated Description')
+            expect(body.message).toBe('Community updated successfully')
+          })
+        })
+
+        describe('when updating placeIds', () => {
+          let newPlaceIds: string[]
+          beforeEach(async () => {
+            newPlaceIds = [randomUUID(), randomUUID()]
+            
+            stubComponents.fetcher.fetch.onFirstCall().resolves({
+              ok: true,
+              status: 200,
+              json: () => Promise.resolve({
+                data: newPlaceIds.map(id => ({
+                  id,
+                  title: 'Test Place',
+                  positions: ['0,0,0'],
+                  owner: identity.realAccount.address.toLowerCase()
+                }))
+              })
+            } as any)
+          })
+
+          afterEach(async () => {
+            await components.communitiesDb.removeCommunityPlace(communityId, newPlaceIds[0])
+            await components.communitiesDb.removeCommunityPlace(communityId, newPlaceIds[1])
+          })
+
+          it('should replace all community places with new ones', async () => {
+            const response = await makeMultipartRequest(identity, `/v1/communities/${communityId}`, {
+              placeIds: newPlaceIds
+            }, 'PUT')
+
+            expect(response.status).toBe(200)
+            const body = await response.json()
+            expect(body.message).toBe('Community updated successfully')
+
+            const placesResponse = await makeRequest(identity, `/v1/communities/${communityId}/places`, 'GET')
+            expect(placesResponse.status).toBe(200)
+            const placesResult = await placesResponse.json()
+            expect(placesResult.data.results.map((p: { id: string }) => p.id)).toEqual(expect.arrayContaining(newPlaceIds))
+          })
+
+          it('should remove all places when empty array is provided', async () => {
+            const response = await makeMultipartRequest(identity, `/v1/communities/${communityId}`, {
+              placeIds: []
+            }, 'PUT')
+
+            expect(response.status).toBe(200)
+            const body = await response.json()
+            expect(body.message).toBe('Community updated successfully')
+
+            const placesResponse = await makeRequest(identity, `/v1/communities/${communityId}/places`, 'GET')
+            expect(placesResponse.status).toBe(200)
+            const placesResult = await placesResponse.json()
+            expect(placesResult.data.results).toHaveLength(0)
+          })
+        })
+
+        describe('when updating with thumbnail', () => {
+          it('should update the community with new thumbnail', async () => {
+            const response = await makeMultipartRequest(identity, `/v1/communities/${communityId}`, {
+              name: 'Thumbnail Updated',
+              thumbnailPath: require('path').join(__dirname, 'fixtures/example.png')
+            }, 'PUT')
+
+            expect(response.status).toBe(200)
+            const body = await response.json()
+            expect(body.data.name).toBe('Thumbnail Updated')
+            expect(body.data.thumbnails).toBeDefined()
+            expect(body.data.thumbnails.raw).toContain('social/communities/')
+            expect(body.message).toBe('Community updated successfully')
+          })
+        })
+
+        describe('when updating multiple fields', () => {
+          it('should update all provided fields', async () => {
+            const response = await makeMultipartRequest(identity, `/v1/communities/${communityId}`, {
+              name: 'Multi Updated Name',
+              description: 'Multi Updated Description'
+            }, 'PUT')
+
+            expect(response.status).toBe(200)
+            const body = await response.json()
+            expect(body.data.name).toBe('Multi Updated Name')
+            expect(body.data.description).toBe('Multi Updated Description')
+            expect(body.message).toBe('Community updated successfully')
+          })
+        })
+      })
+
+      describe('but the user is not authorized', () => {
+        let otherIdentity: Identity
+
+        beforeEach(async () => {
+          otherIdentity = await createTestIdentity()
+        })
+
+        it('should respond with a 401 status code', async () => {
+          const response = await makeMultipartRequest(otherIdentity, `/v1/communities/${communityId}`, {
+            name: 'Unauthorized Update'
+          }, 'PUT')
+
+          expect(response.status).toBe(401)
+        })
+      })
+
+      describe('but the community does not exist', () => {
+        it('should respond with a 404 status code', async () => {
+          const nonExistentId = randomUUID()
+          const response = await makeMultipartRequest(identity, `/v1/communities/${nonExistentId}`, {
+            name: 'Non Existent Update'
+          }, 'PUT')
+
+          expect(response.status).toBe(404)
+        })
+      })
+
+      describe('but invalid data is provided', () => {
+        it('should respond with a 400 status code for empty name', async () => {
+          const response = await makeMultipartRequest(identity, `/v1/communities/${communityId}`, {
+            name: ''
+          }, 'PUT')
+
+          expect(response.status).toBe(400)
+        })
+
+        it('should respond with a 400 status code for empty description', async () => {
+          const response = await makeMultipartRequest(identity, `/v1/communities/${communityId}`, {
+            description: ''
+          }, 'PUT')
+
+          expect(response.status).toBe(400)
+        })
+
+        it('should respond with a 400 status code for invalid placeIds JSON', async () => {
+          const form = new FormData()
+          form.append('placeIds', 'invalid json')
+          
+          const headers = {
+            ...createAuthHeaders('PUT', `/v1/communities/${communityId}`, {}, identity)
+          }
+
+          const response = await components.localHttpFetch.fetch(`/v1/communities/${communityId}`, {
+            method: 'PUT',
+            headers,
+            body: form as any
+          })
+
+          expect(response.status).toBe(400)
+        })
+
+        it('should respond with a 400 status code when placeIds is not an array', async () => {
+          const form = new FormData()
+          form.append('placeIds', '"not an array"')
+          
+          const headers = {
+            ...createAuthHeaders('PUT', `/v1/communities/${communityId}`, {}, identity)
+          }
+
+          const response = await components.localHttpFetch.fetch(`/v1/communities/${communityId}`, {
+            method: 'PUT',
+            headers,
+            body: form as any
+          })
+
+          expect(response.status).toBe(400)
+        })
+
+        it('should respond with a 400 status code for invalid thumbnail', async () => {
+          const response = await makeMultipartRequest(identity, `/v1/communities/${communityId}`, {
+            thumbnailPath: require('path').join(__dirname, 'fixtures/example.txt')
+          }, 'PUT')
+
+          expect(response.status).toBe(400)
+        })
+      })
+    })
+  })
+}) 

--- a/test/integration/utils/auth.ts
+++ b/test/integration/utils/auth.ts
@@ -63,16 +63,23 @@ export function makeAuthenticatedMultipartRequest(components: Pick<TestComponent
       thumbnailPath,
       thumbnailBuffer,
       placeIds
-    }: { name?: string; description?: string; thumbnailPath?: string; thumbnailBuffer?: Buffer; placeIds?: string[] }
+    }: { 
+      name?: string; 
+      description?: string; 
+      thumbnailPath?: string; 
+      thumbnailBuffer?: Buffer; 
+      placeIds?: string[];
+    },
+    method: string = 'POST'
   ) => {
     const { localHttpFetch } = components
     const form = new FormData()
 
-    if (name) {
+    if (name !== undefined) {
       form.append('name', name)
     }
 
-    if (description) {
+    if (description !== undefined) {
       form.append('description', description)
     }
 
@@ -84,16 +91,16 @@ export function makeAuthenticatedMultipartRequest(components: Pick<TestComponent
       form.append('thumbnail', thumbnailBuffer, 'thumbnail.png')
     }
 
-    if (placeIds) {
+    if (placeIds !== undefined) {
       form.append('placeIds', JSON.stringify(placeIds))
     }
 
     const headers = {
-      ...createAuthHeaders('POST', path, {}, identity)
+      ...createAuthHeaders(method, path, {}, identity)
     }
 
     return localHttpFetch.fetch(path, {
-      method: 'POST',
+      method,
       headers,
       body: form as any
     })

--- a/test/mocks/components/communities-db.ts
+++ b/test/mocks/components/communities-db.ts
@@ -28,5 +28,6 @@ export const mockCommunitiesDB: jest.Mocked<ICommunitiesDatabaseComponent> = {
   isMemberBanned: jest.fn(),
   getBannedMembers: jest.fn(),
   getBannedMembersCount: jest.fn(),
-  updateMemberRole: jest.fn()
+  updateMemberRole: jest.fn(),
+  updateCommunity: jest.fn()
 }


### PR DESCRIPTION
This PR introduces a new endpoint (`PUT /v1/communities/:id`) for updating community information. The endpoint is secured through signed fetch and the role system.