### PR TITLE
feat: notify about users join whenever a request is accepted

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -242,6 +242,7 @@ export async function initComponents(): Promise<AppComponents> {
     communityBroadcaster,
     communityThumbnail,
     catalystClient,
+    pubsub,
     logs
   })
 

--- a/src/logic/community/requests.ts
+++ b/src/logic/community/requests.ts
@@ -13,6 +13,8 @@ import {
   RequestActionOptions
 } from './types'
 import { getProfileName } from '../profiles'
+import { COMMUNITY_MEMBER_STATUS_UPDATES_CHANNEL } from '../../adapters/pubsub'
+import { ConnectivityStatus } from '@dcl/protocol/out-js/decentraland/social_service/v2/social_service_v2.gen'
 
 export function createCommunityRequestsComponent(
   components: Pick<
@@ -23,11 +25,20 @@ export function createCommunityRequestsComponent(
     | 'communityThumbnail'
     | 'communityBroadcaster'
     | 'catalystClient'
+    | 'pubsub'
     | 'logs'
   >
 ): ICommunityRequestsComponent {
-  const { communitiesDb, communities, communityRoles, communityThumbnail, communityBroadcaster, catalystClient, logs } =
-    components
+  const {
+    communitiesDb,
+    communities,
+    communityRoles,
+    communityThumbnail,
+    communityBroadcaster,
+    catalystClient,
+    pubsub,
+    logs
+  } = components
 
   const logger = logs.getLogger('community-requests-component')
 
@@ -142,6 +153,12 @@ export function createCommunityRequestsComponent(
         status: CommunityRequestStatus.Accepted
       }
 
+      await pubsub.publishInChannel(COMMUNITY_MEMBER_STATUS_UPDATES_CHANNEL, {
+        communityId,
+        memberAddress,
+        status: ConnectivityStatus.ONLINE
+      })
+
       logger.info(
         `Automatically joined user ${memberAddress} to community ${community.name} (${communityId}) by accepting ${oppositeTypeRequest.type}`
       )
@@ -247,6 +264,12 @@ export function createCommunityRequestsComponent(
         communityId: request.communityId,
         memberAddress: request.memberAddress,
         role: CommunityRole.Member
+      })
+
+      await pubsub.publishInChannel(COMMUNITY_MEMBER_STATUS_UPDATES_CHANNEL, {
+        communityId: request.communityId,
+        memberAddress: request.memberAddress,
+        status: ConnectivityStatus.ONLINE
       })
 
       logger.info('Community request accepted', {

--- a/test/components.ts
+++ b/test/components.ts
@@ -236,7 +236,7 @@ async function initComponents(): Promise<TestComponents> {
     communityThumbnail,
     communityPlaces
   })
-  const communityRequests = createCommunityRequestsComponent({ communitiesDb, communities, communityRoles, communityBroadcaster, communityThumbnail, catalystClient, logs })
+  const communityRequests = createCommunityRequestsComponent({ communitiesDb, communities, communityRoles, communityBroadcaster, communityThumbnail, catalystClient, pubsub, logs })
   const rpcServer = await createRpcServerComponent({
     logs,
     pubsub,

--- a/test/unit/logic/community-requests.spec.ts
+++ b/test/unit/logic/community-requests.spec.ts
@@ -274,7 +274,7 @@ describe('Community Requests Component', () => {
                 })
               })
 
-              it('should publish the community member status updates', async () => {
+              it('should notify member join through pubsub', async () => {
                 await communityRequestsComponent.createCommunityRequest(community.id, userAddress, type, callerAddress)
                 expect(mockPubsub.publishInChannel).toHaveBeenCalledWith(COMMUNITY_MEMBER_STATUS_UPDATES_CHANNEL, {
                   communityId: community.id,
@@ -523,7 +523,7 @@ describe('Community Requests Component', () => {
               )
             })
 
-            it('should publish the community member status updates', async () => {
+            it('should notify member join through pubsub', async () => {
               await communityRequestsComponent.createCommunityRequest(community.id, userAddress, type, callerAddress)
               expect(mockPubsub.publishInChannel).toHaveBeenCalledWith(COMMUNITY_MEMBER_STATUS_UPDATES_CHANNEL, {
                 communityId: community.id,
@@ -743,7 +743,7 @@ describe('Community Requests Component', () => {
               })
             })
 
-            it('should publish the community member status updates', async () => {
+            it('should notify member join through pubsub', async () => {
               await communityRequestsComponent.createCommunityRequest(community.id, userAddress, type, callerAddress)
               expect(mockPubsub.publishInChannel).toHaveBeenCalledWith(COMMUNITY_MEMBER_STATUS_UPDATES_CHANNEL, {
                 communityId: community.id,
@@ -1030,7 +1030,7 @@ describe('Community Requests Component', () => {
               expect(mockCommunityRoles.validatePermissionToAcceptAndRejectRequests).not.toHaveBeenCalled()
             })
 
-            it('should publish the community member status updates', async () => {
+            it('should notify member join through pubsub', async () => {
               await communityRequestsComponent.updateRequestStatus(requestId, status, { callerAddress })
 
               expect(mockPubsub.publishInChannel).toHaveBeenCalledWith(COMMUNITY_MEMBER_STATUS_UPDATES_CHANNEL, {
@@ -1327,7 +1327,7 @@ describe('Community Requests Component', () => {
               )
             })
 
-            it('should publish the community member status updates', async () => {
+            it('should notify member join through pubsub', async () => {
               await communityRequestsComponent.updateRequestStatus(requestId, status, { callerAddress })
               expect(mockPubsub.publishInChannel).toHaveBeenCalledWith(COMMUNITY_MEMBER_STATUS_UPDATES_CHANNEL, {
                 communityId: joinRequest.communityId,


### PR DESCRIPTION
Whenever a Community Request is accepted (and a member joins a community), the client should be notified through WS so it can update its chat state.