### PR TITLE
feat: add banned user checks from joining community voice chats

### DIFF
--- a/src/controllers/handlers/rpc/join-community-voice-chat.ts
+++ b/src/controllers/handlers/rpc/join-community-voice-chat.ts
@@ -4,6 +4,7 @@ import {
 } from '@dcl/protocol/out-ts/decentraland/social_service/v2/social_service_v2.gen'
 import { RPCServiceContext, RpcServerContext } from '../../../types/rpc'
 import { CommunityVoiceChatNotFoundError, UserNotCommunityMemberError } from '../../../logic/community-voice/errors'
+import { NotAuthorizedError } from '@dcl/platform-server-commons'
 import { isErrorWithMessage } from '../../../utils/errors'
 
 export function joinCommunityVoiceChatService({
@@ -63,6 +64,15 @@ export function joinCommunityVoiceChatService({
       }
 
       if (error instanceof UserNotCommunityMemberError) {
+        return {
+          response: {
+            $case: 'forbiddenError',
+            forbiddenError: { message: error.message }
+          }
+        }
+      }
+
+      if (error instanceof NotAuthorizedError) {
         return {
           response: {
             $case: 'forbiddenError',

--- a/src/logic/community-voice/community-voice.ts
+++ b/src/logic/community-voice/community-voice.ts
@@ -8,6 +8,7 @@ import {
 } from '../../types'
 import { AnalyticsEvent } from '../../types/analytics'
 import { isErrorWithMessage } from '../../utils/errors'
+import { NotAuthorizedError } from '@dcl/platform-server-commons'
 import {
   CommunityVoiceChatNotFoundError,
   CommunityVoiceChatAlreadyActiveError,
@@ -154,6 +155,12 @@ export async function createCommunityVoiceComponent({
       if (userRole === CommunityRole.None) {
         throw new UserNotCommunityMemberError(userAddress, communityId)
       }
+    }
+
+    // Check if user is banned from the community (applies to both public and private communities)
+    const isBanned = await communitiesDb.isMemberBanned(communityId, userAddress)
+    if (isBanned) {
+      throw new NotAuthorizedError(`The user ${userAddress} is banned from community ${communityId}`)
     }
 
     // Fetch user profile data using helper function

--- a/test/unit/adapters/rpc-server/services/join-community-voice-chat.spec.ts
+++ b/test/unit/adapters/rpc-server/services/join-community-voice-chat.spec.ts
@@ -1,5 +1,6 @@
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import { JoinCommunityVoiceChatPayload } from '@dcl/protocol/out-ts/decentraland/social_service/v2/social_service_v2.gen'
+import { NotAuthorizedError } from '@dcl/platform-server-commons'
 import { joinCommunityVoiceChatService } from '../../../../../src/controllers/handlers/rpc/join-community-voice-chat'
 import { ICommunityVoiceComponent } from '../../../../../src/logic/community-voice'
 import { createLogsMockedComponent } from '../../../../mocks/components'
@@ -136,6 +137,33 @@ describe('when joining a community voice chat', () => {
       if (result.response?.$case === 'forbiddenError') {
         expect(result.response.forbiddenError.message).toBe(
           `User ${userAddress} is not a member of community ${communityId}`
+        )
+      }
+    })
+  })
+
+  describe('and joining a community voice chat fails because user is banned', () => {
+    beforeEach(() => {
+      joinCommunityVoiceChatMock.mockRejectedValue(
+        new NotAuthorizedError(`The user ${userAddress} is banned from community ${communityId}`)
+      )
+    })
+
+    it('should resolve with a forbidden error response', async () => {
+      const result = await service(
+        JoinCommunityVoiceChatPayload.create({
+          communityId
+        }),
+        {
+          address: userAddress,
+          subscribersContext: undefined
+        }
+      )
+
+      expect(result.response?.$case).toBe('forbiddenError')
+      if (result.response?.$case === 'forbiddenError') {
+        expect(result.response.forbiddenError.message).toBe(
+          `The user ${userAddress} is banned from community ${communityId}`
         )
       }
     })


### PR DESCRIPTION
This PR adds a check if the user is banned from the community before letting them join the community voice chat