### PR TITLE
feat: support creation of Community invites and request_to_join

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -61,6 +61,7 @@ import { createFriendsComponent } from './logic/friends'
 import { createCommunityVoiceChatCacheComponent } from './logic/community-voice/community-voice-cache'
 import { createCommunityVoiceChatPollingComponent } from './logic/community-voice/community-voice-polling'
 import { createSlackComponent } from '@dcl/slack-component'
+import { createCommunityRequestsComponent } from './logic/community/requests'
 
 // Initialize all the components of the app
 export async function initComponents(): Promise<AppComponents> {
@@ -202,6 +203,7 @@ export async function initComponents(): Promise<AppComponents> {
   })
   const communityOwners = createCommunityOwnersComponent({ catalystClient })
   const communityEvents = await createCommunityEventsComponent({ config, logs, fetcher, redis })
+  const communityRequests = createCommunityRequestsComponent({ communitiesDb, logs })
   const communities = createCommunityComponent({
     communitiesDb,
     catalystClient,
@@ -285,6 +287,7 @@ export async function initComponents(): Promise<AppComponents> {
     communityOwners,
     communityPlaces,
     communityRoles,
+    communityRequests,
     communityThumbnail,
     communityVoice,
     communityVoiceChatCache,

--- a/src/controllers/handlers/http/create-community-request-handler.ts
+++ b/src/controllers/handlers/http/create-community-request-handler.ts
@@ -1,0 +1,81 @@
+import { EthAddress } from '@dcl/schemas'
+import { CommunityRequest, CommunityRequestType } from '../../../logic/community/types'
+import { HandlerContextWithPath, HTTPResponse } from '../../../types'
+import { CommunityNotFoundError, InvalidCommunityRequestError } from '../../../logic/community'
+import { errorMessageOrDefault } from '../../../utils/errors'
+
+export async function createCommunityRequestHandler(
+  context: Pick<
+    HandlerContextWithPath<'communityRequests' | 'logs', '/v1/communities/:id/requests'>,
+    'components' | 'request' | 'params'
+  >
+): Promise<HTTPResponse<CommunityRequest>> {
+  const {
+    components: { communityRequests, logs },
+    params: { id: communityId },
+    request
+  } = context
+
+  const logger = logs.getLogger('create-community-request-handler')
+
+  let body: { targetedAddress: string; type: CommunityRequestType }
+
+  try {
+    body = await request.json()
+  } catch (error) {
+    return {
+      status: 400,
+      body: {
+        message: 'Invalid JSON in request body'
+      }
+    }
+  }
+
+  try {
+    if (!body.targetedAddress || !body.type) {
+      throw new InvalidCommunityRequestError('Missing targetedAddress or type field')
+    }
+
+    if (!EthAddress.validate(body.targetedAddress)) {
+      throw new InvalidCommunityRequestError('Invalid targeted address')
+    }
+
+    if (!Object.values(CommunityRequestType).includes(body.type)) {
+      throw new InvalidCommunityRequestError('Invalid type value')
+    }
+
+    const communityRequest = await communityRequests.createCommunityRequest(
+      communityId,
+      body.targetedAddress as EthAddress,
+      body.type
+    )
+
+    return {
+      status: 200,
+      body: {
+        data: {
+          ...communityRequest
+        }
+      }
+    }
+  } catch (error) {
+    const message = errorMessageOrDefault(error)
+
+    logger.error(`Error creating community request: ${message}`, {
+      communityId,
+      targetedAddress: body.targetedAddress,
+      type: body.type
+    })
+
+    if (error instanceof InvalidCommunityRequestError || error instanceof CommunityNotFoundError) {
+      throw error
+    }
+
+    return {
+      status: 500,
+      body: {
+        message
+      }
+    }
+  }
+}

--- a/src/controllers/middlewares/communities-errors.ts
+++ b/src/controllers/middlewares/communities-errors.ts
@@ -3,7 +3,8 @@ import {
   CommunityMemberNotFoundError,
   CommunityNotFoundError,
   CommunityOwnerNotFoundError,
-  CommunityPlaceNotFoundError
+  CommunityPlaceNotFoundError,
+  InvalidCommunityRequestError
 } from '../../logic/community/errors'
 import { ComponentsWithLogger } from '@dcl/platform-server-commons/dist/types'
 
@@ -24,6 +25,16 @@ export async function communitiesErrorsHandler(
         status: 404,
         body: {
           error: 'Not Found',
+          message: error.message
+        }
+      }
+    }
+
+    if (error instanceof InvalidCommunityRequestError) {
+      return {
+        status: 400,
+        body: {
+          error: 'Bad Request',
           message: error.message
         }
       }

--- a/src/controllers/routes/http.routes.ts
+++ b/src/controllers/routes/http.routes.ts
@@ -28,6 +28,7 @@ import { wellKnownComponents } from '@dcl/platform-crypto-middleware'
 import { multipartParserWrapper } from '@well-known-components/multipart-wrapper'
 import { communitiesErrorsHandler } from '../middlewares/communities-errors'
 import { getManagedCommunitiesHandler } from '../handlers/http/get-managed-communities-handler'
+import { createCommunityRequestHandler } from '../handlers/http/create-community-request-handler'
 
 export async function setupHttpRoutes(context: GlobalContext): Promise<Router<GlobalContext>> {
   const {
@@ -80,6 +81,8 @@ export async function setupHttpRoutes(context: GlobalContext): Promise<Router<Gl
   router.patch('/v1/referral-progress', signedFetchMiddleware(), updateReferralSignedUpHandler)
   router.get('/v1/referral-progress', signedFetchMiddleware(), getInvitedUsersAcceptedHandler)
   router.post('/v1/referral-email', signedFetchMiddleware(), addReferralEmailHandler)
+
+  router.post('/v1/communities/:id/requests', signedFetchMiddleware(), createCommunityRequestHandler)
 
   // Community voice chats
   router.get('/v1/community-voice-chats/active', signedFetchMiddleware(), getActiveCommunityVoiceChatsHandler)

--- a/src/logic/community/errors.ts
+++ b/src/logic/community/errors.ts
@@ -31,3 +31,17 @@ export class CommunityPlaceNotFoundError extends Error {
     this.name = 'CommunityPlaceNotFoundError'
   }
 }
+
+/**
+ * This error is thrown when a community request (invite or request to join) is invalid
+ *
+ * @export
+ * @class InvalidCommunityRequestError
+ * @extends {Error}
+ */
+export class InvalidCommunityRequestError extends Error {
+  constructor(public readonly message: string) {
+    super(message)
+    this.name = 'InvalidCommunityRequestError'
+  }
+}

--- a/src/logic/community/members.ts
+++ b/src/logic/community/members.ts
@@ -5,7 +5,8 @@ import {
   CommunityMemberProfile,
   CommunityMember,
   GetCommunityMembersOptions,
-  ICommunityMembersComponent
+  ICommunityMembersComponent,
+  CommunityPrivacyEnum
 } from './types'
 import { mapMembersWithProfiles } from './utils'
 import { EthAddress, Events } from '@dcl/schemas'
@@ -53,7 +54,12 @@ export async function createCommunityMembersComponent(
 
     const memberRole = userAddress ? await communitiesDb.getCommunityMemberRole(id, userAddress) : CommunityRole.None
 
-    if (community.privacy === 'private' && userAddress && memberRole === CommunityRole.None && !byPassPrivacy) {
+    if (
+      community.privacy === CommunityPrivacyEnum.Private &&
+      userAddress &&
+      memberRole === CommunityRole.None &&
+      !byPassPrivacy
+    ) {
       throw new NotAuthorizedError("The user doesn't have permission to get community members")
     }
 

--- a/src/logic/community/places.ts
+++ b/src/logic/community/places.ts
@@ -1,7 +1,7 @@
 import { NotAuthorizedError } from '@dcl/platform-server-commons'
 import { AppComponents, CommunityRole } from '../../types'
 import { CommunityNotFoundError, CommunityPlaceNotFoundError } from './errors'
-import { CommunityPlace, ICommunityPlacesComponent } from './types'
+import { CommunityPlace, CommunityPrivacyEnum, ICommunityPlacesComponent } from './types'
 import { separatePositionsAndWorlds } from '../../utils/places'
 import { EthAddress, PaginatedParameters } from '@dcl/schemas'
 
@@ -102,11 +102,15 @@ export async function createCommunityPlacesComponent(
       }
 
       const memberRole =
-        community.privacy === 'private' && options.userAddress
+        community.privacy === CommunityPrivacyEnum.Private && options.userAddress
           ? await communitiesDb.getCommunityMemberRole(communityId, options.userAddress)
           : CommunityRole.None
 
-      if (community.privacy === 'private' && options.userAddress && memberRole === CommunityRole.None) {
+      if (
+        community.privacy === CommunityPrivacyEnum.Private &&
+        options.userAddress &&
+        memberRole === CommunityRole.None
+      ) {
         throw new NotAuthorizedError(
           `The user ${options.userAddress} doesn't have permission to get places from community ${communityId}`
         )

--- a/src/logic/community/requests.ts
+++ b/src/logic/community/requests.ts
@@ -1,0 +1,61 @@
+import { AppComponents, CommunityRole } from '../../types'
+import { CommunityNotFoundError, InvalidCommunityRequestError } from './errors'
+import {
+  CommunityPrivacyEnum,
+  CommunityRequest,
+  CommunityRequestStatus,
+  CommunityRequestType,
+  ICommunityRequestsComponent
+} from './types'
+
+export function createCommunityRequestsComponent(
+  components: Pick<AppComponents, 'communitiesDb' | 'logs'>
+): ICommunityRequestsComponent {
+  const { communitiesDb, logs } = components
+
+  const logger = logs.getLogger('community-requests-component')
+
+  async function createCommunityRequest(
+    communityId: string,
+    memberAddress: string,
+    type: CommunityRequestType
+  ): Promise<CommunityRequest> {
+    const community = await communitiesDb.getCommunity(communityId, memberAddress)
+    if (!community) {
+      throw new CommunityNotFoundError(communityId)
+    }
+
+    if (community.privacy === CommunityPrivacyEnum.Public && type === CommunityRequestType.RequestToJoin) {
+      throw new InvalidCommunityRequestError(`Public communities do not accept requests to join`)
+    }
+
+    if (community.role !== CommunityRole.None) {
+      throw new InvalidCommunityRequestError(
+        `User cannot join since it is already a member of the community: ${community.name}`
+      )
+    }
+
+    const existingRequest = await communitiesDb.getCommunityRequests(communityId, {
+      pagination: { limit: 1, offset: 0 },
+      targetAddress: memberAddress,
+      status: CommunityRequestStatus.Pending,
+      type
+    })
+
+    if (existingRequest.length > 0) {
+      throw new InvalidCommunityRequestError(`Request already exists`)
+    }
+
+    const request = await communitiesDb.createCommunityRequest(communityId, memberAddress, type)
+
+    logger.info(
+      `Created community request: ${type} (${request.id}) for community ${community.name} (${communityId}) for member ${memberAddress}`
+    )
+
+    return request
+  }
+
+  return {
+    createCommunityRequest
+  }
+}

--- a/src/logic/community/types.ts
+++ b/src/logic/community/types.ts
@@ -154,6 +154,22 @@ export interface ICommunityThumbnailComponent {
   uploadThumbnail(communityId: string, thumbnail: Buffer): Promise<string>
 }
 
+export interface ICommunityRequestsComponent {
+  /**
+   * Creates a community request for a given community and member address.
+   *
+   * @param communityId - The id of the community.
+   * @param memberAddress - The address of the member to create the request for.
+   * @param type - The type of request to create.
+   * @returns The created community request.
+   */
+  createCommunityRequest(
+    communityId: string,
+    memberAddress: EthAddress,
+    type: CommunityRequestType
+  ): Promise<CommunityRequest>
+}
+
 export type CommunityDB = {
   id?: string
   name: string
@@ -271,6 +287,13 @@ export type GetCommunityMembersOptions = {
   byPassPrivacy?: boolean
 }
 
+export type GetCommunityRequestsOptions = {
+  pagination: Required<PaginatedParameters>
+  targetAddress?: EthAddress
+  status?: CommunityRequestStatus
+  type?: CommunityRequestType
+}
+
 export type CommunityWithUserInformation = AggregatedCommunityWithMemberData & {
   friends: FriendProfile[]
 }
@@ -293,6 +316,26 @@ export type CommunityPlace = {
   communityId: string
   addedBy: string
   addedAt: Date
+}
+
+export enum CommunityRequestStatus {
+  Pending = 'pending',
+  Accepted = 'accepted',
+  Rejected = 'rejected',
+  Cancelled = 'cancelled'
+}
+
+export enum CommunityRequestType {
+  Invite = 'invite',
+  RequestToJoin = 'request_to_join'
+}
+
+export type CommunityRequest = {
+  id: string
+  communityId: string
+  memberAddress: string
+  type: CommunityRequestType
+  status: CommunityRequestStatus
 }
 
 export interface ActiveCommunityVoiceChat {

--- a/src/migrations/1754425384879_community-requests.ts
+++ b/src/migrations/1754425384879_community-requests.ts
@@ -1,0 +1,66 @@
+import { ColumnDefinitions, MigrationBuilder, PgType } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('community_requests', {
+    id: {
+      type: PgType.UUID,
+      primaryKey: true
+    },
+    community_id: {
+      type: PgType.UUID,
+      notNull: true,
+      references: 'communities',
+      onDelete: 'CASCADE'
+    },
+    member_address: {
+      type: PgType.VARCHAR,
+      notNull: true
+    },
+    status: {
+      type: PgType.VARCHAR,
+      notNull: true,
+      default: 'pending'
+    },
+    type: {
+      type: PgType.VARCHAR,
+      notNull: true
+    },
+    created_at: {
+      type: PgType.TIMESTAMP,
+      notNull: true,
+      default: pgm.func('now()')
+    },
+    updated_at: {
+      type: PgType.TIMESTAMP,
+      notNull: true,
+      default: pgm.func('now()')
+    }
+  })
+
+  pgm.createIndex('community_requests', ['community_id', 'type', 'status'], {
+    name: 'idx_community_requests_community_type_status'
+  })
+
+  pgm.createIndex('community_requests', ['community_id', 'status'], {
+    name: 'idx_community_requests_community_status'
+  })
+
+  pgm.createIndex('community_requests', ['member_address', 'type', 'status'], {
+    name: 'idx_community_requests_member_type_status'
+  })
+
+  pgm.createIndex('community_requests', ['community_id', 'member_address', 'type', 'status'], {
+    name: 'idx_community_requests_community_member_type_status'
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('community_requests', 'idx_community_requests_community_type_status')
+  pgm.dropIndex('community_requests', 'idx_community_requests_community_status')
+  pgm.dropIndex('community_requests', 'idx_community_requests_member_type_status')
+  pgm.dropIndex('community_requests', 'idx_community_requests_community_member_type_status')
+
+  pgm.dropTable('community_requests')
+}

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -46,7 +46,10 @@ import {
   CommunityPublicInformation,
   MemberCommunity,
   BannedMember,
-  CommunityPlace
+  CommunityPlace,
+  CommunityRequestType,
+  CommunityRequest,
+  GetCommunityRequestsOptions
 } from '../logic/community'
 import { Pagination } from './entities'
 import { Subscribers, SubscriptionEventsEmitter } from './rpc'
@@ -189,6 +192,16 @@ export interface ICommunitiesDatabaseComponent {
     communityId: string,
     updates: Partial<Pick<CommunityDB, 'name' | 'description' | 'private'>>
   ): Promise<Community>
+  createCommunityRequest(
+    communityId: string,
+    memberAddress: EthAddress,
+    type: CommunityRequestType
+  ): Promise<CommunityRequest>
+  getCommunityRequests(communityId: string, filters: GetCommunityRequestsOptions): Promise<CommunityRequest[]>
+  getCommunityRequestsCount(
+    communityId: string,
+    filters: Pick<GetCommunityRequestsOptions, 'status' | 'type'>
+  ): Promise<number>
 }
 
 export interface IVoiceDatabaseComponent {

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -49,7 +49,8 @@ import {
   ICommunityPlacesComponent,
   ICommunityRolesComponent,
   ICommunityEventsComponent,
-  ICommunityThumbnailComponent
+  ICommunityThumbnailComponent,
+  ICommunityRequestsComponent
 } from '../logic/community'
 import { ISettingsComponent } from '../logic/settings'
 import { IVoiceComponent } from '../logic/voice'
@@ -88,6 +89,7 @@ export type BaseComponents = {
   communityEvents: ICommunityEventsComponent
   communityBroadcaster: ICommunityBroadcasterComponent
   communityThumbnail: ICommunityThumbnailComponent
+  communityRequests: ICommunityRequestsComponent
   config: IConfigComponent
   email: IEmailComponent
   expirePrivateVoiceChatJob?: IJobComponent

--- a/test/components.ts
+++ b/test/components.ts
@@ -53,6 +53,7 @@ import { createVoiceComponent } from '../src/logic/voice'
 import { createCommunityVoiceComponent } from '../src/logic/community-voice'
 import { createCommunityVoiceChatCacheComponent } from '../src/logic/community-voice/community-voice-cache'
 import { createCommunityVoiceChatPollingComponent } from '../src/logic/community-voice/community-voice-polling'
+import { createCommunityRequestsComponent } from '../src/logic/community/requests'
 import { createSettingsComponent } from '../src/logic/settings'
 import { createMessageProcessorComponent, createMessagesConsumerComponent } from '../src/logic/sqs'
 import { createReferralDBComponent } from '../src/adapters/referral-db'
@@ -217,6 +218,7 @@ async function initComponents(): Promise<TestComponents> {
     communityThumbnail,
     communityPlaces
   })
+  const communityRequests = createCommunityRequestsComponent({ communitiesDb, logs })
   const rpcServer = await createRpcServerComponent({
     logs,
     pubsub,
@@ -286,6 +288,7 @@ async function initComponents(): Promise<TestComponents> {
     communityEvents,
     communityBroadcaster,
     communityThumbnail,
+    communityRequests,
     config,
     email,
     fetcher,

--- a/test/integration/create-community-request-controller.spec.ts
+++ b/test/integration/create-community-request-controller.spec.ts
@@ -1,0 +1,471 @@
+import { CommunityRequestType, CommunityRequestStatus } from '../../src/logic/community'
+import { CommunityRole } from '../../src/types/entities'
+import { test } from '../components'
+import { createTestIdentity, Identity, makeAuthenticatedRequest, createAuthHeaders } from './utils/auth'
+import { mockCommunity } from '../mocks/communities'
+import { randomUUID } from 'crypto'
+import { EthAddress } from '@dcl/schemas'
+
+test('Create Community Request Controller', function ({ components, spyComponents }) {
+  const makeRequest = makeAuthenticatedRequest(components)
+
+  describe('when creating a community request', () => {
+    let identity: Identity
+    let communityId: string
+    let ownerAddress: string
+    let targetAddress: string
+
+    beforeEach(async () => {
+      identity = await createTestIdentity()
+      ownerAddress = identity.realAccount.address.toLowerCase()
+      targetAddress = '0x0000000000000000000000000000000000000002'
+    })
+
+    afterEach(async () => {
+      // Clean up community requests
+      await components.communitiesDbHelper.forceCommunityRemoval(communityId)
+    })
+
+    describe('when the request is not authenticated', () => {
+      it('should return 400 status code', async () => {
+        const { localHttpFetch } = components
+        const response = await localHttpFetch.fetch(`/v1/communities/${communityId}/requests`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            targetedAddress: targetAddress,
+            type: CommunityRequestType.Invite
+          })
+        })
+        expect(response.status).toBe(400)
+      })
+    })
+
+    describe('when the request is authenticated', () => {
+      describe('and targetedAddress is missing in body', () => {
+        it('should return 400 status code', async () => {
+          const response = await makeRequest(identity, `/v1/communities/${communityId}/requests`, 'POST', {
+            type: CommunityRequestType.Invite
+          })
+          expect(response.status).toBe(400)
+        })
+      })
+
+      describe('and type is missing in body', () => {
+        it('should return 400 status code', async () => {
+          const response = await makeRequest(identity, `/v1/communities/${communityId}/requests`, 'POST', {
+            targetedAddress: targetAddress
+          })
+          expect(response.status).toBe(400)
+        })
+      })
+
+      describe('and targetedAddress is not a valid EthAddress', () => {
+        it('should return 400 status code', async () => {
+          const response = await makeRequest(identity, `/v1/communities/${communityId}/requests`, 'POST', {
+            targetedAddress: 'invalid-address',
+            type: CommunityRequestType.Invite
+          })
+          expect(response.status).toBe(400)
+          const body = await response.json()
+          expect(body.message).toBe('Invalid targeted address')
+        })
+      })
+
+      describe('and targetedAddress is empty string', () => {
+        it('should return 400 status code', async () => {
+          const response = await makeRequest(identity, `/v1/communities/${communityId}/requests`, 'POST', {
+            targetedAddress: '',
+            type: CommunityRequestType.Invite
+          })
+          expect(response.status).toBe(400)
+          const body = await response.json()
+          expect(body.message).toBe('Missing targetedAddress or type field')
+        })
+      })
+
+      describe('and type is not a valid CommunityRequestType', () => {
+        it('should return 400 status code', async () => {
+          const response = await makeRequest(identity, `/v1/communities/${communityId}/requests`, 'POST', {
+            targetedAddress: targetAddress,
+            type: 'invalid-type'
+          })
+          expect(response.status).toBe(400)
+        })
+      })
+
+      describe('and the request body is not valid JSON', () => {
+        it('should return 400 status code', async () => {
+          const { localHttpFetch } = components
+          const response = await localHttpFetch.fetch(`/v1/communities/${communityId}/requests`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...createAuthHeaders('POST', `/v1/communities/${communityId}/requests`, {}, identity)
+            },
+            body: 'invalid json'
+          })
+          expect(response.status).toBe(400)
+        })
+
+        describe('when body is empty', () => {
+          it('should return 400 status code', async () => {
+            const { localHttpFetch } = components
+            const response = await localHttpFetch.fetch(`/v1/communities/${communityId}/requests`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                ...createAuthHeaders('POST', `/v1/communities/${communityId}/requests`, {}, identity)
+              },
+              body: ''
+            })
+            expect(response.status).toBe(400)
+          })
+        })
+      })
+
+      describe('and the request body is valid', () => {
+        let requestBody: { targetedAddress: string; type: CommunityRequestType }
+
+        beforeEach(async () => {
+          requestBody = {
+            targetedAddress: targetAddress,
+            type: CommunityRequestType.Invite
+          }
+        })
+
+        describe('and request type is invite', () => {
+          beforeEach(() => {
+            requestBody = {
+              ...requestBody,
+              type: CommunityRequestType.Invite
+            }
+          })
+
+          describe('when community exists', () => {
+            beforeEach(async () => {
+              const result = await components.communitiesDb.createCommunity(
+                mockCommunity({
+                  name: 'Test Community',
+                  description: 'Test Description',
+                  owner_address: ownerAddress,
+                  private: false
+                })
+              )
+              communityId = result.id
+
+              await components.communitiesDb.addCommunityMember({
+                communityId,
+                memberAddress: ownerAddress,
+                role: CommunityRole.Owner
+              })
+            })
+
+            describe('and community is private', () => {
+              beforeEach(async () => {
+                await components.communitiesDb.updateCommunity(communityId, {
+                  private: true
+                })
+              })
+
+              describe('and user is not a member', () => {
+                describe('and no pending invite exists', () => {
+                  it('should return 200 status code and return the created request', async () => {
+                    const response = await makeRequest(
+                      identity,
+                      `/v1/communities/${communityId}/requests`,
+                      'POST',
+                      requestBody
+                    )
+                    expect(response.status).toBe(200)
+                    const body = await response.json()
+                    expect(body.data).toMatchObject({
+                      id: expect.any(String),
+                      communityId,
+                      memberAddress: targetAddress,
+                      type: CommunityRequestType.Invite,
+                      status: CommunityRequestStatus.Pending
+                    })
+                  })
+                })
+
+                describe('when a pending invite already exists', () => {
+                  beforeEach(async () => {
+                    await components.communitiesDb.createCommunityRequest(
+                      communityId,
+                      targetAddress as EthAddress,
+                      CommunityRequestType.Invite
+                    )
+                  })
+
+                  it('should return 400 status code', async () => {
+                    const response = await makeRequest(
+                      identity,
+                      `/v1/communities/${communityId}/requests`,
+                      'POST',
+                      requestBody
+                    )
+                    expect(response.status).toBe(400)
+                    const body = await response.json()
+                    expect(body.message).toBe('Request already exists')
+                  })
+                })
+              })
+
+              describe('when user is already a member', () => {
+                beforeEach(async () => {
+                  await components.communitiesDb.addCommunityMember({
+                    communityId,
+                    memberAddress: targetAddress,
+                    role: CommunityRole.Member
+                  })
+                })
+
+                it('should return 400 status code', async () => {
+                  const response = await makeRequest(
+                    identity,
+                    `/v1/communities/${communityId}/requests`,
+                    'POST',
+                    requestBody
+                  )
+                  expect(response.status).toBe(400)
+                  const body = await response.json()
+                  expect(body.message).toContain('User cannot join since it is already a member')
+                })
+              })
+            })
+
+            describe('and community is public', () => {
+              beforeEach(async () => {
+                await components.communitiesDb.updateCommunity(communityId, {
+                  private: false
+                })
+              })
+
+              describe('and user is not a member', () => {
+                describe('and no pending invite exists', () => {
+                  it('should return 200 status code and return the created request', async () => {
+                    const response = await makeRequest(
+                      identity,
+                      `/v1/communities/${communityId}/requests`,
+                      'POST',
+                      requestBody
+                    )
+                    expect(response.status).toBe(200)
+                    const body = await response.json()
+                    expect(body.data).toMatchObject({
+                      id: expect.any(String),
+                      communityId,
+                      memberAddress: targetAddress,
+                      type: CommunityRequestType.Invite,
+                      status: CommunityRequestStatus.Pending
+                    })
+                  })
+                })
+
+                describe('when a pending invite already exists', () => {
+                  beforeEach(async () => {
+                    await components.communitiesDb.createCommunityRequest(
+                      communityId,
+                      targetAddress as EthAddress,
+                      CommunityRequestType.Invite
+                    )
+                  })
+
+                  it('should return 400 status code', async () => {
+                    const response = await makeRequest(
+                      identity,
+                      `/v1/communities/${communityId}/requests`,
+                      'POST',
+                      requestBody
+                    )
+                    expect(response.status).toBe(400)
+                    const body = await response.json()
+                    expect(body.message).toBe('Request already exists')
+                  })
+                })
+              })
+
+              describe('when user is already a member', () => {
+                beforeEach(async () => {
+                  await components.communitiesDb.addCommunityMember({
+                    communityId,
+                    memberAddress: targetAddress,
+                    role: CommunityRole.Member
+                  })
+                })
+
+                it('should return 400 status code', async () => {
+                  const response = await makeRequest(
+                    identity,
+                    `/v1/communities/${communityId}/requests`,
+                    'POST',
+                    requestBody
+                  )
+                  expect(response.status).toBe(400)
+                  const body = await response.json()
+                  expect(body.message).toContain('User cannot join since it is already a member')
+                })
+              })
+            })
+          })
+
+          describe('when community does not exist', () => {
+            it('should return 404 status code', async () => {
+              const nonExistentId = randomUUID()
+              const response = await makeRequest(
+                identity,
+                `/v1/communities/${nonExistentId}/requests`,
+                'POST',
+                requestBody
+              )
+              expect(response.status).toBe(404)
+            })
+          })
+        })
+
+        describe('and request type is request_to_join', () => {
+          beforeEach(() => {
+            requestBody = {
+              ...requestBody,
+              type: CommunityRequestType.RequestToJoin
+            }
+          })
+          describe('when community exists', () => {
+            beforeEach(async () => {
+              const result = await components.communitiesDb.createCommunity(
+                mockCommunity({
+                  name: 'Test Community',
+                  description: 'Test Description',
+                  owner_address: ownerAddress,
+                  private: false
+                })
+              )
+              communityId = result.id
+
+              await components.communitiesDb.addCommunityMember({
+                communityId,
+                memberAddress: ownerAddress,
+                role: CommunityRole.Owner
+              })
+            })
+
+            describe('and community is private', () => {
+              beforeEach(async () => {
+                await components.communitiesDb.updateCommunity(communityId, {
+                  private: true
+                })
+              })
+
+              describe('and user is not a member', () => {
+                describe('and no pending request exists', () => {
+                  it('should return 200 status code and return the created request', async () => {
+                    const response = await makeRequest(
+                      identity,
+                      `/v1/communities/${communityId}/requests`,
+                      'POST',
+                      requestBody
+                    )
+                    expect(response.status).toBe(200)
+                    const body = await response.json()
+                    expect(body.data).toMatchObject({
+                      id: expect.any(String),
+                      communityId,
+                      memberAddress: targetAddress,
+                      type: CommunityRequestType.RequestToJoin,
+                      status: CommunityRequestStatus.Pending
+                    })
+                  })
+                })
+
+                describe('and a pending request already exists', () => {
+                  beforeEach(async () => {
+                    await components.communitiesDb.createCommunityRequest(
+                      communityId,
+                      targetAddress as EthAddress,
+                      CommunityRequestType.RequestToJoin
+                    )
+                  })
+
+                  it('should return 400 status code', async () => {
+                    const response = await makeRequest(
+                      identity,
+                      `/v1/communities/${communityId}/requests`,
+                      'POST',
+                      requestBody
+                    )
+                    expect(response.status).toBe(400)
+                    const body = await response.json()
+                    expect(body.message).toBe('Request already exists')
+                  })
+                })
+              })
+
+              describe('and user is already a member', () => {
+                beforeEach(async () => {
+                  await components.communitiesDb.addCommunityMember({
+                    communityId,
+                    memberAddress: targetAddress,
+                    role: CommunityRole.Member
+                  })
+                })
+
+                it('should return 400 status code', async () => {
+                  const response = await makeRequest(
+                    identity,
+                    `/v1/communities/${communityId}/requests`,
+                    'POST',
+                    requestBody
+                  )
+                  expect(response.status).toBe(400)
+                  const body = await response.json()
+                  expect(body.message).toContain('User cannot join since it is already a member')
+                })
+              })
+            })
+
+            describe('and community is public', () => {
+              beforeEach(async () => {
+                await components.communitiesDb.updateCommunity(communityId, {
+                  private: false
+                })
+              })
+
+              it('should return 400 status code', async () => {
+                const response = await makeRequest(
+                  identity,
+                  `/v1/communities/${communityId}/requests`,
+                  'POST',
+                  requestBody
+                )
+                expect(response.status).toBe(400)
+                const body = await response.json()
+                expect(body.message).toBe('Public communities do not accept requests to join')
+              })
+            })
+          })
+
+          describe('when community does not exist', () => {
+            beforeEach(async () => {
+              communityId = randomUUID()
+            })
+
+            it('should return 404 status code', async () => {
+              const response = await makeRequest(
+                identity,
+                `/v1/communities/${communityId}/requests`,
+                'POST',
+                requestBody
+              )
+              expect(response.status).toBe(404)
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
+

--- a/test/mocks/components/communities-db.ts
+++ b/test/mocks/components/communities-db.ts
@@ -31,5 +31,8 @@ export const mockCommunitiesDB: jest.Mocked<ICommunitiesDatabaseComponent> = {
   getBannedMembers: jest.fn(),
   getBannedMembersCount: jest.fn(),
   updateMemberRole: jest.fn(),
-  updateCommunity: jest.fn()
+  updateCommunity: jest.fn(),
+  createCommunityRequest: jest.fn(),
+  getCommunityRequests: jest.fn(),
+  getCommunityRequestsCount: jest.fn()
 }

--- a/test/unit/logic/community-members.spec.ts
+++ b/test/unit/logic/community-members.spec.ts
@@ -1,4 +1,4 @@
-import { CommunityRole, IPublisherComponent } from '../../../src/types'
+import { CommunityRole } from '../../../src/types'
 import { NotAuthorizedError } from '@dcl/platform-server-commons'
 import { CommunityNotFoundError } from '../../../src/logic/community/errors'
 import { mockCommunitiesDB } from '../../mocks/components/communities-db'
@@ -11,7 +11,6 @@ import { CommunityMember, CommunityMemberProfile } from '../../../src/logic/comm
 import { IPeersStatsComponent } from '../../../src/logic/peers-stats'
 import { ConnectivityStatus } from '@dcl/protocol/out-js/decentraland/social_service/v2/social_service_v2.gen'
 import { COMMUNITY_MEMBER_STATUS_UPDATES_CHANNEL } from '../../../src/adapters/pubsub'
-import { mockSns } from '../../mocks/components/sns'
 import { Events } from '@dcl/schemas'
 
 describe('Community Members Component', () => {

--- a/test/unit/logic/community-requests.spec.ts
+++ b/test/unit/logic/community-requests.spec.ts
@@ -1,0 +1,309 @@
+import { randomUUID } from 'crypto'
+import {
+  Community,
+  CommunityNotFoundError,
+  CommunityPrivacyEnum,
+  CommunityRequest,
+  CommunityRequestStatus,
+  CommunityRequestType,
+  ICommunityRequestsComponent,
+  InvalidCommunityRequestError
+} from '../../../src/logic/community'
+import { createCommunityRequestsComponent } from '../../../src/logic/community/requests'
+import { mockLogs } from '../../mocks/components'
+import { mockCommunitiesDB } from '../../mocks/components/communities-db'
+import { CommunityRole } from '../../../src/types'
+
+describe('Community Requests Component', () => {
+  let communityRequestsComponent: ICommunityRequestsComponent
+  let type: CommunityRequestType
+  let userAddress: string
+
+  beforeEach(() => {
+    communityRequestsComponent = createCommunityRequestsComponent({
+      communitiesDb: mockCommunitiesDB,
+      logs: mockLogs
+    })
+
+    userAddress = '0x1234567890123456789012345678901234567890'
+  })
+
+  describe('when community does not exist', () => {
+    beforeEach(() => {
+      mockCommunitiesDB.getCommunity.mockResolvedValueOnce(null)
+    })
+
+    it('should throw a CommunityNotFoundError', () => {
+      expect(
+        communityRequestsComponent.createCommunityRequest(randomUUID(), userAddress, CommunityRequestType.RequestToJoin)
+      ).rejects.toThrow(CommunityNotFoundError)
+    })
+  })
+
+  describe('when community exists', () => {
+    let community: Community & { role: CommunityRole }
+    let expectedCreatedRequest: CommunityRequest
+    beforeEach(() => {
+      community = {
+        id: randomUUID(),
+        name: 'Mock Community',
+        description: 'Mock Description',
+        ownerAddress: userAddress,
+        privacy: CommunityPrivacyEnum.Public,
+        active: true,
+        role: CommunityRole.None
+      }
+      mockCommunitiesDB.getCommunity.mockResolvedValueOnce(community)
+      mockCommunitiesDB.createCommunityRequest.mockImplementation(() => {
+        return Promise.resolve(expectedCreatedRequest)
+      })
+    })
+
+    describe('and community is public', () => {
+      beforeEach(() => {
+        community.privacy = CommunityPrivacyEnum.Public
+      })
+      
+      describe('and request type is RequestToJoin', () => { 
+        beforeEach(() => {
+          type = CommunityRequestType.RequestToJoin
+        })
+
+        it('should throw an InvalidCommunityRequestError with correct message', () => {
+          expect(communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)).rejects.toThrow(
+            `Public communities do not accept requests to join`
+          )
+        })
+
+        it('should throw an InvalidCommunityRequestError', () => {
+          expect(communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)).rejects.toThrow(
+            InvalidCommunityRequestError
+          )
+        })
+      })
+
+      describe('and request type is Invite', () => {
+        beforeEach(() => {
+          type = CommunityRequestType.Invite
+          expectedCreatedRequest = {
+            id: randomUUID(),
+            communityId: community.id,
+            memberAddress: userAddress,
+            type,
+            status: CommunityRequestStatus.Pending
+          }
+        })
+        
+        describe('and user do not belong to community', () => {
+          beforeEach(() => {
+            community.role = CommunityRole.None
+          })
+          
+          describe('and there are no pending requests for the user', () => {
+            beforeEach(() => {
+              mockCommunitiesDB.getCommunityRequests.mockResolvedValueOnce([])
+            })
+            
+            it('should create and return the request as pending', async () => {
+              const result = await communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)
+              expect(result).toEqual({
+                id: expect.any(String),
+                communityId: community.id,
+                memberAddress: userAddress,
+                type,
+                status: CommunityRequestStatus.Pending
+              })
+              expect(mockCommunitiesDB.createCommunityRequest).toHaveBeenCalledWith(community.id, userAddress, type)
+            })
+          })
+
+          describe('and there is a pending invite for the user', () => {
+            beforeEach(() => {
+              mockCommunitiesDB.getCommunityRequests.mockResolvedValueOnce([expectedCreatedRequest])
+            })
+            
+            it('should throw an InvalidCommunityRequestError with correct message', () => {
+              expect(
+                communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)
+              ).rejects.toThrow('Request already exists')
+            })
+
+            it('should throw an InvalidCommunityRequestError', () => {
+              expect(
+                communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)
+              ).rejects.toThrow(InvalidCommunityRequestError)
+            })
+          })
+        })
+
+        describe('and user already belongs to community', () => {
+          beforeEach(() => {
+            community.role = CommunityRole.Member
+          })
+          
+          it('should throw an InvalidCommunityRequestError with correct message', () => {
+            expect(communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)).rejects.toThrow(
+              `User cannot join since it is already a member of the community: ${community.name}`
+            )
+          })
+
+          it('should throw an InvalidCommunityRequestError', () => {
+            expect(communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)).rejects.toThrow(
+              InvalidCommunityRequestError
+            )
+          })
+        })
+      })
+    })
+
+    describe('and community is private', () => {
+      beforeEach(() => {
+        community.privacy = CommunityPrivacyEnum.Private
+      })
+
+      describe('and request type is RequestToJoin', () => {
+        beforeEach(() => {
+          type = CommunityRequestType.RequestToJoin
+          expectedCreatedRequest = {
+            id: randomUUID(),
+            communityId: community.id,
+            memberAddress: userAddress,
+            type,
+            status: CommunityRequestStatus.Pending
+          }
+        })
+
+        describe('and user do not belong to community', () => {
+          beforeEach(() => {
+            community.role = CommunityRole.None
+          })
+
+          describe('and there are no pending requests for the user', () => {
+            beforeEach(() => {
+              mockCommunitiesDB.getCommunityRequests.mockResolvedValueOnce([])
+            })
+
+            it('should create and return the request as pending', async () => {
+              const result = await communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)
+              expect(result).toEqual({
+                id: expect.any(String),
+                communityId: community.id,
+                memberAddress: userAddress,
+                type,
+                status: CommunityRequestStatus.Pending
+              })
+              expect(mockCommunitiesDB.createCommunityRequest).toHaveBeenCalledWith(community.id, userAddress, type)
+            })
+          })
+
+          describe('and there is a pending request_to_join for the user', () => {
+            beforeEach(() => {
+              mockCommunitiesDB.getCommunityRequests.mockResolvedValueOnce([expectedCreatedRequest])
+            })
+
+            it('should throw an InvalidCommunityRequestError with correct message', () => {
+              expect(
+                communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)
+              ).rejects.toThrow('Request already exists')
+            })
+
+            it('should throw an InvalidCommunityRequestError', () => {
+              expect(
+                communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)
+              ).rejects.toThrow(InvalidCommunityRequestError)
+            })
+          })
+        })
+
+        describe('and user already belongs to community', () => {
+          beforeEach(() => {
+            community.role = CommunityRole.Member
+          })
+
+          it('should throw an InvalidCommunityRequestError with correct message', () => {
+            expect(communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)).rejects.toThrow(
+              `User cannot join since it is already a member of the community: ${community.name}`
+            )
+          })
+
+          it('should throw an InvalidCommunityRequestError', () => {
+            expect(communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)).rejects.toThrow(
+              InvalidCommunityRequestError
+            )
+          })
+        })
+      })
+
+      describe('and request type is Invite', () => {
+        beforeEach(() => {
+          type = CommunityRequestType.Invite
+          expectedCreatedRequest = {
+            id: randomUUID(),
+            communityId: community.id,
+            memberAddress: userAddress,
+            type,
+            status: CommunityRequestStatus.Pending
+          }
+        })
+
+        describe('and user do not belong to community', () => {
+          beforeEach(() => {
+            community.role = CommunityRole.None
+          })
+
+          describe('and there are no pending requests for the user', () => {
+            beforeEach(() => {
+              mockCommunitiesDB.getCommunityRequests.mockResolvedValueOnce([])
+            })
+
+            it('should create and return the request as pending', async () => {
+              const result = await communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)
+              expect(result).toEqual({
+                id: expect.any(String),
+                communityId: community.id,
+                memberAddress: userAddress,
+                type,
+                status: CommunityRequestStatus.Pending
+              })
+              expect(mockCommunitiesDB.createCommunityRequest).toHaveBeenCalledWith(community.id, userAddress, type)
+            })
+          })
+
+          describe('and there is a pending invite for the user', () => {
+            beforeEach(() => {
+              mockCommunitiesDB.getCommunityRequests.mockResolvedValueOnce([expectedCreatedRequest])
+            })
+
+            it('should throw an InvalidCommunityRequestError with correct message', () => {
+              expect(
+                communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)
+              ).rejects.toThrow('Request already exists')
+            })
+
+            it('should throw an InvalidCommunityRequestError', () => {
+              expect(
+                communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)
+              ).rejects.toThrow(InvalidCommunityRequestError)
+            })
+          })
+        })
+
+        describe('and user already belongs to community', () => {
+          beforeEach(() => {
+            community.role = CommunityRole.Member
+          })
+
+          it('should throw an InvalidCommunityRequestError with correct message', () => {
+            expect(communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)).rejects.toThrow(
+              `User cannot join since it is already a member of the community: ${community.name}`
+            )
+          })
+
+          it('should throw an InvalidCommunityRequestError', () => {
+            expect(communityRequestsComponent.createCommunityRequest(community.id, userAddress, type)).rejects.toThrow(InvalidCommunityRequestError)
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
# Create Community Request Endpoint
## Intention

This endpoint allows users to create community requests for either:
- **Invites**: Community owners/members can invite other users to join their community
- **Request to Join**: Users can request to join a private community

## Restrictions

- **Authentication Required**: All requests must be authenticated
- **Community Existence**: Community must exist
- **Privacy Rules**: 
  - Public communities do not accept `request_to_join` requests
  - Private communities accept both invite and request_to_join
- **Membership Validation**: 
  - Cannot invite/request users who are already members
  - Cannot create duplicate pending requests

## New Endpoint Contract

**Path:** `POST /v1/communities/:id/requests`

**Request Body:**
```typescript
{
  "targetedAddress": "0x...",
  "type": "invite" | "request_to_join"
}
```

**Response:**
```typescript
{
  "data": {
    "id": "uuid",
    "communityId": "uuid", 
    "memberAddress": "0x...",
    "type": "invite" | "request_to_join",
    "status": "pending"
  }
}
```