### PR TITLE
fix: Skip updates if required profile is not found

### DIFF
--- a/src/controllers/handlers/rpc/subscribe-to-friend-connectivity-updates.ts
+++ b/src/controllers/handlers/rpc/subscribe-to-friend-connectivity-updates.ts
@@ -32,6 +32,7 @@ export function subscribeToFriendConnectivityUpdatesService({
       >({
         rpcContext: context,
         eventName: 'friendConnectivityUpdate',
+        shouldRetrieveProfile: true,
         getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendConnectivityUpdate']) => update.address,
         shouldHandleUpdate: (update: SubscriptionEventsEmitter['friendConnectivityUpdate']) =>
           update.address !== context.address,

--- a/src/controllers/handlers/rpc/subscribe-to-friendship-updates.ts
+++ b/src/controllers/handlers/rpc/subscribe-to-friendship-updates.ts
@@ -20,7 +20,7 @@ export function subscribeToFriendshipUpdatesService({
         eventName: 'friendshipUpdate',
         getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
         parser: parseEmittedUpdateToFriendshipUpdate,
-        shouldRetrieveProfile: false,
+        shouldRetrieveProfile: true,
         shouldHandleUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) =>
           update.from !== context.address && update.to === context.address
       })

--- a/src/logic/updates.ts
+++ b/src/logic/updates.ts
@@ -225,7 +225,7 @@ export function createUpdateHandlerComponent(
   async function* handleSubscriptionUpdates<T, U>({
     rpcContext,
     eventName,
-    shouldRetrieveProfile = true,
+    shouldRetrieveProfile = false,
     getAddressFromUpdate,
     shouldHandleUpdate,
     parser,

--- a/test/unit/logic/updates.spec.ts
+++ b/test/unit/logic/updates.spec.ts
@@ -963,6 +963,7 @@ describe('Updates Handlers', () => {
         const generator = updateHandler.handleSubscriptionUpdates({
           rpcContext,
           eventName: 'friendshipUpdate',
+          shouldRetrieveProfile: true,
           getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
           shouldHandleUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from === '0x123',
           parser
@@ -983,6 +984,7 @@ describe('Updates Handlers', () => {
         const generator = updateHandler.handleSubscriptionUpdates({
           rpcContext,
           eventName: 'friendshipUpdate',
+          shouldRetrieveProfile: true,
           getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
           shouldHandleUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from === '0x123',
           parser
@@ -1000,6 +1002,7 @@ describe('Updates Handlers', () => {
         const generator = updateHandler.handleSubscriptionUpdates({
           rpcContext,
           eventName: 'friendshipUpdate',
+          shouldRetrieveProfile: true,
           getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
           shouldHandleUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from === '0x123',
           parser
@@ -1022,6 +1025,7 @@ describe('Updates Handlers', () => {
         const generator = updateHandler.handleSubscriptionUpdates({
           rpcContext,
           eventName: 'friendshipUpdate',
+          shouldRetrieveProfile: true,
           getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
           shouldHandleUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from === '0x123',
           parser
@@ -1045,6 +1049,7 @@ describe('Updates Handlers', () => {
         const generator = updateHandler.handleSubscriptionUpdates({
           rpcContext,
           eventName: 'friendshipUpdate',
+          shouldRetrieveProfile: true,
           getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
           shouldHandleUpdate: () => false,
           parser
@@ -1067,6 +1072,7 @@ describe('Updates Handlers', () => {
         const generator = updateHandler.handleSubscriptionUpdates({
           rpcContext,
           eventName: 'friendshipUpdate',
+          shouldRetrieveProfile: true,
           getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
           shouldHandleUpdate: () => true,
           parser


### PR DESCRIPTION
This PR skips updates if the `shouldRetrieveProfile` is set to true and the profile is not found. It also sets the property as false by default to prevent any issues.