### PR TITLE
chore: lower trace sampling for Sentry

### DIFF
--- a/src/utils/instrument.ts
+++ b/src/utils/instrument.ts
@@ -16,6 +16,6 @@ export function initSentry() {
     release: `${process.env.SENTRY_RELEASE_PREFIX || 'social-service-ea'}@${process.env.CURRENT_VERSION || 'development'}`,
     integrations: [Sentry.onUncaughtExceptionIntegration(), Sentry.onUnhandledRejectionIntegration()],
     debug: process.env.SENTRY_DEBUG === 'true',
-    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE) || 0.1
+    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE) || 0.001
   })
 }


### PR DESCRIPTION
Currently we send over a million of traces to sentry, this change will lower the sampling rate, so we don't burn the budget.