### PR TITLE
fix: communities WS connection updates should send the affected wallet despite who is informing

### DIFF
--- a/src/logic/updates.ts
+++ b/src/logic/updates.ts
@@ -185,7 +185,7 @@ export function createUpdateHandlerComponent(
         if (updateEmitter) {
           updateEmitter.emit('communityMemberConnectivityUpdate', {
             communityId,
-            memberAddress,
+            memberAddress: update.memberAddress,
             status
           })
         }

--- a/test/unit/logic/updates.spec.ts
+++ b/test/unit/logic/updates.spec.ts
@@ -542,12 +542,12 @@ describe('Updates Handlers', () => {
             ])
             expect(emitSpy456).toHaveBeenCalledWith('communityMemberConnectivityUpdate', {
               communityId: 'community-1',
-              memberAddress: '0x456',
+              memberAddress: '0x123',
               status
             })
             expect(emitSpy789).toHaveBeenCalledWith('communityMemberConnectivityUpdate', {
               communityId: 'community-1',
-              memberAddress: '0x789',
+              memberAddress: '0x123',
               status
             })
             expect(emitSpy123).not.toHaveBeenCalled()
@@ -586,17 +586,17 @@ describe('Updates Handlers', () => {
             ])
             expect(emitSpy456).toHaveBeenCalledWith('communityMemberConnectivityUpdate', {
               communityId: 'community-1',
-              memberAddress: '0x456',
+              memberAddress: '0x123',
               status
             })
             expect(emitSpy789).toHaveBeenCalledWith('communityMemberConnectivityUpdate', {
               communityId: 'community-1',
-              memberAddress: '0x789',
+              memberAddress: '0x123',
               status
             })
             expect(emitSpy999).toHaveBeenCalledWith('communityMemberConnectivityUpdate', {
               communityId: 'community-1',
-              memberAddress: '0x999',
+              memberAddress: '0x123',
               status
             })
             expect(emitSpy123).toHaveBeenCalledWith('communityMemberConnectivityUpdate', update)
@@ -629,17 +629,17 @@ describe('Updates Handlers', () => {
             ])
             expect(emitSpy456).toHaveBeenCalledWith('communityMemberConnectivityUpdate', {
               communityId: 'community-1',
-              memberAddress: '0x456',
+              memberAddress: '0x123',
               status
             })
             expect(emitSpy789).toHaveBeenCalledWith('communityMemberConnectivityUpdate', {
               communityId: 'community-1',
-              memberAddress: '0x789',
+              memberAddress: '0x123',
               status
             })
             expect(emitSpy999).toHaveBeenCalledWith('communityMemberConnectivityUpdate', {
               communityId: 'community-1',
-              memberAddress: '0x999',
+              memberAddress: '0x123',
               status
             })
             expect(emitSpy123).not.toHaveBeenCalled()


### PR DESCRIPTION
This PR fixes an issue in community member status updates where other members received their own wallet address instead of the address of the member who joined/left the community.
