### PR TITLE
feat: check if users are in community calls before allowing private call

### DIFF
--- a/src/adapters/comms-gatekeeper.ts
+++ b/src/adapters/comms-gatekeeper.ts
@@ -570,6 +570,35 @@ export const createCommsGatekeeperComponent = async ({
     }
   }
 
+  /**
+   * Checks if a user is currently in any community voice chat.
+   * @param userAddress - The address of the user to check.
+   * @returns Promise<boolean> - True if user is in a community voice chat, false otherwise.
+   */
+  async function isUserInCommunityVoiceChat(userAddress: string): Promise<boolean> {
+    try {
+      const response = await fetch(`${commsUrl}/users/${userAddress}/community-voice-chat/status`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${commsGateKeeperToken}`
+        }
+      })
+
+      if (!response.ok) {
+        throw new Error(`Server responded with status ${response.status}`)
+      }
+
+      const data = await response.json()
+      return data.isInCommunityVoiceChat
+    } catch (error) {
+      logger.error(
+        `Failed to check community voice chat status for user ${userAddress}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
+      )
+      throw error
+    }
+  }
+
   return {
     endPrivateVoiceChat,
     updateUserPrivateMessagePrivacyMetadata,
@@ -586,6 +615,7 @@ export const createCommsGatekeeperComponent = async ({
     getCommunityVoiceChatStatus,
     getCommunitiesVoiceChatStatus,
     getAllActiveCommunityVoiceChats,
-    kickUserFromCommunityVoiceChat
+    kickUserFromCommunityVoiceChat,
+    isUserInCommunityVoiceChat
   }
 }

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -323,6 +323,7 @@ export type ICommsGatekeeperComponent = {
     }>
   >
   kickUserFromCommunityVoiceChat: (communityId: string, userAddress: string) => Promise<void>
+  isUserInCommunityVoiceChat: (userAddress: string) => Promise<boolean>
 }
 
 export type IWebSocketComponent = IBaseComponent & {

--- a/test/mocks/components/comms-gatekeeper.ts
+++ b/test/mocks/components/comms-gatekeeper.ts
@@ -16,7 +16,8 @@ export function createCommsGatekeeperMockedComponent({
   getCommunityVoiceChatStatus = jest.fn(),
   getCommunitiesVoiceChatStatus = jest.fn(),
   getAllActiveCommunityVoiceChats = jest.fn(),
-  kickUserFromCommunityVoiceChat = jest.fn()
+  kickUserFromCommunityVoiceChat = jest.fn(),
+  isUserInCommunityVoiceChat = jest.fn()
 }: Partial<jest.Mocked<ICommsGatekeeperComponent>>): jest.Mocked<ICommsGatekeeperComponent> {
   return {
     getPrivateVoiceChatCredentials,
@@ -34,6 +35,7 @@ export function createCommsGatekeeperMockedComponent({
     getCommunityVoiceChatStatus,
     getCommunitiesVoiceChatStatus,
     getAllActiveCommunityVoiceChats,
-    kickUserFromCommunityVoiceChat
+    kickUserFromCommunityVoiceChat,
+    isUserInCommunityVoiceChat
   }
 }

--- a/test/unit/adapters/comms-gatekeeper-community-voice.spec.ts
+++ b/test/unit/adapters/comms-gatekeeper-community-voice.spec.ts
@@ -45,7 +45,11 @@ describe('Comms Gatekeeper Community Voice Chat', () => {
       })
 
       it('should return connection URL', async () => {
-        const result = await commsGatekeeper.getCommunityVoiceChatCredentials(testCommunityId, testUserAddress, CommunityRole.Member)
+        const result = await commsGatekeeper.getCommunityVoiceChatCredentials(
+          testCommunityId,
+          testUserAddress,
+          CommunityRole.Member
+        )
 
         expect(result).toEqual({
           connectionUrl: 'wss://livekit.test/room?token=abc123'
@@ -96,7 +100,11 @@ describe('Comms Gatekeeper Community Voice Chat', () => {
       })
 
       it('should create room successfully and return connection URL', async () => {
-        const result = await commsGatekeeper.createCommunityVoiceChatRoom(testCommunityId, testUserAddress, CommunityRole.Owner)
+        const result = await commsGatekeeper.createCommunityVoiceChatRoom(
+          testCommunityId,
+          testUserAddress,
+          CommunityRole.Owner
+        )
 
         expect(result).toEqual({
           connectionUrl: 'wss://livekit.test/room?token=abc123'
@@ -127,9 +135,9 @@ describe('Comms Gatekeeper Community Voice Chat', () => {
       })
 
       it('should throw an error', async () => {
-        await expect(commsGatekeeper.createCommunityVoiceChatRoom(testCommunityId, testUserAddress, CommunityRole.Owner)).rejects.toThrow(
-          'Server responded with status 409'
-        )
+        await expect(
+          commsGatekeeper.createCommunityVoiceChatRoom(testCommunityId, testUserAddress, CommunityRole.Owner)
+        ).rejects.toThrow('Server responded with status 409')
       })
     })
   })
@@ -492,9 +500,85 @@ describe('Comms Gatekeeper Community Voice Chat', () => {
       })
 
       it('should throw an error', async () => {
-        await expect(
-          commsGatekeeper.kickUserFromCommunityVoiceChat(testCommunityId, testUserAddress)
-        ).rejects.toThrow('Server responded with status 403')
+        await expect(commsGatekeeper.kickUserFromCommunityVoiceChat(testCommunityId, testUserAddress)).rejects.toThrow(
+          'Server responded with status 403'
+        )
+      })
+    })
+  })
+
+  describe('when checking if user is in community voice chat', () => {
+    describe('and the request is successful with user in community voice chat', () => {
+      beforeEach(() => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              userAddress: testUserAddress,
+              isInCommunityVoiceChat: true
+            })
+        })
+      })
+
+      it('should return true', async () => {
+        const result = await commsGatekeeper.isUserInCommunityVoiceChat(testUserAddress)
+
+        expect(result).toBe(true)
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${gatekeeperUrl}/users/${testUserAddress}/community-voice-chat/status`,
+          {
+            method: 'GET',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${gatekeeperToken}`
+            }
+          }
+        )
+      })
+    })
+
+    describe('and the request is successful with user not in community voice chat', () => {
+      beforeEach(() => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              userAddress: testUserAddress,
+              isInCommunityVoiceChat: false
+            })
+        })
+      })
+
+      it('should return false', async () => {
+        const result = await commsGatekeeper.isUserInCommunityVoiceChat(testUserAddress)
+
+        expect(result).toBe(false)
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${gatekeeperUrl}/users/${testUserAddress}/community-voice-chat/status`,
+          {
+            method: 'GET',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${gatekeeperToken}`
+            }
+          }
+        )
+      })
+    })
+
+    describe('and the request fails', () => {
+      beforeEach(() => {
+        mockFetch.mockResolvedValue({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve('Internal Server Error')
+        })
+      })
+
+      it('should throw an error', async () => {
+        await expect(commsGatekeeper.isUserInCommunityVoiceChat(testUserAddress)).rejects.toThrow(
+          'Server responded with status 500'
+        )
       })
     })
   })

