### PR TITLE
fix: only admins can change community name and places can be removed only if you own it

### DIFF
--- a/src/logic/community/communities.ts
+++ b/src/logic/community/communities.ts
@@ -342,6 +342,9 @@ export function createCommunityComponent(
       }
 
       await communityRoles.validatePermissionToEditCommunity(communityId, userAddress)
+      if (updates.name && updates.name.trim() !== existingCommunity.name.trim()) {
+        await communityRoles.validatePermissionToEditCommunityName(communityId, userAddress)
+      }
 
       if (Object.keys(updates).length === 0) {
         return {

--- a/src/logic/community/places.ts
+++ b/src/logic/community/places.ts
@@ -135,7 +135,11 @@ export async function createCommunityPlacesComponent(
       await validateCommunityExists(communityId)
       await validatePlaceExists(communityId, placeId)
       await validateOwnership([placeId], userAddress)
-      await communityRoles.validatePermissionToRemovePlacesFromCommunity(communityId, userAddress)
+      const memberRole = await communitiesDb.getCommunityMemberRole(communityId, userAddress)
+
+      if (memberRole !== CommunityRole.Owner) {
+        await communityRoles.validatePermissionToRemovePlacesFromCommunity(communityId, userAddress)
+      }
 
       await communitiesDb.removeCommunityPlace(communityId, placeId)
     },

--- a/src/logic/community/places.ts
+++ b/src/logic/community/places.ts
@@ -133,9 +133,8 @@ export async function createCommunityPlacesComponent(
 
     removePlace: async (communityId: string, userAddress: EthAddress, placeId: string): Promise<void> => {
       await validateCommunityExists(communityId)
-
       await validatePlaceExists(communityId, placeId)
-
+      await validateOwnership([placeId], userAddress)
       await communityRoles.validatePermissionToRemovePlacesFromCommunity(communityId, userAddress)
 
       await communitiesDb.removeCommunityPlace(communityId, placeId)

--- a/src/logic/community/roles.ts
+++ b/src/logic/community/roles.ts
@@ -5,6 +5,7 @@ import { ICommunityRolesComponent } from './types'
 
 export const OWNER_PERMISSIONS: CommunityPermission[] = [
   'edit_info',
+  'edit_name',
   'add_places',
   'remove_places',
   'accept_requests',
@@ -187,6 +188,7 @@ export function createCommunityRolesComponent(
       'accept and reject requests'
     ),
     validatePermissionToViewRequests: validatePermission('view_requests', 'view requests'),
-    validatePermissionToInviteUsers: validatePermission('invite_users', 'invite users')
+    validatePermissionToInviteUsers: validatePermission('invite_users', 'invite users'),
+    validatePermissionToEditCommunityName: validatePermission('edit_name', 'edit the community name')
   }
 }

--- a/src/logic/community/types.ts
+++ b/src/logic/community/types.ts
@@ -98,6 +98,7 @@ export interface ICommunityRolesComponent {
   validatePermissionToAcceptAndRejectRequests: (communityId: string, memberAddress: string) => Promise<void>
   validatePermissionToViewRequests: (communityId: string, memberAddress: string) => Promise<void>
   validatePermissionToInviteUsers: (communityId: string, memberAddress: string) => Promise<void>
+  validatePermissionToEditCommunityName: (communityId: string, memberAddress: string) => Promise<void>
 }
 
 export interface ICommunityEventsComponent {

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -77,6 +77,7 @@ export type Pagination = {
 
 export type CommunityPermission =
   | 'edit_info'
+  | 'edit_name'
   | 'add_places'
   | 'remove_places'
   | 'accept_requests'

--- a/test/integration/remove-community-place-controller.spec.ts
+++ b/test/integration/remove-community-place-controller.spec.ts
@@ -122,9 +122,6 @@ test('Remove Community Place Controller', function ({ components, spyComponents,
           ])
         })
 
-        afterEach(() => {
-          stubComponents.placesApi.getPlaces.reset()
-        })
         describe('and the user is not a member', () => {
           it('should respond with a 401 status code', async () => {
             const response = await makeRequest(identity, `/v1/communities/${communityId}/places/${placeId}`, 'DELETE')

--- a/test/integration/update-community-controller.spec.ts
+++ b/test/integration/update-community-controller.spec.ts
@@ -89,23 +89,100 @@ test('Update Community Controller', async function ({ components, stubComponents
             // Mock AI compliance to return compliant by default
             stubComponents.communityComplianceValidator.validateCommunityContent.resolves()
           })
-
           describe('when updating name only', () => {
-            it('should update the community name', async () => {
-              const response = await makeMultipartRequest(
-                identity,
-                `/v1/communities/${communityId}`,
-                {
-                  name: 'Updated Community Name'
-                },
-                'PUT'
-              )
+            describe('and the user is the community owner', () => {
+              it('should update the community name', async () => {
+                const response = await makeMultipartRequest(
+                  identity,
+                  `/v1/communities/${communityId}`,
+                  {
+                    name: 'Updated Community Name'
+                  },
+                  'PUT'
+                )
 
-              expect(response.status).toBe(200)
-              const body = await response.json()
-              expect(body.data.name).toBe('Updated Community Name')
-              expect(body.data.description).toBe('Original Description')
-              expect(body.message).toBe('Community updated successfully')
+                expect(response.status).toBe(200)
+                const body = await response.json()
+                expect(body.data.name).toBe('Updated Community Name')
+                expect(body.data.description).toBe('Original Description')
+                expect(body.message).toBe('Community updated successfully')
+              })
+            })
+
+            describe('and the user is not an administrator', () => {
+              let nonAdminIdentity: Identity
+              let nonAdminAddress: string
+
+              beforeEach(async () => {
+                nonAdminIdentity = await createTestIdentity()
+                nonAdminAddress = nonAdminIdentity.realAccount.address.toLowerCase()
+
+                // Add non-admin user as a regular member (no edit permissions)
+                await components.communitiesDb.addCommunityMember({
+                  communityId,
+                  memberAddress: nonAdminAddress,
+                  role: 'member' as any
+                })
+              })
+
+              afterEach(async () => {
+                if (nonAdminAddress) {
+                  await components.communitiesDbHelper.forceCommunityMemberRemoval(communityId, [nonAdminAddress])
+                }
+              })
+
+              it('should respond with a 401 and an authorization error for lack of edit_info permission', async () => {
+                const response = await makeMultipartRequest(
+                  nonAdminIdentity,
+                  `/v1/communities/${communityId}`,
+                  {
+                    name: 'Unauthorized Name Change'
+                  },
+                  'PUT'
+                )
+
+                expect(response.status).toBe(401)
+                const body = await response.json()
+                expect(body.error).toBe('Not Authorized')
+              })
+            })
+
+            describe('and the user is a moderator', () => {
+              let moderatorIdentity: Identity
+              let moderatorAddress: string
+
+              beforeEach(async () => {
+                moderatorIdentity = await createTestIdentity()
+                moderatorAddress = moderatorIdentity.realAccount.address.toLowerCase()
+
+                // Add moderator user
+                await components.communitiesDb.addCommunityMember({
+                  communityId,
+                  memberAddress: moderatorAddress,
+                  role: 'moderator' as any
+                })
+              })
+
+              afterEach(async () => {
+                if (moderatorAddress) {
+                  await components.communitiesDbHelper.forceCommunityMemberRemoval(communityId, [moderatorAddress])
+                }
+              })
+
+              it('should respond with a 401 and an authorization error for lack of edit_name permission', async () => {
+                const response = await makeMultipartRequest(
+                  moderatorIdentity,
+                  `/v1/communities/${communityId}`,
+                  {
+                    name: 'Moderator Unauthorized Name Change'
+                  },
+                  'PUT'
+                )
+
+                expect(response.status).toBe(401)
+                const body = await response.json()
+                expect(body.error).toBe('Not Authorized')
+              })
             })
           })
 
@@ -126,239 +203,321 @@ test('Update Community Controller', async function ({ components, stubComponents
               expect(body.data.description).toBe('Updated Description')
               expect(body.message).toBe('Community updated successfully')
             })
-          })
 
-          describe('when updating placeIds', () => {
-            let newPlaceIds: string[]
-            beforeEach(async () => {
-              newPlaceIds = [randomUUID(), randomUUID()]
+            describe('and the user is a moderator', () => {
+              let moderatorIdentity: Identity
+              let moderatorAddress: string
 
-              stubComponents.fetcher.fetch.onFirstCall().resolves({
-                ok: true,
-                status: 200,
-                json: () =>
-                  Promise.resolve({
-                    data: newPlaceIds.map((id) => ({
-                      id,
-                      title: 'Test Place',
-                      positions: ['0,0,0'],
-                      owner: identity.realAccount.address.toLowerCase()
-                    }))
-                  })
-              } as any)
-            })
+              beforeEach(async () => {
+                moderatorIdentity = await createTestIdentity()
+                moderatorAddress = moderatorIdentity.realAccount.address.toLowerCase()
 
-            afterEach(async () => {
-              await components.communitiesDb.removeCommunityPlace(communityId, newPlaceIds[0])
-              await components.communitiesDb.removeCommunityPlace(communityId, newPlaceIds[1])
-            })
+                // Add moderator user with edit_info permission
+                await components.communitiesDb.addCommunityMember({
+                  communityId,
+                  memberAddress: moderatorAddress,
+                  role: 'moderator' as any // Moderators can edit info but not names
+                })
+              })
 
-            it('should replace all community places with new ones', async () => {
-              const response = await makeMultipartRequest(
-                identity,
-                `/v1/communities/${communityId}`,
-                {
-                  placeIds: newPlaceIds
-                },
-                'PUT'
-              )
+              afterEach(async () => {
+                if (moderatorAddress) {
+                  await components.communitiesDbHelper.forceCommunityMemberRemoval(communityId, [moderatorAddress])
+                }
+              })
 
-              expect(response.status).toBe(200)
-              const body = await response.json()
-              expect(body.message).toBe('Community updated successfully')
-
-              const placesResponse = await makeRequest(identity, `/v1/communities/${communityId}/places`, 'GET')
-              expect(placesResponse.status).toBe(200)
-              const placesResult = await placesResponse.json()
-              expect(placesResult.data.results.map((p: { id: string }) => p.id)).toEqual(
-                expect.arrayContaining(newPlaceIds)
-              )
-            })
-
-            it('should remove all places when empty array is provided', async () => {
-              const response = await makeMultipartRequest(
-                identity,
-                `/v1/communities/${communityId}`,
-                {
-                  placeIds: []
-                },
-                'PUT'
-              )
-
-              expect(response.status).toBe(200)
-              const body = await response.json()
-              expect(body.message).toBe('Community updated successfully')
-
-              const placesResponse = await makeRequest(identity, `/v1/communities/${communityId}/places`, 'GET')
-              expect(placesResponse.status).toBe(200)
-              const placesResult = await placesResponse.json()
-              expect(placesResult.data.results).toHaveLength(0)
-            })
-          })
-
-          describe('when updating without placeIds field', () => {
-            it('should not modify places when placeIds field is not provided', async () => {
-              // First, add some places to the community
-              const initialPlaceIds = [randomUUID(), randomUUID()]
-
-              stubComponents.fetcher.fetch.onFirstCall().resolves({
-                ok: true,
-                status: 200,
-                json: () =>
-                  Promise.resolve({
-                    data: initialPlaceIds.map((id) => ({
-                      id,
-                      title: 'Test Place',
-                      positions: ['0,0,0'],
-                      owner: identity.realAccount.address.toLowerCase()
-                    }))
-                  })
-              } as any)
-
-              await makeMultipartRequest(
-                identity,
-                `/v1/communities/${communityId}`,
-                {
-                  placeIds: initialPlaceIds
-                },
-                'PUT'
-              )
-
-              // Verify places were added
-              let placesResponse = await makeRequest(identity, `/v1/communities/${communityId}/places`, 'GET')
-              expect(placesResponse.status).toBe(200)
-              let placesResult = await placesResponse.json()
-              expect(placesResult.data.results.map((p: { id: string }) => p.id)).toEqual(
-                expect.arrayContaining(initialPlaceIds)
-              )
-
-              // Now update without placeIds field
-              const response = await makeMultipartRequest(
-                identity,
-                `/v1/communities/${communityId}`,
-                {
-                  name: 'Updated Without Places'
-                },
-                'PUT'
-              )
-
-              expect(response.status).toBe(200)
-              const body = await response.json()
-              expect(body.data.name).toBe('Updated Without Places')
-              expect(body.message).toBe('Community updated successfully')
-
-              // Verify places remain unchanged
-              placesResponse = await makeRequest(identity, `/v1/communities/${communityId}/places`, 'GET')
-              expect(placesResponse.status).toBe(200)
-              placesResult = await placesResponse.json()
-              expect(placesResult.data.results.map((p: { id: string }) => p.id)).toEqual(
-                expect.arrayContaining(initialPlaceIds)
-              )
-
-              // Cleanup
-              for (const placeId of initialPlaceIds) {
-                await components.communitiesDb.removeCommunityPlace(communityId, placeId)
-              }
-            })
-          })
-
-          describe('when updating with thumbnail', () => {
-            beforeEach(async () => {
-              stubComponents.fetcher.fetch.onFirstCall().resolves({
-                ok: true,
-                status: 200,
-                json: () => Promise.resolve({})
-              } as any)
-            })
-
-            it('should update the community with new thumbnail and invalidate CDN cache', async () => {
-              const response = await makeMultipartRequest(
-                identity,
-                `/v1/communities/${communityId}`,
-                {
-                  name: 'Thumbnail Updated',
-                  thumbnailPath: require('path').join(__dirname, 'fixtures/example.png')
-                },
-                'PUT'
-              )
-
-              expect(response.status).toBe(200)
-              const body = await response.json()
-              expect(body.data.name).toBe('Thumbnail Updated')
-              expect(body.data.thumbnails).toBeDefined()
-              expect(body.data.thumbnails.raw).toBeDefined()
-              expect(body.message).toBe('Community updated successfully')
-              expect(stubComponents.cdnCacheInvalidator.invalidateThumbnail).toHaveBeenCalledWith(communityId)
-            })
-          })
-
-          describe('when updating multiple fields', () => {
-            it('should update all provided fields', async () => {
-              const response = await makeMultipartRequest(
-                identity,
-                `/v1/communities/${communityId}`,
-                {
-                  name: 'Multi Updated Name',
-                  description: 'Multi Updated Description'
-                },
-                'PUT'
-              )
-
-              expect(response.status).toBe(200)
-              const body = await response.json()
-              expect(body.data.name).toBe('Multi Updated Name')
-              expect(body.data.description).toBe('Multi Updated Description')
-              expect(body.message).toBe('Community updated successfully')
-            })
-          })
-
-          describe('when updating privacy', () => {
-            describe('and the user is the owner', () => {
-              it('should update the community privacy', async () => {
+              it('should allow updating description when not changing name', async () => {
                 const response = await makeMultipartRequest(
-                  identity,
+                  moderatorIdentity,
                   `/v1/communities/${communityId}`,
                   {
-                    privacy: CommunityPrivacyEnum.Private
+                    description: 'Description updated by moderator'
                   },
                   'PUT'
                 )
 
                 expect(response.status).toBe(200)
                 const body = await response.json()
-                expect(body.data.privacy).toBe(CommunityPrivacyEnum.Private)
+                expect(body.data.description).toBe('Description updated by moderator')
+                expect(body.data.name).toBe('Original Community')
                 expect(body.message).toBe('Community updated successfully')
               })
             })
+          })
 
-            describe('and the user is not the owner', () => {
-              beforeEach(async () => {
-                await components.communitiesDb.updateMemberRole(
-                  communityId,
-                  identity.realAccount.address,
-                  CommunityRole.Moderator
-                )
-              })
+          describe('when updating placeIds', () => {
+            let newPlaceIds: string[]
 
-              afterEach(async () => {
-                await components.communitiesDb.updateMemberRole(
-                  communityId,
-                  identity.realAccount.address,
-                  CommunityRole.Owner
-                )
-              })
-
-              it('should respond with a 401 status code', async () => {
+            describe('when updating name only', () => {
+              it('should update the community name', async () => {
                 const response = await makeMultipartRequest(
                   identity,
                   `/v1/communities/${communityId}`,
                   {
-                    privacy: CommunityPrivacyEnum.Private
+                    name: 'Updated Community Name'
                   },
                   'PUT'
                 )
 
-                expect(response.status).toBe(401)
+                expect(response.status).toBe(200)
+                const body = await response.json()
+                expect(body.data.name).toBe('Updated Community Name')
+                expect(body.data.description).toBe('Original Description')
+                expect(body.message).toBe('Community updated successfully')
+              })
+            })
+
+            describe('when updating description only', () => {
+              it('should update the community description', async () => {
+                const response = await makeMultipartRequest(
+                  identity,
+                  `/v1/communities/${communityId}`,
+                  {
+                    description: 'Updated Description'
+                  },
+                  'PUT'
+                )
+
+                expect(response.status).toBe(200)
+                const body = await response.json()
+                expect(body.data.name).toBe('Original Community')
+                expect(body.data.description).toBe('Updated Description')
+                expect(body.message).toBe('Community updated successfully')
+              })
+            })
+
+            describe('when updating placeIds', () => {
+              let newPlaceIds: string[]
+              beforeEach(async () => {
+                newPlaceIds = [randomUUID(), randomUUID()]
+
+                stubComponents.fetcher.fetch.onFirstCall().resolves({
+                  ok: true,
+                  status: 200,
+                  json: () =>
+                    Promise.resolve({
+                      data: newPlaceIds.map((id) => ({
+                        id,
+                        title: 'Test Place',
+                        positions: ['0,0,0'],
+                        owner: identity.realAccount.address.toLowerCase()
+                      }))
+                    })
+                } as any)
+              })
+
+              afterEach(async () => {
+                await components.communitiesDb.removeCommunityPlace(communityId, newPlaceIds[0])
+                await components.communitiesDb.removeCommunityPlace(communityId, newPlaceIds[1])
+              })
+
+              it('should replace all community places with new ones', async () => {
+                const response = await makeMultipartRequest(
+                  identity,
+                  `/v1/communities/${communityId}`,
+                  {
+                    placeIds: newPlaceIds
+                  },
+                  'PUT'
+                )
+
+                expect(response.status).toBe(200)
+                const body = await response.json()
+                expect(body.message).toBe('Community updated successfully')
+
+                const placesResponse = await makeRequest(identity, `/v1/communities/${communityId}/places`, 'GET')
+                expect(placesResponse.status).toBe(200)
+                const placesResult = await placesResponse.json()
+                expect(placesResult.data.results.map((p: { id: string }) => p.id)).toEqual(
+                  expect.arrayContaining(newPlaceIds)
+                )
+              })
+
+              it('should remove all places when empty array is provided', async () => {
+                const response = await makeMultipartRequest(
+                  identity,
+                  `/v1/communities/${communityId}`,
+                  {
+                    placeIds: []
+                  },
+                  'PUT'
+                )
+
+                expect(response.status).toBe(200)
+                const body = await response.json()
+                expect(body.message).toBe('Community updated successfully')
+
+                const placesResponse = await makeRequest(identity, `/v1/communities/${communityId}/places`, 'GET')
+                expect(placesResponse.status).toBe(200)
+                const placesResult = await placesResponse.json()
+                expect(placesResult.data.results).toHaveLength(0)
+              })
+            })
+
+            describe('when updating without placeIds field', () => {
+              it('should not modify places when placeIds field is not provided', async () => {
+                // First, add some places to the community
+                const initialPlaceIds = [randomUUID(), randomUUID()]
+
+                stubComponents.fetcher.fetch.onFirstCall().resolves({
+                  ok: true,
+                  status: 200,
+                  json: () =>
+                    Promise.resolve({
+                      data: initialPlaceIds.map((id) => ({
+                        id,
+                        title: 'Test Place',
+                        positions: ['0,0,0'],
+                        owner: identity.realAccount.address.toLowerCase()
+                      }))
+                    })
+                } as any)
+
+                await makeMultipartRequest(
+                  identity,
+                  `/v1/communities/${communityId}`,
+                  {
+                    placeIds: initialPlaceIds
+                  },
+                  'PUT'
+                )
+
+                // Verify places were added
+                let placesResponse = await makeRequest(identity, `/v1/communities/${communityId}/places`, 'GET')
+                expect(placesResponse.status).toBe(200)
+                let placesResult = await placesResponse.json()
+                expect(placesResult.data.results.map((p: { id: string }) => p.id)).toEqual(
+                  expect.arrayContaining(initialPlaceIds)
+                )
+
+                // Now update without placeIds field
+                const response = await makeMultipartRequest(
+                  identity,
+                  `/v1/communities/${communityId}`,
+                  {
+                    name: 'Updated Without Places'
+                  },
+                  'PUT'
+                )
+
+                expect(response.status).toBe(200)
+                const body = await response.json()
+                expect(body.data.name).toBe('Updated Without Places')
+                expect(body.message).toBe('Community updated successfully')
+
+                // Verify places remain unchanged
+                placesResponse = await makeRequest(identity, `/v1/communities/${communityId}/places`, 'GET')
+                expect(placesResponse.status).toBe(200)
+                placesResult = await placesResponse.json()
+                expect(placesResult.data.results.map((p: { id: string }) => p.id)).toEqual(
+                  expect.arrayContaining(initialPlaceIds)
+                )
+
+                // Cleanup
+                for (const placeId of initialPlaceIds) {
+                  await components.communitiesDb.removeCommunityPlace(communityId, placeId)
+                }
+              })
+            })
+
+            describe('when updating with thumbnail', () => {
+              beforeEach(async () => {
+                stubComponents.fetcher.fetch.onFirstCall().resolves({
+                  ok: true,
+                  status: 200,
+                  json: () => Promise.resolve({})
+                } as any)
+              })
+
+              it('should update the community with new thumbnail and invalidate CDN cache', async () => {
+                const response = await makeMultipartRequest(
+                  identity,
+                  `/v1/communities/${communityId}`,
+                  {
+                    name: 'Thumbnail Updated',
+                    thumbnailPath: require('path').join(__dirname, 'fixtures/example.png')
+                  },
+                  'PUT'
+                )
+
+                expect(response.status).toBe(200)
+                const body = await response.json()
+                expect(body.data.name).toBe('Thumbnail Updated')
+                expect(body.data.thumbnails).toBeDefined()
+                expect(body.data.thumbnails.raw).toBeDefined()
+                expect(body.message).toBe('Community updated successfully')
+                expect(stubComponents.cdnCacheInvalidator.invalidateThumbnail).toHaveBeenCalledWith(communityId)
+              })
+            })
+
+            describe('when updating multiple fields', () => {
+              it('should update all provided fields', async () => {
+                const response = await makeMultipartRequest(
+                  identity,
+                  `/v1/communities/${communityId}`,
+                  {
+                    name: 'Multi Updated Name',
+                    description: 'Multi Updated Description'
+                  },
+                  'PUT'
+                )
+
+                expect(response.status).toBe(200)
+                const body = await response.json()
+                expect(body.data.name).toBe('Multi Updated Name')
+                expect(body.data.description).toBe('Multi Updated Description')
+                expect(body.message).toBe('Community updated successfully')
+              })
+            })
+
+            describe('when updating privacy', () => {
+              describe('and the user is the owner', () => {
+                it('should update the community privacy', async () => {
+                  const response = await makeMultipartRequest(
+                    identity,
+                    `/v1/communities/${communityId}`,
+                    {
+                      privacy: CommunityPrivacyEnum.Private
+                    },
+                    'PUT'
+                  )
+
+                  expect(response.status).toBe(200)
+                  const body = await response.json()
+                  expect(body.data.privacy).toBe(CommunityPrivacyEnum.Private)
+                  expect(body.message).toBe('Community updated successfully')
+                })
+              })
+
+              describe('and the user is not the owner', () => {
+                beforeEach(async () => {
+                  await components.communitiesDb.updateMemberRole(
+                    communityId,
+                    identity.realAccount.address,
+                    CommunityRole.Moderator
+                  )
+                })
+
+                afterEach(async () => {
+                  await components.communitiesDb.updateMemberRole(
+                    communityId,
+                    identity.realAccount.address,
+                    CommunityRole.Owner
+                  )
+                })
+
+                it('should respond with a 401 status code', async () => {
+                  const response = await makeMultipartRequest(
+                    identity,
+                    `/v1/communities/${communityId}`,
+                    {
+                      privacy: CommunityPrivacyEnum.Private
+                    },
+                    'PUT'
+                  )
+
+                  expect(response.status).toBe(401)
+                })
               })
             })
           })

--- a/test/integration/update-community-controller.spec.ts
+++ b/test/integration/update-community-controller.spec.ts
@@ -174,7 +174,7 @@ test('Update Community Controller', async function ({ components, stubComponents
                   moderatorIdentity,
                   `/v1/communities/${communityId}`,
                   {
-                    name: 'Moderator Unauthorized Name Change'
+                    name: 'Mod Unauthorized Change'
                   },
                   'PUT'
                 )

--- a/test/mocks/communities.ts
+++ b/test/mocks/communities.ts
@@ -60,7 +60,8 @@ export function createMockCommunityRolesComponent({
   validatePermissionToLeaveCommunity = jest.fn(),
   validatePermissionToAcceptAndRejectRequests = jest.fn(),
   validatePermissionToViewRequests = jest.fn(),
-  validatePermissionToInviteUsers = jest.fn()
+  validatePermissionToInviteUsers = jest.fn(),
+  validatePermissionToEditCommunityName = jest.fn()
 }: Partial<jest.Mocked<ICommunityRolesComponent>>): jest.Mocked<ICommunityRolesComponent> {
   return {
     validatePermissionToKickMemberFromCommunity,
@@ -77,7 +78,8 @@ export function createMockCommunityRolesComponent({
     validatePermissionToLeaveCommunity,
     validatePermissionToAcceptAndRejectRequests,
     validatePermissionToViewRequests,
-    validatePermissionToInviteUsers
+    validatePermissionToInviteUsers,
+    validatePermissionToEditCommunityName
   }
 }
 

--- a/test/unit/logic/community-places.spec.ts
+++ b/test/unit/logic/community-places.spec.ts
@@ -2,17 +2,19 @@ import { CommunityRole } from '../../../src/types/entities'
 import { NotAuthorizedError } from '@dcl/platform-server-commons'
 import { CommunityNotFoundError, CommunityPlaceNotFoundError } from '../../../src/logic/community/errors'
 import { mockCommunitiesDB } from '../../mocks/components/communities-db'
-import { mockLogs, createPlacesApiAdapterMockComponent } from '../../mocks/components'
+import { createPlacesApiAdapterMockComponent, createLogsMockedComponent } from '../../mocks/components'
 import { createCommunityPlacesComponent } from '../../../src/logic/community/places'
 import { ICommunityPlacesComponent, CommunityPlace, ICommunityRolesComponent, CommunityPrivacyEnum } from '../../../src/logic/community'
 import { IPlacesApiComponent } from '../../../src/types/components'
 import { createMockCommunityRolesComponent } from '../../mocks/communities'
+import { ILoggerComponent } from '@well-known-components/interfaces/dist/components/logger'
 
 describe('Community Places Component', () => {
   let defaultWorldData: { world: boolean; world_name: string }
   let communityPlacesComponent: ICommunityPlacesComponent
   let mockCommunityRoles: jest.Mocked<ICommunityRolesComponent>
   let mockPlacesApi: jest.Mocked<IPlacesApiComponent>
+  let mockLogs: jest.Mocked<ILoggerComponent>
   let mockUserAddress: string
   const communityId = 'test-community'
   const mockPlaces: CommunityPlace[] = [
@@ -39,14 +41,7 @@ describe('Community Places Component', () => {
     mockCommunityRoles = createMockCommunityRolesComponent({})
     mockPlacesApi = createPlacesApiAdapterMockComponent({}) as jest.Mocked<IPlacesApiComponent>
     
-    // Re-setup mockLogs after creating mocks
-    mockLogs.getLogger.mockReturnValueOnce({
-      log: jest.fn(),
-      debug: jest.fn(),
-      error: jest.fn(),
-      info: jest.fn(),
-      warn: jest.fn()
-    })
+    mockLogs = createLogsMockedComponent({})
     
     communityPlacesComponent = await createCommunityPlacesComponent({
       communitiesDb: mockCommunitiesDB,


### PR DESCRIPTION
This PR adds restrictions on Community updates so:
- Name can only be changed by Owner
- Places can only be removed by Owners or by Moderators who own them