### PR TITLE
fix: Observe active connections when the number changes

### DIFF
--- a/src/adapters/ws-pool.ts
+++ b/src/adapters/ws-pool.ts
@@ -9,10 +9,35 @@ export async function createWSPoolComponent({
   const logger = logs.getLogger('ws-pool')
   const idleTimeoutInMs = (await config.getNumber('IDLE_TIMEOUT_IN_MS')) || 300000 // 5 minutes default
 
+  /**
+   * Observe the current connection count from Redis
+   * and update the metric accordingly.
+   */
+  async function observeConnectionCount() {
+    try {
+      const currentCount = await getActiveConnections()
+      metrics.observe('ws_active_connections', { type: 'total' }, currentCount)
+
+      logger.debug('Observed active connections', {
+        count: currentCount
+      })
+    } catch (error: any) {
+      logger.error('Error observing connection count', {
+        error: error.message
+      })
+    }
+  }
+
+  /**
+   * Clean up idle connections from Redis.
+   * Runs every 60 seconds and removes connections that have been idle
+   * for longer than the configured timeout.
+   */
   const cleanupInterval = setInterval(async () => {
     try {
       const now = Date.now()
       const pattern = 'ws:conn:*'
+      let connectionsRemoved = 0
 
       for await (const key of redis.client.scanIterator({ MATCH: pattern })) {
         const data = await redis.get<{ lastActivity: number; startTime: number }>(key)
@@ -20,7 +45,13 @@ export async function createWSPoolComponent({
           const id = key.replace('ws:conn:', '')
           await releaseConnection(id)
           metrics.increment('ws_idle_timeouts')
+          connectionsRemoved++
         }
+      }
+
+      // Only observe metric if connections were actually removed
+      if (connectionsRemoved > 0) {
+        await observeConnectionCount()
       }
     } catch (error: any) {
       logger.error('Error cleaning up idle connections', {
@@ -29,11 +60,19 @@ export async function createWSPoolComponent({
     }
   }, 60000)
 
+  /**
+   * Acquire a connection from Redis.
+   * Creates a new connection entry in Redis with the given ID.
+   *
+   * @param id - The unique connection identifier
+   * @throws {Error} If the connection already exists or transaction fails
+   */
   async function acquireConnection(id: string) {
     const key = `ws:conn:${id}`
     const startTime = Date.now()
 
     try {
+      // Use a more robust transaction that ensures atomicity
       const result = await redis.client
         .multi()
         .set(key, JSON.stringify({ lastActivity: startTime, startTime }), {
@@ -44,31 +83,70 @@ export async function createWSPoolComponent({
         .exec()
 
       if (!result) {
+        throw new Error('Transaction failed')
+      }
+
+      // setResult: "OK" if set, null if key exists (NX flag)
+      // _addResult: 1 if added, 0 if already in set
+      const [setResult, _addResult] = result
+
+      if (!setResult) {
+        // Connection already exists
         throw new Error('Connection already exists')
       }
 
-      const totalConnections = await getActiveConnections()
-      metrics.observe('ws_active_connections', { type: 'total' }, totalConnections)
+      // Observe the new connection count after successful acquisition
+      await observeConnectionCount()
+
+      logger.debug('Connection acquired successfully', {
+        connectionId: id
+      })
     } catch (error: any) {
       logger.error('Error acquiring connection', {
         connectionId: id,
         error: error.message
       })
+      // Clean up any partial state
       await redis.client.multi().del(key).sRem('ws:conn_ids', id).exec()
       throw error
     }
   }
 
+  /**
+   * Release a connection from Redis.
+   * Removes the connection entry and ID from Redis.
+   *
+   * @param id - The unique connection identifier
+   */
   async function releaseConnection(id: string) {
     try {
       const key = `ws:conn:${id}`
       const endTime = Date.now()
       const connectionData = await redis.get<{ lastActivity: number; startTime: number }>(key)
 
-      await redis.client.multi().del(key).sRem('ws:conn_ids', id).exec()
+      // Use transaction to ensure atomic removal
+      const result = await redis.client.multi().del(key).sRem('ws:conn_ids', id).exec()
 
-      const totalConnections = await getActiveConnections()
-      metrics.observe('ws_active_connections', { type: 'total' }, totalConnections)
+      if (!result) {
+        throw new Error('Transaction failed')
+      }
+
+      // _deleteResult: 1 if deleted, 0 if key didn't exist
+      // removeResult: 1 if removed, 0 if not in set
+      const [_deleteResult, removeResult] = result
+
+      if (removeResult === 1) {
+        // Connection was successfully removed from set
+        await observeConnectionCount()
+
+        logger.debug('Connection released successfully', {
+          connectionId: id
+        })
+      } else {
+        logger.warn('Connection was already released or did not exist', {
+          connectionId: id
+        })
+      }
 
       if (connectionData?.startTime) {
         const duration = (endTime - connectionData.startTime) / 1000
@@ -82,6 +160,13 @@ export async function createWSPoolComponent({
     }
   }
 
+  /**
+   * Update the activity timestamp for a connection.
+   * Extends the connection's TTL and updates the last activity time.
+   *
+   * @param id - The unique connection identifier
+   * @throws {Error} If the connection doesn't exist or update fails
+   */
   async function updateActivity(id: string) {
     try {
       const key = `ws:conn:${id}`
@@ -102,14 +187,29 @@ export async function createWSPoolComponent({
     }
   }
 
+  /**
+   * Check if a connection is available in Redis.
+   *
+   * @param id - The unique connection identifier
+   * @returns {Promise<boolean>} True if the connection exists, false otherwise
+   */
   async function isConnectionAvailable(id: string) {
     return (await redis.client.exists(`ws:conn:${id}`)) === 1
   }
 
+  /**
+   * Get the total number of active connections.
+   *
+   * @returns {Promise<number>} The number of active connections
+   */
   async function getActiveConnections(): Promise<number> {
     return await redis.client.sCard('ws:conn_ids')
   }
 
+  /**
+   * Clean up all connections and stop the cleanup interval.
+   * This is typically called during service shutdown.
+   */
   async function cleanup() {
     clearInterval(cleanupInterval)
     const pattern = 'ws:conn:*'

--- a/test/unit/adapters/ws-pool.spec.ts
+++ b/test/unit/adapters/ws-pool.spec.ts
@@ -1,7 +1,6 @@
 import { createWSPoolComponent } from '../../../src/adapters/ws-pool'
 import { mockConfig, mockMetrics, mockRedis, mockLogs } from '../../mocks/components'
 import { IWSPoolComponent } from '../../../src/types'
-import { exec } from 'child_process'
 
 describe('ws-pool-component', () => {
   let wsPool: IWSPoolComponent
@@ -9,6 +8,11 @@ describe('ws-pool-component', () => {
   let originalSetInterval: typeof setInterval
   let mockSetInterval: jest.Mock
   let mockClearInterval: jest.Mock
+
+  const testId = 'test-connection-1'
+  const expectedKey = `ws:conn:${testId}`
+  const now = Date.now()
+  const expectedData = { lastActivity: now, startTime: now }
 
   beforeEach(async () => {
     originalSetInterval = global.setInterval
@@ -37,138 +41,291 @@ describe('ws-pool-component', () => {
     mockRedis.get.mockResolvedValue(null)
     mockRedis.put.mockResolvedValue(undefined)
 
-    wsPool = await createWSPoolComponent({ metrics: mockMetrics, config: mockConfig, redis: mockRedis, logs: mockLogs })
+    jest.spyOn(Date, 'now').mockReturnValue(now)
+
+    wsPool = await createWSPoolComponent({
+      metrics: mockMetrics,
+      config: mockConfig,
+      redis: mockRedis,
+      logs: mockLogs
+    })
   })
 
   afterEach(() => {
     global.setInterval = originalSetInterval
+    jest.restoreAllMocks()
   })
 
-  describe('initialization', () => {
-    it('should initialize with default idle timeout if config returns falsy', async () => {
-      mockConfig.getNumber.mockResolvedValueOnce(0)
-      const pool = await createWSPoolComponent({
-        metrics: mockMetrics,
-        config: mockConfig,
-        redis: mockRedis,
-        logs: mockLogs
+  describe('when initializing the component', () => {
+    describe('and config returns falsy value', () => {
+      beforeEach(() => {
+        mockConfig.getNumber.mockResolvedValueOnce(0)
       })
-      expect(pool).toBeDefined()
+
+      it('should initialize with default idle timeout', async () => {
+        const pool = await createWSPoolComponent({
+          metrics: mockMetrics,
+          config: mockConfig,
+          redis: mockRedis,
+          logs: mockLogs
+        })
+
+        expect(pool).toBeDefined()
+      })
     })
 
-    it('should set up cleanup interval of one minute', async () => {
+    describe('and config returns a valid timeout', () => {
+      const customTimeout = 600000 // 10 minutes
+
+      beforeEach(() => {
+        mockConfig.getNumber.mockResolvedValueOnce(customTimeout)
+      })
+
+      it('should use the configured timeout', async () => {
+        await createWSPoolComponent({
+          metrics: mockMetrics,
+          config: mockConfig,
+          redis: mockRedis,
+          logs: mockLogs
+        })
+
+        expect(mockConfig.getNumber).toHaveBeenCalledWith('IDLE_TIMEOUT_IN_MS')
+      })
+    })
+
+    it('should set up cleanup interval of one minute', () => {
       expect(mockSetInterval).toHaveBeenCalledWith(expect.any(Function), 60000)
     })
+  })
 
-    it('should handle idle timeout cleanup', async () => {
-      const cleanupFn = mockSetInterval.mock.calls[0][0]
+  describe('when cleaning up idle connections', () => {
+    let cleanupFn: Function
+
+    beforeEach(() => {
+      cleanupFn = mockSetInterval.mock.calls[0][0]
+    })
+
+    describe('and there are idle connections', () => {
       const mockIterator = ['ws:conn:test-1', 'ws:conn:test-2'][Symbol.iterator]()
-      mockRedisClient.scanIterator.mockReturnValue(mockIterator)
 
-      mockRedis.get
-        .mockResolvedValueOnce({ lastActivity: Date.now() - 400000 })
-        .mockResolvedValueOnce({ lastActivity: Date.now() - 100000 })
-
-      await cleanupFn()
-
-      expect(mockRedisClient.multi().del).toHaveBeenCalledWith('ws:conn:test-1')
-      expect(mockRedisClient.multi().sRem).toHaveBeenCalledWith('ws:conn_ids', 'test-1')
-      expect(mockMetrics.increment).toHaveBeenCalledWith('ws_idle_timeouts')
-
-      expect(mockRedisClient.multi().del).not.toHaveBeenCalledWith('ws:conn:test-2')
-      expect(mockRedisClient.multi().sRem).not.toHaveBeenCalledWith('ws:conn_ids', 'test-2')
-    })
-
-    it('should handle null data in cleanup', async () => {
-      const cleanupFn = mockSetInterval.mock.calls[0][0]
-
-      const mockIterator = ['ws:conn:test-1'][Symbol.iterator]()
-      mockRedisClient.scanIterator.mockReturnValue(mockIterator)
-      mockRedisClient.get.mockResolvedValueOnce(null)
-
-      await cleanupFn()
-
-      expect(mockRedisClient.multi().del).not.toHaveBeenCalled()
-      expect(mockRedisClient.multi().sRem).not.toHaveBeenCalled()
-      expect(mockMetrics.increment).not.toHaveBeenCalled()
-    })
-
-    it('should handle invalid JSON in cleanup', async () => {
-      const cleanupFn = mockSetInterval.mock.calls[0][0]
-
-      const mockIterator = ['ws:conn:test-1'][Symbol.iterator]()
-      mockRedisClient.scanIterator.mockReturnValue(mockIterator)
-      mockRedisClient.get.mockResolvedValueOnce('invalid json')
-
-      await cleanupFn()
-
-      expect(mockRedisClient.multi().del).not.toHaveBeenCalled()
-      expect(mockRedisClient.multi().sRem).not.toHaveBeenCalled()
-      expect(mockMetrics.increment).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('acquireConnection', () => {
-    const testId = 'test-connection-1'
-    const expectedKey = `ws:conn:${testId}`
-    const now = Date.now()
-    const expectedData = { lastActivity: now, startTime: now }
-
-    jest.spyOn(Date, 'now').mockReturnValue(now)
-
-    it('should acquire new connection with correct Redis operations', async () => {
-      await wsPool.acquireConnection(testId)
-
-      expect(mockRedisClient.multi).toHaveBeenCalled()
-      const multiChain = mockRedisClient.multi()
-
-      expect(multiChain.set).toHaveBeenCalledWith(expectedKey, JSON.stringify(expectedData), {
-        NX: true,
-        EX: Math.ceil(300000 / 1000)
+      beforeEach(() => {
+        mockRedisClient.scanIterator.mockReturnValue(mockIterator)
+        mockRedis.get
+          .mockResolvedValueOnce({ lastActivity: Date.now() - 400000 }) // 6.6 minutes ago
+          .mockResolvedValueOnce({ lastActivity: Date.now() - 100000 }) // 1.6 minutes ago
       })
-      expect(multiChain.sAdd).toHaveBeenCalledWith('ws:conn_ids', testId)
-      expect(mockMetrics.observe).toHaveBeenCalledWith('ws_active_connections', { type: 'total' }, expect.any(Number))
+
+      it('should remove only the idle connections and update metrics', async () => {
+        await cleanupFn()
+
+        expect(mockRedisClient.multi().del).toHaveBeenCalledWith('ws:conn:test-1')
+        expect(mockRedisClient.multi().sRem).toHaveBeenCalledWith('ws:conn_ids', 'test-1')
+        expect(mockMetrics.increment).toHaveBeenCalledWith('ws_idle_timeouts')
+
+        expect(mockRedisClient.multi().del).not.toHaveBeenCalledWith('ws:conn:test-2')
+        expect(mockRedisClient.multi().sRem).not.toHaveBeenCalledWith('ws:conn_ids', 'test-2')
+      })
     })
 
-    it('should handle transaction failure', async () => {
-      const mockFailedMulti = {
-        set: jest.fn().mockReturnThis(),
-        sAdd: jest.fn().mockReturnThis(),
-        del: jest.fn().mockReturnThis(),
-        sRem: jest.fn().mockReturnThis(),
-        exec: jest.fn().mockResolvedValue(null)
-      }
+    describe('and there are no idle connections', () => {
+      const mockIterator = ['ws:conn:test-1'][Symbol.iterator]()
 
-      mockRedisClient.multi.mockReturnValueOnce(mockFailedMulti)
+      beforeEach(() => {
+        mockRedisClient.scanIterator.mockReturnValue(mockIterator)
+        mockRedis.get.mockResolvedValueOnce({ lastActivity: Date.now() - 100000 }) // 1.6 minutes ago
+      })
 
-      await expect(wsPool.acquireConnection(testId)).rejects.toThrow('Connection already exists')
+      it('should not remove any connections', async () => {
+        await cleanupFn()
 
-      expect(mockRedisClient.multi().del).toHaveBeenCalledWith(expectedKey)
-      expect(mockRedisClient.multi().sRem).toHaveBeenCalledWith('ws:conn_ids', testId)
+        expect(mockRedisClient.multi().del).not.toHaveBeenCalled()
+        expect(mockRedisClient.multi().sRem).not.toHaveBeenCalled()
+        expect(mockMetrics.increment).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and connection data is null', () => {
+      const mockIterator = ['ws:conn:test-1'][Symbol.iterator]()
+
+      beforeEach(() => {
+        mockRedisClient.scanIterator.mockReturnValue(mockIterator)
+        mockRedis.get.mockResolvedValueOnce(null)
+      })
+
+      it('should not remove any connections', async () => {
+        await cleanupFn()
+
+        expect(mockRedisClient.multi().del).not.toHaveBeenCalled()
+        expect(mockRedisClient.multi().sRem).not.toHaveBeenCalled()
+        expect(mockMetrics.increment).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and connection data is invalid', () => {
+      const mockIterator = ['ws:conn:test-1'][Symbol.iterator]()
+
+      beforeEach(() => {
+        mockRedisClient.scanIterator.mockReturnValue(mockIterator)
+        mockRedis.get.mockResolvedValueOnce('invalid json')
+      })
+
+      it('should not remove any connections', async () => {
+        await cleanupFn()
+
+        expect(mockRedisClient.multi().del).not.toHaveBeenCalled()
+        expect(mockRedisClient.multi().sRem).not.toHaveBeenCalled()
+        expect(mockMetrics.increment).not.toHaveBeenCalled()
+      })
     })
   })
 
-  describe('releaseConnection', () => {
-    it('should release existing connection', async () => {
-      await wsPool.releaseConnection('test-1')
-      expect(mockRedisClient.multi().del).toHaveBeenCalledWith('ws:conn:test-1')
-      expect(mockRedisClient.multi().sRem).toHaveBeenCalledWith('ws:conn_ids', 'test-1')
+  describe('when acquiring a connection', () => {
+    describe('and the transaction succeeds', () => {
+      beforeEach(() => {
+        const mockMulti = {
+          set: jest.fn().mockReturnThis(),
+          sAdd: jest.fn().mockReturnThis(),
+          del: jest.fn().mockReturnThis(),
+          sRem: jest.fn().mockReturnThis(),
+          exec: jest.fn().mockResolvedValue(['OK', 1])
+        }
+        mockRedisClient.multi.mockReturnValue(mockMulti)
+      })
+
+      it('should create the connection with correct Redis operations', async () => {
+        await wsPool.acquireConnection(testId)
+
+        expect(mockRedisClient.multi).toHaveBeenCalled()
+        const multiChain = mockRedisClient.multi()
+
+        expect(multiChain.set).toHaveBeenCalledWith(expectedKey, JSON.stringify(expectedData), {
+          NX: true,
+          EX: Math.ceil(300000 / 1000)
+        })
+        expect(multiChain.sAdd).toHaveBeenCalledWith('ws:conn_ids', testId)
+        expect(mockMetrics.observe).toHaveBeenCalledWith('ws_active_connections', { type: 'total' }, expect.any(Number))
+      })
     })
 
-    it('should update total connections and duration metrics after release', async () => {
-      const now = Date.now()
-      mockRedis.get.mockResolvedValueOnce({ startTime: now - 10000, lastActivity: now - 5000 })
-      mockRedisClient.sCard.mockResolvedValue(0)
+    describe('and the transaction fails', () => {
+      beforeEach(() => {
+        const mockFailedMulti = {
+          set: jest.fn().mockReturnThis(),
+          sAdd: jest.fn().mockReturnThis(),
+          del: jest.fn().mockReturnThis(),
+          sRem: jest.fn().mockReturnThis(),
+          exec: jest.fn().mockResolvedValue(null)
+        }
+        mockRedisClient.multi.mockReturnValue(mockFailedMulti)
+      })
 
-      await wsPool.releaseConnection('test-1')
+      it('should throw an error and clean up partial state', async () => {
+        await expect(wsPool.acquireConnection(testId)).rejects.toThrow('Transaction failed')
 
-      expect(mockMetrics.observe).toHaveBeenCalledWith('ws_active_connections', { type: 'total' }, 0)
-      expect(mockMetrics.observe).toHaveBeenCalledWith('ws_connection_duration_seconds', {}, expect.any(Number))
+        expect(mockRedisClient.multi().del).toHaveBeenCalledWith(expectedKey)
+        expect(mockRedisClient.multi().sRem).toHaveBeenCalledWith('ws:conn_ids', testId)
+      })
+    })
+
+    describe('and the connection already exists', () => {
+      beforeEach(() => {
+        const mockFailedMulti = {
+          set: jest.fn().mockReturnThis(),
+          sAdd: jest.fn().mockReturnThis(),
+          del: jest.fn().mockReturnThis(),
+          sRem: jest.fn().mockReturnThis(),
+          exec: jest.fn().mockResolvedValue([null, 0])
+        }
+        mockRedisClient.multi.mockReturnValue(mockFailedMulti)
+      })
+
+      it('should throw an error and clean up partial state', async () => {
+        await expect(wsPool.acquireConnection(testId)).rejects.toThrow('Connection already exists')
+
+        expect(mockRedisClient.multi().del).toHaveBeenCalledWith(expectedKey)
+        expect(mockRedisClient.multi().sRem).toHaveBeenCalledWith('ws:conn_ids', testId)
+      })
     })
   })
 
-  describe('updateActivity', () => {
-    it('should update connection activity', async () => {
+  describe('when releasing a connection', () => {
+    describe('and the connection exists and is successfully removed', () => {
+      beforeEach(() => {
+        const mockMulti = {
+          set: jest.fn().mockReturnThis(),
+          sAdd: jest.fn().mockReturnThis(),
+          sRem: jest.fn().mockReturnThis(),
+          del: jest.fn().mockReturnThis(),
+          exec: jest.fn().mockResolvedValue([1, 1])
+        }
+        mockRedisClient.multi.mockReturnValue(mockMulti)
+        mockRedis.get.mockResolvedValueOnce({ startTime: now - 10000, lastActivity: now - 5000 })
+        mockRedisClient.sCard.mockResolvedValue(0)
+      })
+
+      it('should remove the connection and update metrics', async () => {
+        await wsPool.releaseConnection('test-1')
+
+        expect(mockRedisClient.multi().del).toHaveBeenCalledWith('ws:conn:test-1')
+        expect(mockRedisClient.multi().sRem).toHaveBeenCalledWith('ws:conn_ids', 'test-1')
+        expect(mockMetrics.observe).toHaveBeenCalledWith('ws_active_connections', { type: 'total' }, 0)
+        expect(mockMetrics.observe).toHaveBeenCalledWith('ws_connection_duration_seconds', {}, expect.any(Number))
+      })
+    })
+
+    describe('and the connection was already released', () => {
+      beforeEach(() => {
+        const mockMulti = {
+          set: jest.fn().mockReturnThis(),
+          sAdd: jest.fn().mockReturnThis(),
+          sRem: jest.fn().mockReturnThis(),
+          del: jest.fn().mockReturnThis(),
+          exec: jest.fn().mockResolvedValue([0, 0])
+        }
+        mockRedisClient.multi.mockReturnValue(mockMulti)
+      })
+
+      it('should not update metrics and log a warning', async () => {
+        await wsPool.releaseConnection('test-1')
+
+        expect(mockRedisClient.multi().del).toHaveBeenCalledWith('ws:conn:test-1')
+        expect(mockRedisClient.multi().sRem).toHaveBeenCalledWith('ws:conn_ids', 'test-1')
+        expect(mockMetrics.observe).not.toHaveBeenCalledWith(
+          'ws_active_connections',
+          { type: 'total' },
+          expect.any(Number)
+        )
+      })
+    })
+
+    describe('and the transaction fails', () => {
+      beforeEach(() => {
+        const mockFailedMulti = {
+          set: jest.fn().mockReturnThis(),
+          sAdd: jest.fn().mockReturnThis(),
+          sRem: jest.fn().mockReturnThis(),
+          del: jest.fn().mockReturnThis(),
+          exec: jest.fn().mockResolvedValue(null)
+        }
+        mockRedisClient.multi.mockReturnValue(mockFailedMulti)
+      })
+
+      it('should not update metrics', async () => {
+        await wsPool.releaseConnection('test-1')
+
+        expect(mockRedisClient.multi().del).toHaveBeenCalledWith('ws:conn:test-1')
+        expect(mockRedisClient.multi().sRem).toHaveBeenCalledWith('ws:conn_ids', 'test-1')
+        expect(mockMetrics.observe).not.toHaveBeenCalledWith(
+          'ws_active_connections',
+          { type: 'total' },
+          expect.any(Number)
+        )
+      })
+    })
+  })
+
+  describe('when updating connection activity', () => {
+    it('should update the connection activity timestamp', async () => {
       const key = 'ws:conn:test-1'
       await wsPool.updateActivity('test-1')
 
@@ -183,28 +340,49 @@ describe('ws-pool-component', () => {
     })
   })
 
-  describe('isConnectionAvailable', () => {
-    it('should check if connection exists', async () => {
-      mockRedisClient.exists.mockResolvedValue(1)
-      expect(await wsPool.isConnectionAvailable('test-1')).toBe(true)
+  describe('when checking if a connection is available', () => {
+    describe('and the connection exists', () => {
+      beforeEach(() => {
+        mockRedisClient.exists.mockResolvedValueOnce(1)
+      })
 
-      mockRedisClient.exists.mockResolvedValue(0)
-      expect(await wsPool.isConnectionAvailable('test-1')).toBe(false)
+      it('should return true', async () => {
+        const result = await wsPool.isConnectionAvailable('test-1')
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('and the connection does not exist', () => {
+      beforeEach(() => {
+        mockRedisClient.exists.mockResolvedValueOnce(0)
+      })
+
+      it('should return false', async () => {
+        const result = await wsPool.isConnectionAvailable('test-1')
+        expect(result).toBe(false)
+      })
     })
   })
 
-  describe('getActiveConnections', () => {
-    it('should return number of active connections', async () => {
-      mockRedisClient.sCard.mockResolvedValue(5)
-      expect(await wsPool.getActiveConnections()).toBe(5)
+  describe('when getting active connections count', () => {
+    beforeEach(() => {
+      mockRedisClient.sCard.mockResolvedValueOnce(5)
+    })
+
+    it('should return the number of active connections', async () => {
+      const result = await wsPool.getActiveConnections()
+      expect(result).toBe(5)
     })
   })
 
-  describe('cleanup', () => {
-    it('should cleanup all connections and clear interval', async () => {
-      const mockIterator = ['ws:conn:test-1', 'ws:conn:test-2'][Symbol.iterator]()
+  describe('when cleaning up all connections', () => {
+    const mockIterator = ['ws:conn:test-1', 'ws:conn:test-2'][Symbol.iterator]()
+
+    beforeEach(() => {
       mockRedisClient.scanIterator.mockReturnValue(mockIterator as any)
+    })
 
+    it('should cleanup all connections and clear interval', async () => {
       await wsPool.cleanup()
 
       expect(mockRedisClient.multi().del).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
# Problem
`ws_active_connections` metric showed inflated values.

# Root Cause
The metric was being updated in multiple places with potential race conditions:
- After `acquireConnection`
- After `releaseConnection`
- During `cleanup interval`

# Fix
- Removed redundant metric updates - eliminated the direct metrics.observe() calls in acquireConnection and releaseConnection
- Added centralized observeConnectionCount() function - single place to read Redis state and update metric
- Only update metric when connections actually change - added connectionsRemoved counter in cleanup to avoid unnecessary updates

