### PR TITLE
fix: Skip parsed friendship requests if they can't be parsed

### DIFF
--- a/src/logic/friends/friendships.ts
+++ b/src/logic/friends/friendships.ts
@@ -257,7 +257,15 @@ export function parseFriendshipRequestsToFriendshipRequestResponses(
         return null
       }
 
-      return parseFriendshipRequestToFriendshipRequestResponse(request, profile)
+      let parsedRequest: FriendshipRequestResponse
+      try {
+        parsedRequest = parseFriendshipRequestToFriendshipRequestResponse(request, profile)
+      } catch (_) {
+        // Ignore profiles that can't be parsed
+        return null
+      }
+
+      return parsedRequest
     })
     .filter((request) => !!request)
 }


### PR DESCRIPTION
This PR changes the way the `getSentFriendshipRequests` and `getPendingFriendshipRequests` services work by ignoring the requests of profiles that can't be parsed.

This fix came from a log of a profile that probably had an old structure:
```
2025-07-17T18:12:30.911Z [ERROR] (get-sent-friendship-requests-service): Error getting sent friendship requests: Missing profile avatar name	"Error getting sent friendship requests: Missing profile avatar name"
```