### PR TITLE
fix: invites endpoint only for moderators and owner and auto-accept requests

### DIFF
--- a/src/adapters/communities-db.ts
+++ b/src/adapters/communities-db.ts
@@ -420,7 +420,9 @@ export function createCommunitiesDBComponent(
           CASE WHEN c.private = true THEN ${CommunityPrivacyEnum.Private} ELSE ${CommunityPrivacyEnum.Public} END as privacy,
           c.active
         FROM communities c
-        JOIN community_members cm_inviter ON c.id = cm_inviter.community_id AND cm_inviter.member_address = ${normalizedInviterAddress}
+        JOIN community_members cm_inviter ON c.id = cm_inviter.community_id 
+          AND cm_inviter.member_address = ${normalizedInviterAddress}
+          AND cm_inviter.role IN ('owner', 'moderator')
         LEFT JOIN community_members cm_invitee ON c.id = cm_invitee.community_id AND cm_invitee.member_address = ${normalizedInviteeAddress}
         WHERE c.active = true
           AND cm_invitee.member_address IS NULL

--- a/test/integration/create-community-request-controller.spec.ts
+++ b/test/integration/create-community-request-controller.spec.ts
@@ -256,16 +256,24 @@ test('Create Community Request Controller', function ({ components, spyComponent
                       await components.communitiesDbHelper.forceCommunityRequestRemoval(requestId)
                     })
 
-                    it('should return 400 status code with correct message', async () => {
+                    it('should return 200 status code with the existing request', async () => {
                       const response = await makeRequest(
                         identity,
                         `/v1/communities/${communityId}/requests`,
                         'POST',
                         requestBody
                       )
-                      expect(response.status).toBe(400)
+                      expect(response.status).toBe(200)
                       const body = await response.json()
-                      expect(body.message).toBe('Request already exists')
+                      expect(body.data).toEqual(
+                        expect.objectContaining({
+                          id: requestId,
+                          communityId,
+                          memberAddress: targetAddress,
+                          type: CommunityRequestType.Invite,
+                          status: CommunityRequestStatus.Pending
+                        })
+                      )
                     })
                   })
                 })
@@ -341,16 +349,24 @@ test('Create Community Request Controller', function ({ components, spyComponent
                       await components.communitiesDbHelper.forceCommunityRequestRemoval(requestId)
                     })
 
-                    it('should return 400 status code with correct message', async () => {
+                    it('should return 200 status code with the existing request', async () => {
                       const response = await makeRequest(
                         identity,
                         `/v1/communities/${communityId}/requests`,
                         'POST',
                         requestBody
                       )
-                      expect(response.status).toBe(400)
+                      expect(response.status).toBe(200)
                       const body = await response.json()
-                      expect(body.message).toBe('Request already exists')
+                      expect(body.data).toEqual(
+                        expect.objectContaining({
+                          id: requestId,
+                          communityId,
+                          memberAddress: targetAddress,
+                          type: CommunityRequestType.Invite,
+                          status: CommunityRequestStatus.Pending
+                        })
+                      )
                     })
                   })
                 })
@@ -508,16 +524,24 @@ test('Create Community Request Controller', function ({ components, spyComponent
                     await components.communitiesDbHelper.forceCommunityRequestRemoval(requestId)
                   })
 
-                  it('should return 400 status code with correct message', async () => {
+                  it('should return 200 status code with the existing request', async () => {
                     const response = await makeRequest(
                       identity,
                       `/v1/communities/${communityId}/requests`,
                       'POST',
                       { ...requestBody, targetedAddress: identity.realAccount.address }
                     )
-                    expect(response.status).toBe(400)
+                    expect(response.status).toBe(200)
                     const body = await response.json()
-                    expect(body.message).toBe('Request already exists')
+                    expect(body.data).toEqual(
+                      expect.objectContaining({
+                        id: requestId,
+                        communityId,
+                        memberAddress: identity.realAccount.address.toLowerCase(),
+                        type: CommunityRequestType.RequestToJoin,
+                        status: CommunityRequestStatus.Pending
+                      })
+                    )
                   })
                 })
 

--- a/test/unit/logic/communities.spec.ts
+++ b/test/unit/logic/communities.spec.ts
@@ -1642,7 +1642,7 @@ describe('Community Component', () => {
         mockCommunitiesDB.getCommunityInvites.mockResolvedValue(mockCommunityInvites)
       })
 
-      it('should return communities where inviter is member but invitee is not', async () => {
+      it('should return communities where inviter is owner/moderator but invitee is not', async () => {
         const result = await communityComponent.getCommunityInvites(inviterAddress, inviteeAddress)
 
         expect(result).toEqual([


### PR DESCRIPTION
This PR modifies the Community requests flow to:
- Auto-accept requests when one of the opposite kind is already present for the same user and community
  - If an invite is received and the user have a request_to_join pending, automatically accept the request and join
  - If a request to join is received and the user have a invite pending, automatically accept the request and join
- The endpoint that list potential communities for invites now only returns communities where the user is moderator or owner of