### PR TITLE
fix: Don't emit transport errors on disconnected sockets

### DIFF
--- a/src/adapters/rpc-server/rpc-server.ts
+++ b/src/adapters/rpc-server/rpc-server.ts
@@ -95,11 +95,14 @@ export async function createRpcServerComponent({
       })
     },
     detachUser(address) {
-      // End all calls that the user is involved in
-      voice.endIncomingOrOutgoingPrivateVoiceChatForUser(address).catch((_) => {
-        // Do nothing
-      })
-      subscribersContext.removeSubscriber(address)
+      // Check if the user is subscribed before detaching
+      if (subscribersContext.getSubscribersAddresses().find((a) => a === address)) {
+        // End all calls that the user is involved in
+        subscribersContext.removeSubscriber(address)
+        voice.endIncomingOrOutgoingPrivateVoiceChatForUser(address).catch((_) => {
+          // Do nothing
+        })
+      }
     }
   }
 }

--- a/src/utils/UWebSocketTransport.ts
+++ b/src/utils/UWebSocketTransport.ts
@@ -362,7 +362,7 @@ export async function createUWebSocketTransport<T extends { isConnected: boolean
     sendMessage(message: any) {
       if (!(message instanceof Uint8Array)) {
         events.emit('error', new Error(`WebSocketTransport: Received unknown type of message, expecting Uint8Array`))
-        return Promise.resolve()
+        return
       }
       return send(message)
     },

--- a/test/unit/controllers/handlers/ws-handler.spec.ts
+++ b/test/unit/controllers/handlers/ws-handler.spec.ts
@@ -228,7 +228,7 @@ describe('ws-handler', () => {
         const updatedData = mockWs.getUserData()
         expect(updatedData.authenticating).toBe(false)
         expect(updatedData.auth).toBe(false)
-        expect(mockWs.close).toHaveBeenCalled()
+        expect(mockWs.end).toHaveBeenCalledWith(3003, 'Unauthorized')
       })
 
       it('should clear timeout when user authenticates', async () => {


### PR DESCRIPTION
This PR does the following:
- Changes the way the `send` method in the transport works so it doesn't emit a transport error when the transport is not active anymore and there are still queued messages.
- Changes the way we're getting detached from the `rpcServer` so we don't execute it if it has already detached the user. This is done because the detach process is done more than once in the close flow.
- Changes the way we're disconnecting unauthorized users or users whose authentication process time outed to use `end` and return custom errors and reasons so we can log them. A close would result in a 1006 error message and we should avoid that if possible.
- Changes the `cleanupConnection` process to not emit the close event. This call was redundant because the `data.transport.close()` removes the event listener for the close event. Closing the transport does the same as closing the transport.
- Changes the close transport function to not receive any information about the closing codes. The transport close function type was not receiving that information and it seemed better to log the disconnection code and reason once, in the close event.