### PR TITLE
feat: add query param to filter communities by ones with active voice chats

### DIFF
--- a/src/adapters/comms-gatekeeper.ts
+++ b/src/adapters/comms-gatekeeper.ts
@@ -1,5 +1,6 @@
 import { ICommsGatekeeperComponent, AppComponents, PrivateMessagesPrivacy, CommunityRole } from '../types'
 import { CommunityVoiceChatAction, CommunityVoiceChatProfileData } from '../logic/community-voice/types'
+import { CommunityVoiceChatStatus } from '../logic/community/types'
 import { isErrorWithMessage } from '../utils/errors'
 
 export class PrivateVoiceChatNotFoundError extends Error {
@@ -367,11 +368,7 @@ export const createCommsGatekeeperComponent = async ({
    * @param communityId - The ID of the community
    * @returns The community voice chat status or null if not active
    */
-  async function getCommunityVoiceChatStatus(communityId: string): Promise<{
-    isActive: boolean
-    participantCount: number
-    moderatorCount: number
-  } | null> {
+  async function getCommunityVoiceChatStatus(communityId: string): Promise<CommunityVoiceChatStatus | null> {
     try {
       const response = await fetch(`${commsUrl}/community-voice-chat/${communityId}/status`, {
         method: 'GET',
@@ -398,6 +395,55 @@ export const createCommsGatekeeperComponent = async ({
     } catch (error) {
       logger.error(
         `Failed to get community voice chat status for community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
+      )
+      throw error
+    }
+  }
+
+  /**
+   * Gets the status of multiple community voice chats in batch.
+   * @param communityIds - Array of community IDs to check
+   * @returns Record mapping community IDs to their voice chat status
+   */
+  async function getCommunitiesVoiceChatStatus(
+    communityIds: string[]
+  ): Promise<Record<string, CommunityVoiceChatStatus>> {
+    if (communityIds.length === 0) {
+      return {}
+    }
+
+    try {
+      const statuses = await Promise.all(
+        communityIds.map(async (communityId) => {
+          try {
+            const status = await getCommunityVoiceChatStatus(communityId)
+            return {
+              communityId,
+              status:
+                status || ({ isActive: false, participantCount: 0, moderatorCount: 0 } as CommunityVoiceChatStatus)
+            }
+          } catch (error) {
+            logger.warn(`Could not get voice chat status for community ${communityId}`, {
+              error: isErrorWithMessage(error) ? error.message : 'Unknown error'
+            })
+            return {
+              communityId,
+              status: { isActive: false, participantCount: 0, moderatorCount: 0 } as CommunityVoiceChatStatus
+            }
+          }
+        })
+      )
+
+      return statuses.reduce(
+        (acc, { communityId, status }) => {
+          acc[communityId] = status
+          return acc
+        },
+        {} as Record<string, CommunityVoiceChatStatus>
+      )
+    } catch (error) {
+      logger.error(
+        `Failed to get multiple community voice chat statuses: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
       )
       throw error
     }
@@ -441,6 +487,7 @@ export const createCommsGatekeeperComponent = async ({
     promoteSpeakerInCommunityVoiceChat,
     demoteSpeakerInCommunityVoiceChat,
     getCommunityVoiceChatStatus,
+    getCommunitiesVoiceChatStatus,
     kickUserFromCommunityVoiceChat
   }
 }

--- a/src/controllers/handlers/http/get-communities-handler.ts
+++ b/src/controllers/handlers/http/get-communities-handler.ts
@@ -27,11 +27,12 @@ export async function getCommunitiesHandler(
   const pagination = getPaginationParams(url.searchParams)
   const search = url.searchParams.get('search')
   const onlyMemberOf = url.searchParams.get('onlyMemberOf')?.toLowerCase() === 'true'
+  const onlyWithActiveVoiceChat = url.searchParams.get('onlyWithActiveVoiceChat')?.toLowerCase() === 'true'
 
   try {
     const { communities: communitiesData, total } = userAddress
-      ? await communities.getCommunities(userAddress, { pagination, search, onlyMemberOf })
-      : await communities.getCommunitiesPublicInformation({ pagination, search })
+      ? await communities.getCommunities(userAddress, { pagination, search, onlyMemberOf, onlyWithActiveVoiceChat })
+      : await communities.getCommunitiesPublicInformation({ pagination, search, onlyWithActiveVoiceChat })
 
     return {
       status: 200,

--- a/src/logic/community/types.ts
+++ b/src/logic/community/types.ts
@@ -235,6 +235,7 @@ export type GetCommunitiesOptions = {
   onlyPublic?: boolean
   sortBy?: 'membersCount' | 'role'
   onlyMemberOf?: boolean
+  onlyWithActiveVoiceChat?: boolean
 }
 
 export type GetCommunityMembersOptions = {

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -36,6 +36,7 @@ import {
   Community,
   CommunityDB,
   CommunityMember,
+  CommunityVoiceChatStatus,
   AggregatedCommunityWithMemberAndFriendsData,
   GetCommunitiesOptions,
   CommunityPublicInformation,
@@ -302,11 +303,8 @@ export type ICommsGatekeeperComponent = {
   requestToSpeakInCommunityVoiceChat: (communityId: string, userAddress: string) => Promise<void>
   promoteSpeakerInCommunityVoiceChat: (communityId: string, userAddress: string) => Promise<void>
   demoteSpeakerInCommunityVoiceChat: (communityId: string, userAddress: string) => Promise<void>
-  getCommunityVoiceChatStatus: (communityId: string) => Promise<{
-    isActive: boolean
-    participantCount: number
-    moderatorCount: number
-  } | null>
+  getCommunityVoiceChatStatus: (communityId: string) => Promise<CommunityVoiceChatStatus | null>
+  getCommunitiesVoiceChatStatus: (communityIds: string[]) => Promise<Record<string, CommunityVoiceChatStatus>>
   kickUserFromCommunityVoiceChat: (communityId: string, userAddress: string) => Promise<void>
 }
 

--- a/test/integration/get-communities-controller.spec.ts
+++ b/test/integration/get-communities-controller.spec.ts
@@ -31,7 +31,7 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
         createMockProfile(friendAddress1),
         createMockProfile(friendAddress2)
       ])
-      
+
       // Mock the communityOwners.getOwnerName to return owner names
       spyComponents.communityOwners.getOwnerName.mockImplementation(async (ownerAddress: string) => {
         if (ownerAddress === address) {
@@ -244,7 +244,7 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
 
           expect(response.status).toBe(200)
           expect(body.data.results).toHaveLength(3)
-          expect(body.data.results.every(community => community.ownerName === 'Test Owner')).toBe(true)
+          expect(body.data.results.every((community) => community.ownerName === 'Test Owner')).toBe(true)
           expect(body.data.total).toBe(3)
         })
       })
@@ -252,21 +252,20 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
       describe('when filtering by active voice chat', () => {
         beforeEach(() => {
           // Mock voice chat status for the communities
-          spyComponents.commsGatekeeper.getCommunityVoiceChatStatus
-            .mockImplementation(async (communityId: string) => {
-              if (communityId === communityId1) {
-                return { isActive: true, participantCount: 5, moderatorCount: 2 }
-              } else if (communityId === communityId2) {
-                return { isActive: false, participantCount: 0, moderatorCount: 0 }
-              }
-              return null
-            })
+          spyComponents.commsGatekeeper.getCommunityVoiceChatStatus.mockImplementation(async (communityId: string) => {
+            if (communityId === communityId1) {
+              return { isActive: true, participantCount: 5, moderatorCount: 2 }
+            } else if (communityId === communityId2) {
+              return { isActive: false, participantCount: 0, moderatorCount: 0 }
+            }
+            return null
+          })
 
-          // Mock batch voice chat status method  
-          spyComponents.commsGatekeeper.getCommunitiesVoiceChatStatus
-            .mockImplementation(async (communityIds: string[]) => {
+          // Mock batch voice chat status method
+          spyComponents.commsGatekeeper.getCommunitiesVoiceChatStatus.mockImplementation(
+            async (communityIds: string[]) => {
               const result: Record<string, any> = {}
-              communityIds.forEach(communityId => {
+              communityIds.forEach((communityId) => {
                 if (communityId === communityId1) {
                   result[communityId] = { isActive: true, participantCount: 5, moderatorCount: 2 }
                 } else if (communityId === communityId2) {
@@ -276,7 +275,8 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
                 }
               })
               return result
-            })
+            }
+          )
         })
 
         it('should return only communities with active voice chat when onlyWithActiveVoiceChat=true', async () => {
@@ -289,12 +289,17 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
           expect(body.data.total).toBe(1)
 
           // Verify that the comms gatekeeper was called to check voice chat status
-          expect(spyComponents.commsGatekeeper.getCommunityVoiceChatStatus).toHaveBeenCalledWith(communityId1)
-          expect(spyComponents.commsGatekeeper.getCommunityVoiceChatStatus).toHaveBeenCalledWith(communityId2)
+          expect(spyComponents.commsGatekeeper.getCommunitiesVoiceChatStatus).toHaveBeenCalledWith([
+            communityId1,
+            communityId2
+          ])
         })
 
         it('should return all communities when onlyWithActiveVoiceChat=false', async () => {
-          const response = await makeRequest(identity, '/v1/communities?limit=10&offset=0&onlyWithActiveVoiceChat=false')
+          const response = await makeRequest(
+            identity,
+            '/v1/communities?limit=10&offset=0&onlyWithActiveVoiceChat=false'
+          )
           const body = await response.json()
 
           expect(response.status).toBe(200)
@@ -314,21 +319,22 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
         describe('when voice chat status check fails', () => {
           beforeEach(() => {
             // Mock one success and one failure
-            spyComponents.commsGatekeeper.getCommunityVoiceChatStatus
-              .mockImplementation(async (communityId: string) => {
+            spyComponents.commsGatekeeper.getCommunityVoiceChatStatus.mockImplementation(
+              async (communityId: string) => {
                 if (communityId === communityId1) {
                   return { isActive: true, participantCount: 5, moderatorCount: 2 }
                 } else if (communityId === communityId2) {
                   throw new Error('Voice chat service unavailable')
                 }
                 return null
-              })
+              }
+            )
 
             // Mock batch method to simulate one success and one failure
-            spyComponents.commsGatekeeper.getCommunitiesVoiceChatStatus
-              .mockImplementation(async (communityIds: string[]) => {
+            spyComponents.commsGatekeeper.getCommunitiesVoiceChatStatus.mockImplementation(
+              async (communityIds: string[]) => {
                 const result: Record<string, any> = {}
-                communityIds.forEach(communityId => {
+                communityIds.forEach((communityId) => {
                   if (communityId === communityId1) {
                     result[communityId] = { isActive: true, participantCount: 5, moderatorCount: 2 }
                   } else if (communityId === communityId2) {
@@ -339,11 +345,15 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
                   }
                 })
                 return result
-              })
+              }
+            )
           })
 
           it('should exclude communities where status check fails', async () => {
-            const response = await makeRequest(identity, '/v1/communities?limit=10&offset=0&onlyWithActiveVoiceChat=true')
+            const response = await makeRequest(
+              identity,
+              '/v1/communities?limit=10&offset=0&onlyWithActiveVoiceChat=true'
+            )
             const body = await response.json()
 
             expect(response.status).toBe(200)
@@ -439,7 +449,7 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
 
           expect(response.status).toBe(200)
           expect(body.data.results).toHaveLength(3)
-          
+
           const originalOwnerCommunities = body.data.results.filter(
             (community: any) => community.ownerAddress === address
           )
@@ -448,7 +458,9 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
           )
 
           expect(originalOwnerCommunities.every((community: any) => community.ownerName === 'Test Owner')).toBe(true)
-          expect(differentOwnerCommunities.every((community: any) => community.ownerName === 'Different Owner')).toBe(true)
+          expect(differentOwnerCommunities.every((community: any) => community.ownerName === 'Different Owner')).toBe(
+            true
+          )
         })
       })
     })

--- a/test/integration/get-communities-controller.spec.ts
+++ b/test/integration/get-communities-controller.spec.ts
@@ -261,6 +261,22 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
               }
               return null
             })
+
+          // Mock batch voice chat status method  
+          spyComponents.commsGatekeeper.getCommunitiesVoiceChatStatus
+            .mockImplementation(async (communityIds: string[]) => {
+              const result: Record<string, any> = {}
+              communityIds.forEach(communityId => {
+                if (communityId === communityId1) {
+                  result[communityId] = { isActive: true, participantCount: 5, moderatorCount: 2 }
+                } else if (communityId === communityId2) {
+                  result[communityId] = { isActive: false, participantCount: 0, moderatorCount: 0 }
+                } else {
+                  result[communityId] = { isActive: false, participantCount: 0, moderatorCount: 0 }
+                }
+              })
+              return result
+            })
         })
 
         it('should return only communities with active voice chat when onlyWithActiveVoiceChat=true', async () => {
@@ -306,6 +322,23 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
                   throw new Error('Voice chat service unavailable')
                 }
                 return null
+              })
+
+            // Mock batch method to simulate one success and one failure
+            spyComponents.commsGatekeeper.getCommunitiesVoiceChatStatus
+              .mockImplementation(async (communityIds: string[]) => {
+                const result: Record<string, any> = {}
+                communityIds.forEach(communityId => {
+                  if (communityId === communityId1) {
+                    result[communityId] = { isActive: true, participantCount: 5, moderatorCount: 2 }
+                  } else if (communityId === communityId2) {
+                    // When community2 fails, it gets marked as inactive in our batch implementation
+                    result[communityId] = { isActive: false, participantCount: 0, moderatorCount: 0 }
+                  } else {
+                    result[communityId] = { isActive: false, participantCount: 0, moderatorCount: 0 }
+                  }
+                })
+                return result
               })
           })
 

--- a/test/mocks/components/comms-gatekeeper.ts
+++ b/test/mocks/components/comms-gatekeeper.ts
@@ -12,6 +12,7 @@ export function createCommsGatekeeperMockedComponent({
   promoteSpeakerInCommunityVoiceChat = jest.fn(),
   demoteSpeakerInCommunityVoiceChat = jest.fn(),
   getCommunityVoiceChatStatus = jest.fn(),
+  getCommunitiesVoiceChatStatus = jest.fn(),
   kickUserFromCommunityVoiceChat = jest.fn()
 }: Partial<jest.Mocked<ICommsGatekeeperComponent>>): jest.Mocked<ICommsGatekeeperComponent> {
   return {
@@ -26,6 +27,7 @@ export function createCommsGatekeeperMockedComponent({
     promoteSpeakerInCommunityVoiceChat,
     demoteSpeakerInCommunityVoiceChat,
     getCommunityVoiceChatStatus,
+    getCommunitiesVoiceChatStatus,
     kickUserFromCommunityVoiceChat
   }
 }

--- a/test/unit/adapters/rpc-server/services/demote-speaker-in-community-voice-chat.spec.ts
+++ b/test/unit/adapters/rpc-server/services/demote-speaker-in-community-voice-chat.spec.ts
@@ -7,25 +7,7 @@ import {
   UserNotCommunityMemberError,
   CommunityVoiceChatNotFoundError
 } from '../../../../../src/logic/community-voice/errors'
-
-function createCommsGatekeeperMockedComponent({
-  demoteSpeakerInCommunityVoiceChat = jest.fn()
-}: Partial<jest.Mocked<ICommsGatekeeperComponent>>): jest.Mocked<ICommsGatekeeperComponent> {
-  return {
-    requestToSpeakInCommunityVoiceChat: jest.fn(),
-    createCommunityVoiceChatRoom: jest.fn(),
-    getCommunityVoiceChatCredentials: jest.fn(),
-    getCommunityVoiceChatStatus: jest.fn(),
-    isUserInAVoiceChat: jest.fn(),
-    getPrivateVoiceChatCredentials: jest.fn(),
-    endPrivateVoiceChat: jest.fn(),
-    updateUserPrivateMessagePrivacyMetadata: jest.fn(),
-    updateUserMetadataInCommunityVoiceChat: jest.fn(),
-    promoteSpeakerInCommunityVoiceChat: jest.fn(),
-    demoteSpeakerInCommunityVoiceChat,
-    kickUserFromCommunityVoiceChat: jest.fn()
-  }
-}
+import { createCommsGatekeeperMockedComponent } from '../../../../mocks/components/comms-gatekeeper'
 
 describe('when demoting speaker in community voice chat', () => {
   let demoteSpeakerMock: jest.MockedFn<ICommsGatekeeperComponent['demoteSpeakerInCommunityVoiceChat']>

--- a/test/unit/adapters/rpc-server/services/kick-player-from-community-voice-chat.spec.ts
+++ b/test/unit/adapters/rpc-server/services/kick-player-from-community-voice-chat.spec.ts
@@ -7,25 +7,7 @@ import {
   UserNotCommunityMemberError,
   CommunityVoiceChatNotFoundError
 } from '../../../../../src/logic/community-voice/errors'
-
-function createCommsGatekeeperMockedComponent({
-  kickUserFromCommunityVoiceChat = jest.fn()
-}: Partial<jest.Mocked<ICommsGatekeeperComponent>>): jest.Mocked<ICommsGatekeeperComponent> {
-  return {
-    requestToSpeakInCommunityVoiceChat: jest.fn(),
-    createCommunityVoiceChatRoom: jest.fn(),
-    getCommunityVoiceChatCredentials: jest.fn(),
-    getCommunityVoiceChatStatus: jest.fn(),
-    isUserInAVoiceChat: jest.fn(),
-    getPrivateVoiceChatCredentials: jest.fn(),
-    endPrivateVoiceChat: jest.fn(),
-    updateUserPrivateMessagePrivacyMetadata: jest.fn(),
-    updateUserMetadataInCommunityVoiceChat: jest.fn(),
-    promoteSpeakerInCommunityVoiceChat: jest.fn(),
-    demoteSpeakerInCommunityVoiceChat: jest.fn(),
-    kickUserFromCommunityVoiceChat
-  }
-}
+import { createCommsGatekeeperMockedComponent } from '../../../../mocks/components/comms-gatekeeper'
 
 describe('when kicking player from community voice chat', () => {
   let kickPlayerMock: jest.MockedFn<ICommsGatekeeperComponent['kickUserFromCommunityVoiceChat']>
@@ -168,4 +150,4 @@ describe('when kicking player from community voice chat', () => {
       expect(result.response?.$case).toBe('internalServerError')
     })
   })
-}) 
+})

--- a/test/unit/adapters/rpc-server/services/promote-speaker-in-community-voice-chat.spec.ts
+++ b/test/unit/adapters/rpc-server/services/promote-speaker-in-community-voice-chat.spec.ts
@@ -7,25 +7,7 @@ import {
   UserNotCommunityMemberError,
   CommunityVoiceChatNotFoundError
 } from '../../../../../src/logic/community-voice/errors'
-
-function createCommsGatekeeperMockedComponent({
-  promoteSpeakerInCommunityVoiceChat = jest.fn()
-}: Partial<jest.Mocked<ICommsGatekeeperComponent>>): jest.Mocked<ICommsGatekeeperComponent> {
-  return {
-    requestToSpeakInCommunityVoiceChat: jest.fn(),
-    createCommunityVoiceChatRoom: jest.fn(),
-    getCommunityVoiceChatCredentials: jest.fn(),
-    getCommunityVoiceChatStatus: jest.fn(),
-    isUserInAVoiceChat: jest.fn(),
-    getPrivateVoiceChatCredentials: jest.fn(),
-    endPrivateVoiceChat: jest.fn(),
-    updateUserPrivateMessagePrivacyMetadata: jest.fn(),
-    updateUserMetadataInCommunityVoiceChat: jest.fn(),
-    promoteSpeakerInCommunityVoiceChat,
-    demoteSpeakerInCommunityVoiceChat: jest.fn(),
-    kickUserFromCommunityVoiceChat: jest.fn()
-  }
-}
+import { createCommsGatekeeperMockedComponent } from '../../../../mocks/components/comms-gatekeeper'
 
 describe('when promoting speaker in community voice chat', () => {
   let promoteSpeakerMock: jest.MockedFn<ICommsGatekeeperComponent['promoteSpeakerInCommunityVoiceChat']>

--- a/test/unit/adapters/rpc-server/services/request-to-speak-in-community-voice-chat.spec.ts
+++ b/test/unit/adapters/rpc-server/services/request-to-speak-in-community-voice-chat.spec.ts
@@ -7,36 +7,7 @@ import {
   UserNotCommunityMemberError,
   CommunityVoiceChatNotFoundError
 } from '../../../../../src/logic/community-voice/errors'
-
-function createCommsGatekeeperMockedComponent({
-  requestToSpeakInCommunityVoiceChat = jest.fn(),
-  createCommunityVoiceChatRoom = jest.fn(),
-  getCommunityVoiceChatCredentials = jest.fn(),
-  getCommunityVoiceChatStatus = jest.fn(),
-  isUserInAVoiceChat = jest.fn(),
-  getPrivateVoiceChatCredentials = jest.fn(),
-  endPrivateVoiceChat = jest.fn(),
-  updateUserPrivateMessagePrivacyMetadata = jest.fn(),
-  updateUserMetadataInCommunityVoiceChat = jest.fn(),
-  promoteSpeakerInCommunityVoiceChat = jest.fn(),
-  demoteSpeakerInCommunityVoiceChat = jest.fn(),
-  kickUserFromCommunityVoiceChat = jest.fn()
-}: Partial<jest.Mocked<ICommsGatekeeperComponent>>): jest.Mocked<ICommsGatekeeperComponent> {
-  return {
-    requestToSpeakInCommunityVoiceChat,
-    createCommunityVoiceChatRoom,
-    getCommunityVoiceChatCredentials,
-    getCommunityVoiceChatStatus,
-    isUserInAVoiceChat,
-    getPrivateVoiceChatCredentials,
-    endPrivateVoiceChat,
-    updateUserPrivateMessagePrivacyMetadata,
-    updateUserMetadataInCommunityVoiceChat,
-    promoteSpeakerInCommunityVoiceChat,
-    demoteSpeakerInCommunityVoiceChat,
-    kickUserFromCommunityVoiceChat
-  }
-}
+import { createCommsGatekeeperMockedComponent } from '../../../../mocks/components/comms-gatekeeper'
 
 describe('when requesting to speak in community voice chat', () => {
   let requestToSpeakMock: jest.MockedFn<ICommsGatekeeperComponent['requestToSpeakInCommunityVoiceChat']>
@@ -155,4 +126,4 @@ describe('when requesting to speak in community voice chat', () => {
       expect(result.response?.$case).toBe('internalServerError')
     })
   })
-}) 
+})

--- a/test/unit/logic/communities.spec.ts
+++ b/test/unit/logic/communities.spec.ts
@@ -248,6 +248,62 @@ describe('Community Component', () => {
         })
       })
     })
+
+    describe('when filtering by active voice chat', () => {
+      const optionsWithVoiceChat = { ...options, onlyWithActiveVoiceChat: true }
+      const mockCommunitiesWithVoiceChat = [
+        {
+          ...mockCommunities[0],
+          id: 'community-with-voice-chat'
+        },
+        {
+          ...mockCommunities[0],
+          id: 'community-without-voice-chat'
+        }
+      ]
+
+      beforeEach(() => {
+        mockCommunitiesDB.getCommunities.mockResolvedValue(mockCommunitiesWithVoiceChat)
+        mockCommunitiesDB.getCommunitiesCount.mockResolvedValue(2)
+        mockStorage.exists.mockResolvedValue(false)
+        mockCatalystClient.getProfiles.mockResolvedValue([])
+        mockCommunityOwners.getOwnerName.mockResolvedValue('Test Owner Name')
+        
+        // Mock voice chat status - first community has active voice chat, second doesn't
+        mockCommsGatekeeper.getCommunityVoiceChatStatus
+          .mockResolvedValueOnce({ isActive: true, participantCount: 3, moderatorCount: 1 })
+          .mockResolvedValueOnce({ isActive: false, participantCount: 0, moderatorCount: 0 })
+      })
+
+      it('should return only communities with active voice chat when onlyWithActiveVoiceChat is true', async () => {
+        const result = await communityComponent.getCommunities(userAddress, optionsWithVoiceChat)
+
+        expect(result.communities).toHaveLength(1)
+        expect(result.communities[0].id).toBe('community-with-voice-chat')
+        expect(result.total).toBe(1)
+
+        expect(mockCommsGatekeeper.getCommunityVoiceChatStatus).toHaveBeenCalledWith('community-with-voice-chat')
+        expect(mockCommsGatekeeper.getCommunityVoiceChatStatus).toHaveBeenCalledWith('community-without-voice-chat')
+      })
+
+      describe('when voice chat status check fails', () => {
+        beforeEach(() => {
+          // Reset the mock to simulate one success and one failure
+          mockCommsGatekeeper.getCommunityVoiceChatStatus.mockReset()
+          mockCommsGatekeeper.getCommunityVoiceChatStatus
+            .mockResolvedValueOnce({ isActive: true, participantCount: 3, moderatorCount: 1 })
+            .mockRejectedValueOnce(new Error('Voice chat service unavailable'))
+        })
+
+        it('should exclude communities where status check fails', async () => {
+          const result = await communityComponent.getCommunities(userAddress, optionsWithVoiceChat)
+
+          expect(result.communities).toHaveLength(1)
+          expect(result.communities[0].id).toBe('community-with-voice-chat')
+          expect(result.total).toBe(1)
+        })
+      })
+    })
   })
 
   describe('when getting public communities', () => {
@@ -316,6 +372,61 @@ describe('Community Component', () => {
 
         expect(result.communities[0].thumbnails).toEqual({
           raw: `${cdnUrl}/social/communities/${communityId}/raw-thumbnail.png`
+        })
+      })
+    })
+
+    describe('when filtering by active voice chat', () => {
+      const optionsWithVoiceChat = { ...options, onlyWithActiveVoiceChat: true }
+      const mockCommunitiesWithVoiceChat = [
+        {
+          ...mockCommunities[0],
+          id: 'public-community-with-voice-chat'
+        },
+        {
+          ...mockCommunities[0],
+          id: 'public-community-without-voice-chat'
+        }
+      ]
+
+      beforeEach(() => {
+        mockCommunitiesDB.getCommunitiesPublicInformation.mockResolvedValue(mockCommunitiesWithVoiceChat)
+        mockCommunitiesDB.getPublicCommunitiesCount.mockResolvedValue(2)
+        mockStorage.exists.mockResolvedValue(false)
+        mockCommunityOwners.getOwnerName.mockResolvedValue('Test Owner Name')
+        
+        // Mock voice chat status - first community has active voice chat, second doesn't
+        mockCommsGatekeeper.getCommunityVoiceChatStatus
+          .mockResolvedValueOnce({ isActive: true, participantCount: 5, moderatorCount: 2 })
+          .mockResolvedValueOnce({ isActive: false, participantCount: 0, moderatorCount: 0 })
+      })
+
+      it('should return only public communities with active voice chat when onlyWithActiveVoiceChat is true', async () => {
+        const result = await communityComponent.getCommunitiesPublicInformation(optionsWithVoiceChat)
+
+        expect(result.communities).toHaveLength(1)
+        expect(result.communities[0].id).toBe('public-community-with-voice-chat')
+        expect(result.total).toBe(1)
+
+        expect(mockCommsGatekeeper.getCommunityVoiceChatStatus).toHaveBeenCalledWith('public-community-with-voice-chat')
+        expect(mockCommsGatekeeper.getCommunityVoiceChatStatus).toHaveBeenCalledWith('public-community-without-voice-chat')
+      })
+
+      describe('when voice chat status check fails', () => {
+        beforeEach(() => {
+          // Reset the mock to simulate one success and one failure
+          mockCommsGatekeeper.getCommunityVoiceChatStatus.mockReset()
+          mockCommsGatekeeper.getCommunityVoiceChatStatus
+            .mockResolvedValueOnce({ isActive: true, participantCount: 5, moderatorCount: 2 })
+            .mockRejectedValueOnce(new Error('Voice chat service unavailable'))
+        })
+
+        it('should exclude public communities where status check fails', async () => {
+          const result = await communityComponent.getCommunitiesPublicInformation(optionsWithVoiceChat)
+
+          expect(result.communities).toHaveLength(1)
+          expect(result.communities[0].id).toBe('public-community-with-voice-chat')
+          expect(result.total).toBe(1)
         })
       })
     })