--- a/test/unit/adapters/rpc-server/services/start-private-voice-chat.spec.ts
+++ b/test/unit/adapters/rpc-server/services/start-private-voice-chat.spec.ts
@@ -2,8 +2,10 @@ import { ILoggerComponent } from '@well-known-components/interfaces'
 import { StartPrivateVoiceChatPayload } from '@dcl/protocol/out-ts/decentraland/social_service/v2/social_service_v2.gen'
 import { startPrivateVoiceChatService } from '../../../../../src/controllers/handlers/rpc/start-private-voice-chat'
 import { IVoiceComponent } from '../../../../../src/logic/voice'
+import { ICommsGatekeeperComponent } from '../../../../../src/types/components'
 import { createLogsMockedComponent } from '../../../../mocks/components'
 import { createVoiceMockedComponent } from '../../../../mocks/components/voice'
+import { createCommsGatekeeperMockedComponent } from '../../../../mocks/components/comms-gatekeeper'
 import {
   UserAlreadyInVoiceChatError,
   UsersAreCallingSomeoneElseError,
@@ -12,22 +14,32 @@ import {
 
 describe('when starting a private voice chat', () => {
   let startPrivateVoiceChatMock: jest.MockedFn<IVoiceComponent['startPrivateVoiceChat']>
+  let isUserInCommunityVoiceChatMock: jest.MockedFn<ICommsGatekeeperComponent['isUserInCommunityVoiceChat']>
   let logs: jest.Mocked<ILoggerComponent>
   let voice: jest.Mocked<IVoiceComponent>
+  let commsGatekeeper: jest.Mocked<ICommsGatekeeperComponent>
   let callerAddress: string
   let calleeAddress: string
   let service: ReturnType<typeof startPrivateVoiceChatService>
 
   beforeEach(async () => {
     startPrivateVoiceChatMock = jest.fn()
+    isUserInCommunityVoiceChatMock = jest.fn()
     callerAddress = '0xBceaD48696C30eBfF0725D842116D334aAd585C1'
     calleeAddress = '0xC001010101010101010101010101010101010101'
     logs = createLogsMockedComponent()
     voice = createVoiceMockedComponent({
       startPrivateVoiceChat: startPrivateVoiceChatMock
     })
+    commsGatekeeper = createCommsGatekeeperMockedComponent({
+      isUserInCommunityVoiceChat: isUserInCommunityVoiceChatMock
+    })
+
+    // By default, users are not in community voice chat
+    isUserInCommunityVoiceChatMock.mockResolvedValue(false)
+
     service = startPrivateVoiceChatService({
-      components: { voice, logs }
+      components: { voice, logs, commsGatekeeper }
     })
   })
 
@@ -54,6 +66,67 @@ describe('when starting a private voice chat', () => {
       if (result.response?.$case === 'ok') {
         expect(result.response.ok.callId).toBe(callId)
       }
+      expect(isUserInCommunityVoiceChatMock).toHaveBeenCalledWith(callerAddress)
+      expect(isUserInCommunityVoiceChatMock).toHaveBeenCalledWith(calleeAddress)
+    })
+  })
+
+  describe('and caller is in a community voice chat', () => {
+    beforeEach(() => {
+      isUserInCommunityVoiceChatMock.mockImplementation((userAddress: string) => {
+        return Promise.resolve(userAddress === callerAddress)
+      })
+    })
+
+    it('should resolve with a conflicting error response', async () => {
+      const result = await service(
+        StartPrivateVoiceChatPayload.create({
+          callee: { address: calleeAddress }
+        }),
+        {
+          address: callerAddress,
+          subscribersContext: undefined
+        }
+      )
+
+      expect(result.response?.$case).toBe('conflictingError')
+      if (result.response?.$case === 'conflictingError') {
+        expect(result.response.conflictingError.message).toBe(
+          'Cannot start private voice chat while in a community voice chat'
+        )
+      }
+      expect(isUserInCommunityVoiceChatMock).toHaveBeenCalledWith(callerAddress)
+      expect(startPrivateVoiceChatMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and callee is in a community voice chat', () => {
+    beforeEach(() => {
+      isUserInCommunityVoiceChatMock.mockImplementation((userAddress: string) => {
+        return Promise.resolve(userAddress === calleeAddress)
+      })
+    })
+
+    it('should resolve with a conflicting error response', async () => {
+      const result = await service(
+        StartPrivateVoiceChatPayload.create({
+          callee: { address: calleeAddress }
+        }),
+        {
+          address: callerAddress,
+          subscribersContext: undefined
+        }
+      )
+
+      expect(result.response?.$case).toBe('conflictingError')
+      if (result.response?.$case === 'conflictingError') {
+        expect(result.response.conflictingError.message).toBe(
+          'Cannot start private voice chat: the callee is in a community voice chat'
+        )
+      }
+      expect(isUserInCommunityVoiceChatMock).toHaveBeenCalledWith(callerAddress)
+      expect(isUserInCommunityVoiceChatMock).toHaveBeenCalledWith(calleeAddress)
+      expect(startPrivateVoiceChatMock).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
Add check if there is a community call ongoing for caller or callee when starting a private voice chat. 