### PR TITLE
feat: restrict signed fetch endpoints to only be consumed from explorer client

### DIFF
--- a/src/controllers/routes/http.routes.ts
+++ b/src/controllers/routes/http.routes.ts
@@ -50,7 +50,8 @@ export async function setupHttpRoutes(context: GlobalContext): Promise<Router<Gl
       onError: (err: any) => ({
         error: err.message,
         message: 'This endpoint requires a signed fetch request. See ADR-44.'
-      })
+      }),
+      metadataValidator: (metadata) => metadata?.signer !== 'decentraland-kernel-scene' // prevent requests from scenes
     })
 
   router.use(errorHandler)


### PR DESCRIPTION
This PR updates the endpoints restricted by Signed Fetch so they cannot be consumed from scenes in-world (`metadata.signer !== 'decentraland-kernel-scene'`).