--- a/test/unit/logic/communities.spec.ts
+++ b/test/unit/logic/communities.spec.ts
@@ -12,7 +12,12 @@ import {
   ICommunityOwnersComponent,
   ICommunityEventsComponent
 } from '../../../src/logic/community/types'
-import { createMockCommunityRolesComponent, createMockCommunityPlacesComponent, createMockCommunityOwnersComponent, createMockCommunityEventsComponent } from '../../mocks/communities'
+import {
+  createMockCommunityRolesComponent,
+  createMockCommunityPlacesComponent,
+  createMockCommunityOwnersComponent,
+  createMockCommunityEventsComponent
+} from '../../mocks/communities'
 import { createMockProfile } from '../../mocks/profile'
 import { Community } from '../../../src/logic/community/types'
 import { createCommsGatekeeperMockedComponent } from '../../mocks/components/comms-gatekeeper'
@@ -135,7 +140,7 @@ describe('Community Component', () => {
           expect(result.voiceChatStatus).toBeNull()
         })
       })
-      
+
       describe('when the community is hosting live events', () => {
         beforeEach(() => {
           mockCommunityEvents.isCurrentlyHostingEvents.mockResolvedValue(true)
@@ -268,7 +273,7 @@ describe('Community Component', () => {
         mockStorage.exists.mockResolvedValue(false)
         mockCatalystClient.getProfiles.mockResolvedValue([])
         mockCommunityOwners.getOwnerName.mockResolvedValue('Test Owner Name')
-        
+
         // Mock voice chat status - first community has active voice chat, second doesn't
         mockCommsGatekeeper.getCommunityVoiceChatStatus
           .mockResolvedValueOnce({ isActive: true, participantCount: 3, moderatorCount: 1 })
@@ -277,7 +282,7 @@ describe('Community Component', () => {
         // Mock batch voice chat status method
         mockCommsGatekeeper.getCommunitiesVoiceChatStatus.mockImplementation(async (communityIds: string[]) => {
           const result: Record<string, any> = {}
-          communityIds.forEach(communityId => {
+          communityIds.forEach((communityId) => {
             if (communityId === 'community-with-voice-chat') {
               result[communityId] = { isActive: true, participantCount: 3, moderatorCount: 1 }
             } else {
@@ -295,16 +300,21 @@ describe('Community Component', () => {
         expect(result.communities[0].id).toBe('community-with-voice-chat')
         expect(result.total).toBe(1)
 
-        expect(mockCommsGatekeeper.getCommunityVoiceChatStatus).toHaveBeenCalledWith('community-with-voice-chat')
-        expect(mockCommsGatekeeper.getCommunityVoiceChatStatus).toHaveBeenCalledWith('community-without-voice-chat')
+        expect(mockCommsGatekeeper.getCommunitiesVoiceChatStatus).toHaveBeenCalledWith([
+          'community-with-voice-chat',
+          'community-without-voice-chat'
+        ])
       })
 
       describe('when voice chat status check fails', () => {
         beforeEach(() => {
           // Reset the mock to simulate one success and one failure
-          mockCommsGatekeeper.getCommunityVoiceChatStatus.mockReset()
-          mockCommsGatekeeper.getCommunityVoiceChatStatus
-            .mockResolvedValueOnce({ isActive: true, participantCount: 3, moderatorCount: 1 })
+          mockCommsGatekeeper.getCommunitiesVoiceChatStatus.mockReset()
+          mockCommsGatekeeper.getCommunitiesVoiceChatStatus
+            .mockResolvedValueOnce({
+              'community-with-voice-chat': { isActive: true, participantCount: 3, moderatorCount: 1 },
+              'community-without-voice-chat': { isActive: false, participantCount: 0, moderatorCount: 0 }
+            })
             .mockRejectedValueOnce(new Error('Voice chat service unavailable'))
         })
 
@@ -407,11 +417,12 @@ describe('Community Component', () => {
         mockCommunitiesDB.getPublicCommunitiesCount.mockResolvedValue(2)
         mockStorage.exists.mockResolvedValue(false)
         mockCommunityOwners.getOwnerName.mockResolvedValue('Test Owner Name')
-        
+
         // Mock voice chat status - first community has active voice chat, second doesn't
-        mockCommsGatekeeper.getCommunityVoiceChatStatus
-          .mockResolvedValueOnce({ isActive: true, participantCount: 5, moderatorCount: 2 })
-          .mockResolvedValueOnce({ isActive: false, participantCount: 0, moderatorCount: 0 })
+        mockCommsGatekeeper.getCommunitiesVoiceChatStatus.mockResolvedValueOnce({
+          'public-community-with-voice-chat': { isActive: true, participantCount: 5, moderatorCount: 2 },
+          'public-community-without-voice-chat': { isActive: false, participantCount: 0, moderatorCount: 0 }
+        })
       })
 
       it('should return only public communities with active voice chat when onlyWithActiveVoiceChat is true', async () => {
@@ -421,8 +432,10 @@ describe('Community Component', () => {
         expect(result.communities[0].id).toBe('public-community-with-voice-chat')
         expect(result.total).toBe(1)
 
-        expect(mockCommsGatekeeper.getCommunityVoiceChatStatus).toHaveBeenCalledWith('public-community-with-voice-chat')
-        expect(mockCommsGatekeeper.getCommunityVoiceChatStatus).toHaveBeenCalledWith('public-community-without-voice-chat')
+        expect(mockCommsGatekeeper.getCommunitiesVoiceChatStatus).toHaveBeenCalledWith([
+          'public-community-with-voice-chat',
+          'public-community-without-voice-chat'
+        ])
       })
 
       describe('when voice chat status check fails', () => {

--- a/test/unit/logic/communities.spec.ts
+++ b/test/unit/logic/communities.spec.ts
@@ -273,6 +273,19 @@ describe('Community Component', () => {
         mockCommsGatekeeper.getCommunityVoiceChatStatus
           .mockResolvedValueOnce({ isActive: true, participantCount: 3, moderatorCount: 1 })
           .mockResolvedValueOnce({ isActive: false, participantCount: 0, moderatorCount: 0 })
+
+        // Mock batch voice chat status method
+        mockCommsGatekeeper.getCommunitiesVoiceChatStatus.mockImplementation(async (communityIds: string[]) => {
+          const result: Record<string, any> = {}
+          communityIds.forEach(communityId => {
+            if (communityId === 'community-with-voice-chat') {
+              result[communityId] = { isActive: true, participantCount: 3, moderatorCount: 1 }
+            } else {
+              result[communityId] = { isActive: false, participantCount: 0, moderatorCount: 0 }
+            }
+          })
+          return result
+        })
       })
 
       it('should return only communities with active voice chat when onlyWithActiveVoiceChat is true', async () => {

--- a/test/unit/logic/community-voice.spec.ts
+++ b/test/unit/logic/community-voice.spec.ts
@@ -21,6 +21,7 @@ import { CommunityRole } from '../../../src/types'
 import { AnalyticsEvent, AnalyticsEventPayload } from '../../../src/types/analytics'
 import { ICommunityVoiceComponent } from '../../../src/logic/community-voice'
 import { ICommunityVoiceChatCacheComponent } from '../../../src/logic/community-voice/community-voice-cache'
+import { createCommsGatekeeperMockedComponent } from '../../mocks/components/comms-gatekeeper'
 
 describe('Community Voice Logic', () => {
   let mockLogs: jest.Mocked<ILoggerComponent>
@@ -46,20 +47,7 @@ describe('Community Voice Logic', () => {
       getLogger: jest.fn().mockReturnValue(logger)
     } as jest.Mocked<ILoggerComponent>
 
-    mockCommsGatekeeper = {
-      getCommunityVoiceChatStatus: jest.fn(),
-      createCommunityVoiceChatRoom: jest.fn(),
-      getCommunityVoiceChatCredentials: jest.fn(),
-      isUserInAVoiceChat: jest.fn(),
-      updateUserPrivateMessagePrivacyMetadata: jest.fn(),
-      getPrivateVoiceChatCredentials: jest.fn(),
-      endPrivateVoiceChat: jest.fn(),
-      updateUserMetadataInCommunityVoiceChat: jest.fn(),
-      requestToSpeakInCommunityVoiceChat: jest.fn(),
-      promoteSpeakerInCommunityVoiceChat: jest.fn(),
-      demoteSpeakerInCommunityVoiceChat: jest.fn(),
-      kickUserFromCommunityVoiceChat: jest.fn()
-    } as jest.Mocked<ICommsGatekeeperComponent>
+    mockCommsGatekeeper = createCommsGatekeeperMockedComponent({})
 
     mockCommunitiesDb = {
       getCommunityMemberRole: jest.fn(),


### PR DESCRIPTION
This PR adds support for the `onlyWithActiveVoiceChat` and returns communities with voice chats active