### PR TITLE
feat: adjust permissions on community call actions

### DIFF
--- a/src/controllers/handlers/rpc/kick-player-from-community-voice-chat.ts
+++ b/src/controllers/handlers/rpc/kick-player-from-community-voice-chat.ts
@@ -45,12 +45,8 @@ export function kickPlayerFromCommunityVoiceChatService({
         throw new CommunityVoiceChatPermissionError('Only community owners and moderators can kick players')
       }
 
-      // Verify the target user is a member of the community
-      const targetUserRole = await communitiesDb.getCommunityMemberRole(request.communityId, request.userAddress)
-      if (targetUserRole === CommunityRole.None) {
-        throw new UserNotCommunityMemberError(request.userAddress, request.communityId)
-      }
-
+      // For kicking: no restrictions, moderators/owners can kick anyone in voice chat
+      // Let comms-gatekeeper validate if user is actually in voice chat
       logger.info('Permission check passed: moderator/owner kicking player', {
         communityId: request.communityId,
         actingUserRole,

--- a/src/logic/community-voice/index.ts
+++ b/src/logic/community-voice/index.ts
@@ -1,3 +1,4 @@
 export * from './community-voice'
 export * from './errors'
 export * from './types'
+export * from './validation'

--- a/src/logic/community-voice/validation.ts
+++ b/src/logic/community-voice/validation.ts
@@ -1,0 +1,39 @@
+import { CommunityRole } from '../../types/entities'
+import { UserNotCommunityMemberError } from './errors'
+import { ICommunitiesDatabaseComponent } from '../../types/components'
+import { Community } from '../community/types'
+
+/**
+ * Helper function to validate target user permissions for voice chat operations (promote/demote) based on community privacy
+ * @param communitiesDb - Communities database adapter
+ * @param community - Community object with privacy information
+ * @param communityId - Community ID
+ * @param targetUserAddress - Target user address
+ * @returns Promise<void> - Throws error if validation fails
+ */
+export async function validateCommunityVoiceChatTargetUser(
+  communitiesDb: ICommunitiesDatabaseComponent,
+  community: Community,
+  communityId: string,
+  targetUserAddress: string
+): Promise<void> {
+  // Validation logic based on community type
+  if (community.privacy === 'private') {
+    // For private communities: user must be member AND NOT banned
+    const targetUserRole = await communitiesDb.getCommunityMemberRole(communityId, targetUserAddress)
+
+    // User must be a member first
+    if (targetUserRole === CommunityRole.None) {
+      throw new UserNotCommunityMemberError(targetUserAddress, communityId)
+    }
+
+    // If user is a member, check they are not banned
+    const isTargetBanned = await communitiesDb.isMemberBanned(communityId, targetUserAddress)
+    if (isTargetBanned) {
+      throw new UserNotCommunityMemberError(targetUserAddress, communityId)
+    }
+  } else {
+    // For public communities: no restrictions, anyone in voice chat can be promoted/demoted
+    // Let comms-gatekeeper validate if user is actually in voice chat
+  }
+}

--- a/test/integration/rpc-server-controller.spec.ts
+++ b/test/integration/rpc-server-controller.spec.ts
@@ -1050,7 +1050,8 @@ test('RPC Server Controller', function ({ components, stubComponents }) {
             communityId,
             rpcClient.authAddress.toLowerCase()
           )
-          expect(communitiesDbSpy.getCommunityMemberRole).toHaveBeenCalledWith(communityId, targetMemberAddress)
+          // For public communities, no additional validation calls are made for target user
+          expect(communitiesDbSpy.getCommunity).toHaveBeenCalledWith(communityId, rpcClient.authAddress.toLowerCase())
 
           // Verify external service calls
           expect(commsGatekeeperSpy.promoteSpeakerInCommunityVoiceChat).toHaveBeenCalledWith(
@@ -1104,7 +1105,7 @@ test('RPC Server Controller', function ({ components, stubComponents }) {
             communityId,
             rpcClient.authAddress.toLowerCase()
           )
-          expect(communitiesDbSpy.getCommunityMemberRole).toHaveBeenCalledWith(communityId, targetMemberAddress)
+          // For kick operations, no validation is performed on target user
 
           // Verify external service calls
           expect(commsGatekeeperSpy.kickUserFromCommunityVoiceChat).toHaveBeenCalledWith(


### PR DESCRIPTION
This PR changes the logic to:
- for kicking, kick the user no matter what, if the community is private/public it doesn't matter.
- for promoting/demoting: always if public. If private, it needs to be part of the community and not be banned.