### PR TITLE
feat: accept privacy property while creating or editing a community

### DIFF
--- a/src/adapters/communities-db.ts
+++ b/src/adapters/communities-db.ts
@@ -9,7 +9,8 @@ import {
   CommunityMember,
   MemberCommunity,
   BannedMember,
-  CommunityPlace
+  CommunityPlace,
+  CommunityPrivacyEnum
 } from '../logic/community'
 
 import { normalizeAddress } from '../utils/address'
@@ -449,7 +450,7 @@ export function createCommunitiesDBComponent(
         name: row.name,
         description: row.description,
         ownerAddress: row.owner_address,
-        privacy: row.private ? 'private' : 'public',
+        privacy: row.private ? CommunityPrivacyEnum.Private : CommunityPrivacyEnum.Public,
         active: row.active
       }
     },
@@ -613,7 +614,7 @@ export function createCommunitiesDBComponent(
         name: row.name,
         description: row.description,
         ownerAddress: row.owner_address,
-        privacy: row.private ? 'private' : 'public',
+        privacy: row.private ? CommunityPrivacyEnum.Private : CommunityPrivacyEnum.Public,
         active: row.active
       }
     }

--- a/src/controllers/handlers/http/create-community-handler.ts
+++ b/src/controllers/handlers/http/create-community-handler.ts
@@ -21,7 +21,7 @@ export async function createCommunityHandler(
     const thumbnailFile = formData?.files?.['thumbnail']
     const thumbnailBuffer = thumbnailFile?.value
 
-    const { name, description, placeIds } = await validateCommunityFields(formData, thumbnailBuffer, {
+    const { name, description, placeIds, privacy } = await validateCommunityFields(formData, thumbnailBuffer, {
       requireName: true,
       requireDescription: true
     })
@@ -36,7 +36,8 @@ export async function createCommunityHandler(
       {
         name: name!,
         description: description!,
-        ownerAddress: address
+        ownerAddress: address,
+        privacy
       },
       thumbnailBuffer,
       placeIds ?? []

--- a/src/controllers/handlers/http/get-community-handler.ts
+++ b/src/controllers/handlers/http/get-community-handler.ts
@@ -42,7 +42,6 @@ export async function getCommunityHandler(
       }
     }
   } catch (error: any) {
-    console.log('error', error?.message)
     const message = errorMessageOrDefault(error)
     logger.error(`Error getting community: ${id}, error: ${message}`)
 

--- a/src/controllers/handlers/http/update-community-handler.ts
+++ b/src/controllers/handlers/http/update-community-handler.ts
@@ -2,7 +2,7 @@ import { DecentralandSignatureContext } from '@dcl/platform-crypto-middleware'
 import { FormHandlerContextWithPath, HTTPResponse } from '../../../types/http'
 import { InvalidRequestError, NotAuthorizedError } from '@dcl/platform-server-commons'
 import { errorMessageOrDefault } from '../../../utils/errors'
-import { CommunityNotFoundError } from '../../../logic/community'
+import { CommunityNotFoundError, CommunityPrivacyEnum } from '../../../logic/community'
 import { validateCommunityFields } from '../../../utils/community-validation'
 
 export async function updateCommunityHandler(
@@ -22,6 +22,7 @@ export async function updateCommunityHandler(
   try {
     const thumbnailFile = formData?.files?.['thumbnail']
     const thumbnailBuffer = thumbnailFile?.value
+    const privacy: CommunityPrivacyEnum | undefined = formData?.fields?.['privacy']?.value
 
     const {
       name,
@@ -41,7 +42,8 @@ export async function updateCommunityHandler(
       name,
       description,
       placeIds,
-      thumbnailBuffer: validatedThumbnail
+      thumbnailBuffer: validatedThumbnail,
+      privacy
     })
 
     return {

--- a/src/controllers/handlers/http/update-community-handler.ts
+++ b/src/controllers/handlers/http/update-community-handler.ts
@@ -2,7 +2,7 @@ import { DecentralandSignatureContext } from '@dcl/platform-crypto-middleware'
 import { FormHandlerContextWithPath, HTTPResponse } from '../../../types/http'
 import { InvalidRequestError, NotAuthorizedError } from '@dcl/platform-server-commons'
 import { errorMessageOrDefault } from '../../../utils/errors'
-import { CommunityNotFoundError, CommunityPrivacyEnum } from '../../../logic/community'
+import { CommunityNotFoundError } from '../../../logic/community'
 import { validateCommunityFields } from '../../../utils/community-validation'
 
 export async function updateCommunityHandler(

--- a/src/controllers/handlers/http/update-community-handler.ts
+++ b/src/controllers/handlers/http/update-community-handler.ts
@@ -22,18 +22,19 @@ export async function updateCommunityHandler(
   try {
     const thumbnailFile = formData?.files?.['thumbnail']
     const thumbnailBuffer = thumbnailFile?.value
-    const privacy: CommunityPrivacyEnum | undefined = formData?.fields?.['privacy']?.value
 
     const {
       name,
       description,
       placeIds,
+      privacy,
       thumbnailBuffer: validatedThumbnail
     } = await validateCommunityFields(formData, thumbnailBuffer)
 
     logger.info('Updating community', {
       communityId,
       userAddress,
+      privacy,
       updates: JSON.stringify({ name, description, placeIds: placeIds ? placeIds.length : 0 }),
       hasThumbnail: validatedThumbnail ? 'true' : 'false'
     })

--- a/src/logic/community-voice/community-voice.ts
+++ b/src/logic/community-voice/community-voice.ts
@@ -3,7 +3,7 @@ import { AppComponents, CommunityVoiceChat, CommunityRole, CommunityVoiceChatSta
 import { AnalyticsEvent } from '../../types/analytics'
 import { isErrorWithMessage, errorMessageOrDefault } from '../../utils/errors'
 import { separatePositionsAndWorlds } from '../../utils/places'
-import { ActiveCommunityVoiceChat } from '../community/types'
+import { ActiveCommunityVoiceChat, CommunityPrivacyEnum } from '../community/types'
 import { CommunityVoiceChatStatus as ProtocolCommunityVoiceChatStatus } from '@dcl/protocol/out-js/decentraland/social_service/v2/social_service_v2.gen'
 import { NotAuthorizedError } from '@dcl/platform-server-commons'
 import {
@@ -387,7 +387,7 @@ export async function createCommunityVoiceComponent({
           const { participantCount, moderatorCount } = voiceChatStatus
 
           // Early privacy check: for non-members, only include public communities
-          if (!isMember && privacy !== 'public') {
+          if (!isMember && privacy !== CommunityPrivacyEnum.Public) {
             return null
           }
 

--- a/src/logic/community/communities.ts
+++ b/src/logic/community/communities.ts
@@ -11,7 +11,8 @@ import {
   MemberCommunity,
   Community,
   CommunityUpdates,
-  AggregatedCommunity
+  AggregatedCommunity,
+  CommunityPrivacyEnum
 } from './types'
 import { isOwner, toCommunityWithMembersCount, toCommunityResults, toPublicCommunity } from './utils'
 import { isErrorWithMessage } from '../../utils/errors'
@@ -199,7 +200,7 @@ export function createCommunityComponent(
     },
 
     createCommunity: async (
-      community: Omit<Community, 'id' | 'active' | 'privacy' | 'thumbnails'>,
+      community: Omit<Community, 'id' | 'active' | 'thumbnails'>,
       thumbnail?: Buffer,
       placeIds: string[] = []
     ): Promise<AggregatedCommunity> => {
@@ -220,7 +221,7 @@ export function createCommunityComponent(
       const newCommunity = await communitiesDb.createCommunity({
         ...community,
         owner_address: community.ownerAddress,
-        private: false, // TODO: support private communities
+        private: community.privacy === CommunityPrivacyEnum.Private,
         active: true
       })
 
@@ -325,7 +326,10 @@ export function createCommunityComponent(
         placeIds: placeIds ? placeIds.length : 0
       })
 
-      const updatedCommunity = await communitiesDb.updateCommunity(communityId, updates)
+      const updatedCommunity = await communitiesDb.updateCommunity(communityId, {
+        ...updates,
+        private: updates.privacy ? updates.privacy === CommunityPrivacyEnum.Private : undefined
+      })
 
       if (!!updates.name) {
         setImmediate(async () => {

--- a/src/logic/community/communities.ts
+++ b/src/logic/community/communities.ts
@@ -309,6 +309,10 @@ export function createCommunityComponent(
 
       await communityRoles.validatePermissionToEditCommunity(communityId, userAddress)
 
+      if (updates.privacy && updates.privacy !== community.privacy) {
+        await communityRoles.validatePermissionToUpdateCommunityPrivacy(communityId, userAddress)
+      }
+
       const { placeIds, thumbnailBuffer, ...restUpdates } = updates
 
       if (placeIds && placeIds.length > 0) {

--- a/src/logic/community/roles.ts
+++ b/src/logic/community/roles.ts
@@ -164,6 +164,7 @@ export function createCommunityRolesComponent(
       'remove places from the community'
     ),
     validatePermissionToEditCommunity: validatePermission('edit_info', 'edit the community'),
+    validatePermissionToUpdateCommunityPrivacy: validatePermission('edit_settings', 'update the community privacy'),
     validatePermissionToDeleteCommunity: validatePermission('delete_community', 'delete the community'),
     validatePermissionToUpdatePlaces: validatePermissions(
       ['add_places', 'remove_places'],

--- a/src/logic/community/types.ts
+++ b/src/logic/community/types.ts
@@ -81,6 +81,7 @@ export interface ICommunityRolesComponent {
   validatePermissionToRemovePlacesFromCommunity: (communityId: string, removerAddress: string) => Promise<void>
   validatePermissionToUpdatePlaces: (communityId: string, editorAddress: string) => Promise<void>
   validatePermissionToEditCommunity: (communityId: string, editorAddress: string) => Promise<void>
+  validatePermissionToUpdateCommunityPrivacy: (communityId: string, updaterAddress: string) => Promise<void>
   validatePermissionToDeleteCommunity: (communityId: string, removerAddress: string) => Promise<void>
   validatePermissionToLeaveCommunity: (communityId: string, memberAddress: string) => Promise<void>
 }

--- a/src/logic/community/types.ts
+++ b/src/logic/community/types.ts
@@ -20,7 +20,7 @@ export interface ICommunitiesComponent {
     options: Pick<GetCommunitiesOptions, 'pagination' | 'roles'>
   ): Promise<GetCommunitiesWithTotal<MemberCommunity>>
   createCommunity(
-    community: Omit<Community, 'id' | 'active' | 'privacy' | 'thumbnails'>,
+    community: Omit<Community, 'id' | 'active' | 'thumbnails'>,
     thumbnail?: Buffer,
     placeIds?: string[]
   ): Promise<AggregatedCommunity>
@@ -169,6 +169,12 @@ export type CommunityUpdates = {
   description?: string
   placeIds?: string[]
   thumbnailBuffer?: Buffer
+  privacy?: CommunityPrivacyEnum
+}
+
+export enum CommunityPrivacyEnum {
+  Public = 'public',
+  Private = 'private'
 }
 
 export type Community = {
@@ -177,7 +183,7 @@ export type Community = {
   name: string
   description: string
   ownerAddress: string
-  privacy: 'public' | 'private'
+  privacy: CommunityPrivacyEnum
   active: boolean
 }
 

--- a/src/logic/community/types.ts
+++ b/src/logic/community/types.ts
@@ -275,7 +275,7 @@ export type CommunityWithUserInformation = AggregatedCommunityWithMemberData & {
 }
 
 export type CommunityPublicInformation = Omit<CommunityWithUserInformation, 'role' | 'friends' | 'privacy'> & {
-  privacy: 'public'
+  privacy: CommunityPrivacyEnum.Public
 }
 
 export type GetCommunitiesWithTotal<T> = {

--- a/src/utils/community-validation.ts
+++ b/src/utils/community-validation.ts
@@ -52,7 +52,13 @@ export async function validateCommunityFields(
   }
 
   // Always require at least one field for updates
-  if (name === undefined && description === undefined && !thumbnailBuffer && placeIds === undefined) {
+  if (
+    name === undefined &&
+    description === undefined &&
+    !thumbnailBuffer &&
+    placeIds === undefined &&
+    privacy === undefined
+  ) {
     throw new InvalidRequestError('At least one field must be provided for update')
   }
 

--- a/src/utils/community-validation.ts
+++ b/src/utils/community-validation.ts
@@ -1,11 +1,13 @@
 import { InvalidRequestError } from '@dcl/platform-server-commons'
 import fileType from 'file-type'
+import { CommunityPrivacyEnum } from '../logic/community'
 
 export interface CommunityValidationFields {
   name?: string
   description?: string
   placeIds?: string[]
   thumbnailBuffer?: Buffer
+  privacy: CommunityPrivacyEnum
 }
 
 export interface CommunityValidationOptions {
@@ -23,6 +25,7 @@ export async function validateCommunityFields(
   const name: string | undefined = formData.fields.name?.value
   const description: string | undefined = formData.fields.description?.value
   const placeIdsField: string | undefined = formData.fields.placeIds?.value
+  const privacy: string | undefined = formData.fields.privacy?.value
 
   let placeIds: string[] | undefined = undefined
   if (placeIdsField) {
@@ -70,6 +73,7 @@ export async function validateCommunityFields(
     name,
     description,
     placeIds,
+    privacy: privacy === 'private' ? CommunityPrivacyEnum.Private : CommunityPrivacyEnum.Public,
     thumbnailBuffer
   }
 }

--- a/test/integration/create-community-controller.spec.ts
+++ b/test/integration/create-community-controller.spec.ts
@@ -1,3 +1,4 @@
+import { CommunityPrivacyEnum } from '../../src/logic/community'
 import { test } from '../components'
 import { createMockProfile } from '../mocks/profile'
 import { createTestIdentity, Identity, makeAuthenticatedRequest } from './utils/auth'
@@ -136,7 +137,7 @@ test('Create Community Controller', async function ({ components, stubComponents
                     description: 'Test Description',
                     active: true,
                     ownerAddress: identity.realAccount.address.toLowerCase(),
-                    privacy: 'public'
+                    privacy: CommunityPrivacyEnum.Public
                   },
                   message: 'Community created successfully'
                 })
@@ -194,7 +195,7 @@ test('Create Community Controller', async function ({ components, stubComponents
                   description: 'Test Description',
                   active: true,
                   ownerAddress: identity.realAccount.address.toLowerCase(),
-                  privacy: 'public'
+                  privacy: CommunityPrivacyEnum.Public
                 },
                 message: 'Community created successfully'
               })
@@ -249,7 +250,7 @@ test('Create Community Controller', async function ({ components, stubComponents
                   description: 'Test Description',
                   active: true,
                   ownerAddress: identity.realAccount.address.toLowerCase(),
-                  privacy: 'public'
+                  privacy: CommunityPrivacyEnum.Public
                 },
                 message: 'Community created successfully'
               })

--- a/test/integration/create-community-controller.spec.ts
+++ b/test/integration/create-community-controller.spec.ts
@@ -269,6 +269,32 @@ test('Create Community Controller', async function ({ components, stubComponents
               expect(await response.json()).toMatchObject({ message: 'Failed to fetch names' })
             })
           })
+
+          describe('and the community privacy is private', () => {
+            let validBodyWithPrivatePrivacy = {
+              ...validBody,
+              privacy: CommunityPrivacyEnum.Private
+            }
+
+            it('should create community with private privacy', async () => {
+              const response = await makeMultipartRequest(identity, '/v1/communities', validBodyWithPrivatePrivacy)
+              const body = await response.json()
+              communityId = body.data.id
+
+              expect(response.status).toBe(201)
+              expect(body).toMatchObject({
+                data: {
+                  id: expect.any(String),
+                  name: 'Test Community',
+                  description: 'Test Description',
+                  active: true,
+                  ownerAddress: identity.realAccount.address.toLowerCase(),
+                  privacy: CommunityPrivacyEnum.Private
+                },
+                message: 'Community created successfully'
+              })
+            })
+          })
         })
 
         describe('when the user does not own a name', () => {

--- a/test/integration/create-community-controller.spec.ts
+++ b/test/integration/create-community-controller.spec.ts
@@ -76,10 +76,21 @@ test('Create Community Controller', async function ({ components, stubComponents
 
       describe('and the body structure is valid', () => {
         let communityId: string
-        let validBody: { name: string; description: string; thumbnailPath?: string; placeIds?: string[] } = {
-          name: 'Test Community',
-          description: 'Test Description'
+        let validBody: {
+          name: string
+          description: string
+          privacy: CommunityPrivacyEnum
+          thumbnailPath?: string
+          placeIds?: string[]
         }
+
+        beforeEach(() => {
+          validBody = {
+            name: 'Test Community',
+            description: 'Test Description',
+            privacy: CommunityPrivacyEnum.Public
+          }
+        })
 
         afterEach(async () => {
           await components.communitiesDb.deleteCommunity(communityId)
@@ -101,11 +112,16 @@ test('Create Community Controller', async function ({ components, stubComponents
           })
 
           describe('and places are provided', () => {
-            const mockPlaceIds = [randomUUID(), randomUUID()]
-            const validBodyWithPlaces = {
-              ...validBody,
-              placeIds: mockPlaceIds
-            }
+            let mockPlaceIds: string[]
+            let validBodyWithPlaces
+
+            beforeEach(() => {
+              mockPlaceIds = [randomUUID(), randomUUID()]
+              validBodyWithPlaces = {
+                ...validBody,
+                placeIds: mockPlaceIds
+              }
+            })
 
             describe('and the places are owned by the user', () => {
               beforeEach(async () => {
@@ -171,14 +187,16 @@ test('Create Community Controller', async function ({ components, stubComponents
           })
 
           describe('and a valid thumbnail is provided', () => {
-            const validBodyWithThumbnail = {
-              ...validBody,
-              thumbnailPath: require('path').join(__dirname, 'fixtures/example.png')
-            }
+            let validBodyWithThumbnail
 
             let expectedCdn: string
 
             beforeEach(async () => {
+              validBodyWithThumbnail = {
+                ...validBody,
+                thumbnailPath: require('path').join(__dirname, 'fixtures/example.png')
+              }
+
               expectedCdn = await components.config.requireString('CDN_URL')
             })
 
@@ -271,13 +289,12 @@ test('Create Community Controller', async function ({ components, stubComponents
           })
 
           describe('and the community privacy is private', () => {
-            let validBodyWithPrivatePrivacy = {
-              ...validBody,
-              privacy: CommunityPrivacyEnum.Private
-            }
+            beforeEach(() => {
+              validBody.privacy = CommunityPrivacyEnum.Private
+            })
 
-            it('should create community with private privacy', async () => {
-              const response = await makeMultipartRequest(identity, '/v1/communities', validBodyWithPrivatePrivacy)
+            it('should respond with a 201 and the created community with private privacy', async () => {
+              const response = await makeMultipartRequest(identity, '/v1/communities', validBody)
               const body = await response.json()
               communityId = body.data.id
 

--- a/test/integration/get-communities-controller.spec.ts
+++ b/test/integration/get-communities-controller.spec.ts
@@ -5,7 +5,7 @@ import { createMockProfile } from '../mocks/profile'
 import { parseExpectedFriends } from '../mocks/friend'
 import { mockCommunity } from '../mocks/communities'
 import { createOrUpsertActiveFriendship, removeFriendship } from './utils/friendships'
-import { CommunityOwnerNotFoundError } from '../../src/logic/community'
+import { CommunityOwnerNotFoundError, CommunityPrivacyEnum } from '../../src/logic/community'
 
 test('Get Communities Controller', function ({ components, spyComponents }) {
   const makeRequest = makeAuthenticatedRequest(components)
@@ -105,7 +105,7 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
                 description: 'Test Description 1',
                 ownerAddress: address,
                 ownerName: 'Test Owner',
-                privacy: 'public',
+                privacy: CommunityPrivacyEnum.Public,
                 active: true,
                 membersCount: 2
               }),
@@ -115,7 +115,7 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
                 description: 'Test Description 2',
                 ownerAddress: address,
                 ownerName: 'Test Owner',
-                privacy: 'public',
+                privacy: CommunityPrivacyEnum.Public,
                 active: true,
                 membersCount: 1
               })
@@ -148,7 +148,7 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
                   description: 'Test Description 1',
                   ownerAddress: address,
                   ownerName: 'Test Owner',
-                  privacy: 'public',
+                  privacy: CommunityPrivacyEnum.Public,
                   active: true,
                   role: CommunityRole.None,
                   membersCount: 2,
@@ -160,7 +160,7 @@ test('Get Communities Controller', function ({ components, spyComponents }) {
                   description: 'Test Description 2',
                   ownerAddress: address,
                   ownerName: 'Test Owner',
-                  privacy: 'public',
+                  privacy: CommunityPrivacyEnum.Public,
                   active: true,
                   role: CommunityRole.None,
                   membersCount: 1,

--- a/test/integration/get-community-controller.spec.ts
+++ b/test/integration/get-community-controller.spec.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { CommunityRole } from '../../src/types'
 import { test } from '../components'
 import { createTestIdentity, Identity, makeAuthenticatedRequest } from './utils/auth'
-import { CommunityOwnerNotFoundError } from '../../src/logic/community'
+import { CommunityOwnerNotFoundError, CommunityPrivacyEnum } from '../../src/logic/community'
 
 test('Get Community Controller', function ({ components, spyComponents }) {
   const makeRequest = makeAuthenticatedRequest(components)
@@ -70,7 +70,7 @@ test('Get Community Controller', function ({ components, spyComponents }) {
               description: 'Test Description',
               ownerAddress: address,
               ownerName: 'Test Owner',
-              privacy: 'public',
+              privacy: CommunityPrivacyEnum.Public,
             })
           })
         })
@@ -132,7 +132,7 @@ test('Get Community Controller', function ({ components, spyComponents }) {
                   description: 'Test Description',
                   ownerAddress: address,
                   ownerName: 'Test Owner',
-                  privacy: 'public',
+                  privacy: CommunityPrivacyEnum.Public,
                   active: true,
                   isHostingLiveEvent: false,
                   role: CommunityRole.None,
@@ -228,7 +228,7 @@ test('Get Community Controller', function ({ components, spyComponents }) {
                   description: 'Test Description',
                   ownerAddress: address,
                   ownerName: 'Test Owner Unclaimed',
-                  privacy: 'public',
+                  privacy: CommunityPrivacyEnum.Public,
                   active: true,
                   isHostingLiveEvent: false,
                   role: CommunityRole.None,

--- a/test/integration/update-community-controller.spec.ts
+++ b/test/integration/update-community-controller.spec.ts
@@ -1,3 +1,4 @@
+import { CommunityPrivacyEnum } from '../../src/logic/community'
 import { test } from '../components'
 import {
   createTestIdentity,
@@ -294,6 +295,24 @@ test('Update Community Controller', async function ({ components, stubComponents
             const body = await response.json()
             expect(body.data.name).toBe('Multi Updated Name')
             expect(body.data.description).toBe('Multi Updated Description')
+            expect(body.message).toBe('Community updated successfully')
+          })
+        })
+
+        describe('when updating privacy', () => {
+          it('should update the community privacy', async () => {
+            const response = await makeMultipartRequest(
+              identity,
+              `/v1/communities/${communityId}`,
+              {
+                privacy: CommunityPrivacyEnum.Private
+              },
+              'PUT'
+            )
+
+            expect(response.status).toBe(200)
+            const body = await response.json()
+            expect(body.data.privacy).toBe(CommunityPrivacyEnum.Private)
             expect(body.message).toBe('Community updated successfully')
           })
         })

--- a/test/integration/update-community-controller.spec.ts
+++ b/test/integration/update-community-controller.spec.ts
@@ -1,4 +1,5 @@
 import { CommunityPrivacyEnum } from '../../src/logic/community'
+import { CommunityRole } from '../../src/types'
 import { test } from '../components'
 import {
   createTestIdentity,
@@ -61,8 +62,10 @@ test('Update Community Controller', async function ({ components, stubComponents
           limit: 1000,
           offset: 0
         })
-        for (const place of places) {
-          await components.communitiesDb.removeCommunityPlace(communityId, place.id)
+        if (places) {
+          for (const place of places) {
+            await components.communitiesDb.removeCommunityPlace(communityId, place.id)
+          }
         }
       }
     })
@@ -300,20 +303,45 @@ test('Update Community Controller', async function ({ components, stubComponents
         })
 
         describe('when updating privacy', () => {
-          it('should update the community privacy', async () => {
-            const response = await makeMultipartRequest(
-              identity,
-              `/v1/communities/${communityId}`,
-              {
-                privacy: CommunityPrivacyEnum.Private
-              },
-              'PUT'
-            )
+          describe('and the user is the owner', () => {
+            it('should update the community privacy', async () => {
+              const response = await makeMultipartRequest(
+                identity,
+                `/v1/communities/${communityId}`,
+                {
+                  privacy: CommunityPrivacyEnum.Private
+                },
+                'PUT'
+              )
+  
+              expect(response.status).toBe(200)
+              const body = await response.json()
+              expect(body.data.privacy).toBe(CommunityPrivacyEnum.Private)
+              expect(body.message).toBe('Community updated successfully')
+            })
+          })
 
-            expect(response.status).toBe(200)
-            const body = await response.json()
-            expect(body.data.privacy).toBe(CommunityPrivacyEnum.Private)
-            expect(body.message).toBe('Community updated successfully')
+          describe('and the user is not the owner', () => {
+            beforeEach(async () => {
+              await components.communitiesDb.updateMemberRole(communityId, identity.realAccount.address, CommunityRole.Moderator)
+            })
+
+            afterEach(async () => {
+              await components.communitiesDb.updateMemberRole(communityId, identity.realAccount.address, CommunityRole.Owner)
+            })
+
+            it('should respond with a 401 status code', async () => {
+              const response = await makeMultipartRequest(
+                identity,
+                `/v1/communities/${communityId}`,
+                {
+                  privacy: CommunityPrivacyEnum.Private
+                },
+                'PUT'
+              )
+
+              expect(response.status).toBe(401)
+            })
           })
         })
       })

--- a/test/integration/utils/auth.ts
+++ b/test/integration/utils/auth.ts
@@ -67,7 +67,8 @@ export function makeAuthenticatedMultipartRequest(components: Pick<TestComponent
       description,
       thumbnailPath,
       thumbnailBuffer,
-      placeIds
+      placeIds,
+      privacy
     }: {
       name?: string
       description?: string
@@ -99,6 +100,10 @@ export function makeAuthenticatedMultipartRequest(components: Pick<TestComponent
 
     if (placeIds !== undefined) {
       form.append('placeIds', JSON.stringify(placeIds))
+    }
+
+    if (privacy !== undefined) {
+      form.append('privacy', privacy)
     }
 
     const headers = {

--- a/test/integration/utils/auth.ts
+++ b/test/integration/utils/auth.ts
@@ -1,6 +1,7 @@
 import { Authenticator, AuthIdentity, IdentityType } from '@dcl/crypto'
 import { createUnsafeIdentity } from '@dcl/crypto/dist/crypto'
 import { signedHeaderFactory } from 'decentraland-crypto-fetch'
+import { CommunityPrivacyEnum } from '../../../src/logic/community'
 import { TestComponents } from '../../../src/types'
 import FormData from 'form-data'
 import fs from 'fs'
@@ -73,6 +74,7 @@ export function makeAuthenticatedMultipartRequest(components: Pick<TestComponent
       thumbnailPath?: string
       thumbnailBuffer?: Buffer
       placeIds?: string[]
+      privacy?: CommunityPrivacyEnum
     },
     method: string = 'POST'
   ) => {

--- a/test/mocks/communities.ts
+++ b/test/mocks/communities.ts
@@ -49,6 +49,7 @@ export function createMockCommunityRolesComponent({
   validatePermissionToAddPlacesToCommunity = jest.fn(),
   validatePermissionToRemovePlacesFromCommunity = jest.fn(),
   validatePermissionToEditCommunity = jest.fn(),
+  validatePermissionToUpdateCommunityPrivacy = jest.fn(),
   validatePermissionToDeleteCommunity = jest.fn(),
   validatePermissionToUpdatePlaces = jest.fn(),
   validatePermissionToLeaveCommunity = jest.fn()
@@ -62,6 +63,7 @@ export function createMockCommunityRolesComponent({
     validatePermissionToAddPlacesToCommunity,
     validatePermissionToRemovePlacesFromCommunity,
     validatePermissionToEditCommunity,
+    validatePermissionToUpdateCommunityPrivacy,
     validatePermissionToDeleteCommunity,
     validatePermissionToUpdatePlaces,
     validatePermissionToLeaveCommunity

--- a/test/unit/logic/communities.spec.ts
+++ b/test/unit/logic/communities.spec.ts
@@ -12,7 +12,9 @@ import {
   ICommunityOwnersComponent,
   ICommunityEventsComponent,
   ICommunityThumbnailComponent,
-  ICommunityBroadcasterComponent
+  ICommunityBroadcasterComponent,
+  CommunityPrivacyEnum,
+  CommunityPublicInformation
 } from '../../../src/logic/community/types'
 import {
   createMockCommunityRolesComponent,
@@ -45,7 +47,7 @@ describe('Community Component', () => {
     name: 'Test Community',
     description: 'Test Description',
     ownerAddress: '0x1234567890123456789012345678901234567890',
-    privacy: 'public',
+    privacy: CommunityPrivacyEnum.Public,
     active: true,
     thumbnails: undefined
   }
@@ -344,22 +346,16 @@ describe('Community Component', () => {
 
   describe('when getting public communities', () => {
     const options = { pagination: { limit: 10, offset: 0 }, search: 'test' }
-    const mockCommunities = [
+    const mockCommunities: Omit<CommunityPublicInformation, 'ownerName'>[] = [
       {
         id: communityId,
         name: 'Test Community',
         description: 'Test Description',
         ownerAddress: '0x1234567890123456789012345678901234567890',
-        privacy: 'public' as const,
+        privacy: CommunityPrivacyEnum.Public,
         active: true,
-        role: CommunityRole.Member,
         membersCount: 10,
-        isHostingLiveEvent: false,
-        voiceChatStatus: {
-          isActive: false,
-          participantCount: 0,
-          moderatorCount: 0
-        }
+        isHostingLiveEvent: false
       }
     ]
 
@@ -384,7 +380,7 @@ describe('Community Component', () => {
               name: mockCommunity.name,
               description: mockCommunity.description,
               ownerAddress: mockCommunity.ownerAddress,
-              privacy: 'public',
+              privacy: CommunityPrivacyEnum.Public,
               active: mockCommunity.active,
               membersCount: 10,
               isHostingLiveEvent: false,
@@ -418,7 +414,7 @@ describe('Community Component', () => {
 
     describe('when filtering by active voice chat', () => {
       const optionsWithVoiceChat = { ...options, onlyWithActiveVoiceChat: true }
-      const mockCommunitiesWithVoiceChat = [
+      const mockCommunitiesWithVoiceChat: Omit<CommunityPublicInformation, 'ownerName'>[] = [
         {
           ...mockCommunities[0],
           id: 'public-community-with-voice-chat'
@@ -484,7 +480,7 @@ describe('Community Component', () => {
         name: 'Test Community',
         description: 'Test Description',
         ownerAddress: '0x1234567890123456789012345678901234567890',
-        privacy: 'public',
+        privacy: CommunityPrivacyEnum.Public,
         active: true,
         role: CommunityRole.Member,
         joinedAt: '2023-01-01T00:00:00Z'
@@ -514,7 +510,8 @@ describe('Community Component', () => {
     const communityData = {
       name: 'New Community',
       description: 'New Description',
-      ownerAddress
+      ownerAddress,
+      privacy: CommunityPrivacyEnum.Public
     }
     const placeIds = ['place-1', 'place-2']
     const thumbnail = Buffer.from('fake-thumbnail')

--- a/test/unit/logic/communities.spec.ts
+++ b/test/unit/logic/communities.spec.ts
@@ -346,20 +346,21 @@ describe('Community Component', () => {
 
   describe('when getting public communities', () => {
     const options = { pagination: { limit: 10, offset: 0 }, search: 'test' }
-    const mockCommunities: Omit<CommunityPublicInformation, 'ownerName'>[] = [
-      {
-        id: communityId,
-        name: 'Test Community',
-        description: 'Test Description',
-        ownerAddress: '0x1234567890123456789012345678901234567890',
-        privacy: CommunityPrivacyEnum.Public,
-        active: true,
-        membersCount: 10,
-        isHostingLiveEvent: false
-      }
-    ]
+    let mockCommunities: Omit<CommunityPublicInformation, 'ownerName'>[] = []
 
     beforeEach(() => {
+      mockCommunities = [
+        {
+          id: communityId,
+          name: 'Test Community',
+          description: 'Test Description',
+          ownerAddress: '0x1234567890123456789012345678901234567890',
+          privacy: CommunityPrivacyEnum.Public,
+          active: true,
+          membersCount: 10,
+          isHostingLiveEvent: false
+        }
+      ]
       mockCommunitiesDB.getCommunitiesPublicInformation.mockResolvedValue(mockCommunities)
       mockCommunitiesDB.getPublicCommunitiesCount.mockResolvedValue(1)
       mockCommunityOwners.getOwnerName.mockResolvedValue('Test Owner Name')

--- a/test/unit/logic/community-bans.spec.ts
+++ b/test/unit/logic/community-bans.spec.ts
@@ -4,7 +4,7 @@ import { mockCommunitiesDB } from '../../mocks/components/communities-db'
 import { mockLogs, mockCatalystClient, mockPubSub } from '../../mocks/components'
 import { createCommunityBansComponent } from '../../../src/logic/community/bans'
 import { ICommunityBansComponent } from '../../../src/logic/community'
-import { BannedMember, ICommunityBroadcasterComponent, ICommunityRolesComponent, ICommunityThumbnailComponent } from '../../../src/logic/community/types'
+import { BannedMember, CommunityPrivacyEnum, ICommunityBroadcasterComponent, ICommunityRolesComponent, ICommunityThumbnailComponent } from '../../../src/logic/community/types'
 import { createMockCommunityBroadcasterComponent, createMockCommunityRolesComponent, createMockCommunityThumbnailComponent } from '../../mocks/communities'
 import { createMockProfile } from '../../mocks/profile'
 import { ConnectivityStatus } from '@dcl/protocol/out-js/decentraland/social_service/v2/social_service_v2.gen'
@@ -67,7 +67,7 @@ describe('Community Bans Component', () => {
           description: 'Test Description',
           active: true,
           ownerAddress: bannerAddress,
-          privacy: 'public',
+          privacy: CommunityPrivacyEnum.Public,
           role: CommunityRole.Owner
         })
       })
@@ -347,7 +347,7 @@ describe('Community Bans Component', () => {
           description: 'Test Description',
           active: true,
           ownerAddress: userAddress,
-          privacy: 'public',
+          privacy: CommunityPrivacyEnum.Public,
           role: CommunityRole.Owner
         })
       })

--- a/test/unit/logic/community-members.spec.ts
+++ b/test/unit/logic/community-members.spec.ts
@@ -4,7 +4,7 @@ import { CommunityNotFoundError } from '../../../src/logic/community/errors'
 import { mockCommunitiesDB } from '../../mocks/components/communities-db'
 import { mockLogs, mockCatalystClient, createMockPeersStatsComponent, mockPubSub } from '../../mocks/components'
 import { createCommunityMembersComponent } from '../../../src/logic/community/members'
-import { ICommunityBroadcasterComponent, ICommunityMembersComponent, ICommunityRolesComponent, ICommunityThumbnailComponent } from '../../../src/logic/community/types'
+import { CommunityPrivacyEnum, ICommunityBroadcasterComponent, ICommunityMembersComponent, ICommunityRolesComponent, ICommunityThumbnailComponent } from '../../../src/logic/community/types'
 import { createMockCommunityBroadcasterComponent, createMockCommunityRolesComponent, createMockCommunityThumbnailComponent } from '../../mocks/communities'
 import { createMockProfile } from '../../mocks/profile'
 import { CommunityMember, CommunityMemberProfile } from '../../../src/logic/community/types'
@@ -92,7 +92,7 @@ describe('Community Members Component', () => {
             id: communityId,
             name: 'Test Community',
             description: 'Test Description',
-            privacy: 'public',
+            privacy: CommunityPrivacyEnum.Public,
             active: true,
             ownerAddress: '0xowner',
             role: CommunityRole.Member
@@ -175,7 +175,7 @@ describe('Community Members Component', () => {
             id: communityId,
             name: 'Test Community',
             description: 'Test Description',
-            privacy: 'private',
+            privacy: CommunityPrivacyEnum.Private,
             active: true,
             ownerAddress: '0xowner',
             role: CommunityRole.Member
@@ -278,7 +278,7 @@ describe('Community Members Component', () => {
           id: communityId,
           name: 'Test Community',
           description: 'Test Description',
-          privacy: 'public',
+          privacy: CommunityPrivacyEnum.Public,
           active: true,
           ownerAddress: '0xowner',
           role: CommunityRole.Member
@@ -598,7 +598,7 @@ describe('Community Members Component', () => {
         description: 'Test Description',
         active: true,
         ownerAddress: kickerAddress,
-        privacy: 'public',
+        privacy: CommunityPrivacyEnum.Public,
         role: CommunityRole.Owner
       })
       mockCommunitiesDB.isMemberOfCommunity.mockResolvedValue(isMember)
@@ -614,7 +614,7 @@ describe('Community Members Component', () => {
           description: 'Test Description',
           active: true,
           ownerAddress: kickerAddress,
-          privacy: 'public',
+          privacy: CommunityPrivacyEnum.Public,
           role: CommunityRole.Owner
         })
       })

--- a/test/unit/logic/community-places.spec.ts
+++ b/test/unit/logic/community-places.spec.ts
@@ -4,7 +4,7 @@ import { CommunityNotFoundError, CommunityPlaceNotFoundError } from '../../../sr
 import { mockCommunitiesDB } from '../../mocks/components/communities-db'
 import { mockLogs, createPlacesApiAdapterMockComponent } from '../../mocks/components'
 import { createCommunityPlacesComponent } from '../../../src/logic/community/places'
-import { ICommunityPlacesComponent, CommunityPlace, ICommunityRolesComponent } from '../../../src/logic/community'
+import { ICommunityPlacesComponent, CommunityPlace, ICommunityRolesComponent, CommunityPrivacyEnum } from '../../../src/logic/community'
 import { IPlacesApiComponent } from '../../../src/types/components'
 import { createMockCommunityRolesComponent } from '../../mocks/communities'
 
@@ -72,7 +72,7 @@ describe('Community Places Component', () => {
             name: 'Test Community',
             description: 'Test Description',
             ownerAddress: '0xowner',
-            privacy: 'public',
+            privacy: CommunityPrivacyEnum.Public,
             active: true,
             role: CommunityRole.Member
           }
@@ -101,7 +101,7 @@ describe('Community Places Component', () => {
             name: 'Test Community',
             description: 'Test Description',
             ownerAddress: '0xowner',
-            privacy: 'private',
+            privacy: CommunityPrivacyEnum.Private,
             active: true,
             role: CommunityRole.Member
           }
@@ -159,7 +159,7 @@ describe('Community Places Component', () => {
             name: 'Test Community',
             description: 'Test Description',
             ownerAddress: '0xowner',
-            privacy: 'public',
+            privacy: CommunityPrivacyEnum.Public,
             active: true,
             role: CommunityRole.Member
           }
@@ -188,7 +188,7 @@ describe('Community Places Component', () => {
             name: 'Test Community',
             description: 'Test Description',
             ownerAddress: '0xowner',
-            privacy: 'public',
+            privacy: CommunityPrivacyEnum.Public,
             active: true,
             role: CommunityRole.Member
           }

--- a/test/unit/logic/community-voice.spec.ts
+++ b/test/unit/logic/community-voice.spec.ts
@@ -22,6 +22,7 @@ import { AnalyticsEvent, AnalyticsEventPayload } from '../../../src/types/analyt
 import { ICommunityVoiceComponent } from '../../../src/logic/community-voice'
 import { ICommunityVoiceChatCacheComponent } from '../../../src/logic/community-voice/community-voice-cache'
 import { createCommsGatekeeperMockedComponent } from '../../mocks/components/comms-gatekeeper'
+import { CommunityPrivacyEnum } from '../../../src/logic/community'
 
 describe('Community Voice Logic', () => {
   let mockLogs: jest.Mocked<ILoggerComponent>
@@ -143,7 +144,7 @@ describe('Community Voice Logic', () => {
             name: 'Test Community',
             description: 'Test Description',
             ownerAddress: '0x123',
-            privacy: 'public',
+            privacy: CommunityPrivacyEnum.Public,
             active: true,
             role: CommunityRole.Owner
           })
@@ -240,7 +241,7 @@ describe('Community Voice Logic', () => {
             name: 'Test Community',
             description: 'Test Description',
             ownerAddress: '0x123',
-            privacy: 'public',
+            privacy: CommunityPrivacyEnum.Public,
             active: true,
             role: CommunityRole.Owner
           })
@@ -558,7 +559,7 @@ describe('Community Voice Logic', () => {
             name: 'Test Community',
             description: 'Test Description',
             ownerAddress: '0x123',
-            privacy: 'private',
+            privacy: CommunityPrivacyEnum.Private,
             active: true,
             role: CommunityRole.Member
           })
@@ -623,7 +624,7 @@ describe('Community Voice Logic', () => {
             name: 'Public Test Community',
             description: 'Public community for testing',
             ownerAddress: '0x123',
-            privacy: 'public',
+            privacy: CommunityPrivacyEnum.Public,
             active: true,
             role: CommunityRole.None
           })
@@ -713,7 +714,7 @@ describe('Community Voice Logic', () => {
             name: 'Private Test Community',
             description: 'Private community for testing',
             ownerAddress: '0x123',
-            privacy: 'private',
+            privacy: CommunityPrivacyEnum.Private,
             active: true,
             role: CommunityRole.None
           })
@@ -738,7 +739,7 @@ describe('Community Voice Logic', () => {
             name: 'Test Community',
             description: 'Test Description',
             ownerAddress: '0x123',
-            privacy: 'public',
+            privacy: CommunityPrivacyEnum.Public,
             active: true,
             role: CommunityRole.None
           })
@@ -763,7 +764,7 @@ describe('Community Voice Logic', () => {
             name: 'Private Test Community',
             description: 'Test Description',
             ownerAddress: '0x123',
-            privacy: 'private',
+            privacy: CommunityPrivacyEnum.Private,
             active: true,
             role: CommunityRole.Member
           })

--- a/test/unit/logic/updates.spec.ts
+++ b/test/unit/logic/updates.spec.ts
@@ -1303,7 +1303,6 @@ describe('Updates Handlers', () => {
         rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('blockUpdate', blockUpdate)
 
         const result = await resultPromise
-        console.log(result)
         expect(result.value).toEqual({ parsed: true })
         expect(parser).toHaveBeenCalledWith(blockUpdate, null)
         expect(mockCatalystClient.getProfile).not.toHaveBeenCalled()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,13 +1228,6 @@
     "@well-known-components/interfaces" "^1.4.3"
     node-fetch "^2.7.0"
 
-"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-16750498281.commit-51e445c.tgz":
-  version "1.0.0-16750498281.commit-51e445c"
-  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-16750498281.commit-51e445c.tgz#0a543c22fff662f1ae4c69c39b41189ffd65764d"
-  dependencies:
-    "@dcl/ts-proto" "1.154.0"
-    protobufjs "7.2.4"
-
 "@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-16751971069.commit-16c6dee.tgz":
   version "1.0.0-16751971069.commit-16c6dee"
   resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-16751971069.commit-16c6dee.tgz#f7668c6fdd0f4f0cbe268e8a4aa1cdb7b3063116"


### PR DESCRIPTION
At this point, there is no way to create `private` communities using the exposed endpoints. This PR modifies the endpoints exposed to create and update communities to support changing community privacy (`POST /v1/communities` and `PUT /v1/communities` respectively).