### PR TITLE
chore: remove @well-known-components/http-server reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@dcl/analytics-component": "^0.2.2",
     "@dcl/http-server": "^1.0.0",
     "@dcl/platform-crypto-middleware": "^1.1.0",
-    "@dcl/platform-server-commons": "^0.1.0",
+    "@dcl/platform-server-commons": "^1.0.1",
     "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-18139325564.commit-905b963.tgz",
     "@dcl/rpc": "^1.1.2",
     "@dcl/schema-validator-component": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1060,13 +1060,13 @@
     "@well-known-components/fetch-component" "^2.0.2"
     "@well-known-components/interfaces" "^1.4.2"
 
-"@dcl/platform-server-commons@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@dcl/platform-server-commons/-/platform-server-commons-0.1.0.tgz#02400b9fa75201b3c31ef098f00abd153c4b81b6"
-  integrity sha512-lFdk9nw5mC37oWPu8p5cRwmN9hiLPCZvKZB74lIYTu/TL7XPmJIe0afans3ftptx1CP96dqor8LBTzaUx+HpoQ==
+"@dcl/platform-server-commons@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@dcl/platform-server-commons/-/platform-server-commons-1.0.1.tgz#c88e339b83958ca3b3203aca20d64eacff2ac26c"
+  integrity sha512-qXd/UCTxQC2A5uJuE5MiDXGmxNpk+kMPZjdCEFVZsvmFjDEKxg5oonMI26iNoYrjhfnSt9u1We9qf62MbqdlDg==
   dependencies:
-    "@dcl/schemas" "^16.9.0"
-    "@well-known-components/http-server" "^2.1.0"
+    "@dcl/http-server" "^1.0.0"
+    "@dcl/schemas" "^18.0.0"
     "@well-known-components/interfaces" "^1.4.3"
     node-fetch "^2.7.0"
 
@@ -1105,10 +1105,10 @@
     ajv-keywords "^5.1.0"
     mitt "^3.0.1"
 
-"@dcl/schemas@^16.9.0":
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-16.14.0.tgz#a9723135296437c29795386d82025ad722f3c54a"
-  integrity sha512-Z5FoOwJY7FUaeEg/N0mRNTJM7azPMTTbLdcJ9SpCdBpXRTegKUmmmWbnbosd7W2Z+nXkF2Q0rOyVHIy4FqH4dQ==
+"@dcl/schemas@^18.0.0":
+  version "18.8.0"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-18.8.0.tgz#fe8e3fb47d01b848481f54887008118aafee0f51"
+  integrity sha512-1HxbL0azB7N+kMwYyU4/Uqltc+7F8Lv8UcS3dxDNVTPn71gldIDImj58OM9Y3gIyQG5Tauacrlk5cDkXhjMkOA==
   dependencies:
     ajv "^8.11.0"
     ajv-errors "^3.0.0"
@@ -3015,7 +3015,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/http-errors@^2.0.1", "@types/http-errors@^2.0.4":
+"@types/http-errors@^2.0.4":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.5.tgz#5b749ab2b16ba113423feb1a64a95dcd30398472"
   integrity sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==
@@ -3409,20 +3409,6 @@
   dependencies:
     "@well-known-components/interfaces" "^1.4.1"
     cross-fetch "^3.1.5"
-
-"@well-known-components/http-server@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@well-known-components/http-server/-/http-server-2.1.0.tgz#23a18edc82904b3a575452c2d7e618c7da37a07f"
-  integrity sha512-IHD7aLTA+9DYEchQubHDBwc4FmVEmQC+2TWbi8Tz+QlkiQdtndcuba8XHH+EwqlB5sna/EAJGZGXPxS7okcHKA==
-  dependencies:
-    "@types/http-errors" "^2.0.1"
-    destroy "^1.2.0"
-    fp-future "^1.0.1"
-    http-errors "^2.0.0"
-    mitt "^3.0.0"
-    node-fetch "^2.6.9"
-    on-finished "^2.4.1"
-    path-to-regexp "^6.2.1"
 
 "@well-known-components/interfaces@^1.1.1", "@well-known-components/interfaces@^1.3.0", "@well-known-components/interfaces@^1.4.1", "@well-known-components/interfaces@^1.4.2", "@well-known-components/interfaces@^1.4.3", "@well-known-components/interfaces@^1.5.1", "@well-known-components/interfaces@^1.5.2":
   version "1.5.2"
@@ -5980,7 +5966,7 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@^6.2.1, path-to-regexp@^6.3.0:
+path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
   integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==


### PR DESCRIPTION
This service is already using `@dcl/http-server` instead of `@well-known-components/http-server`. Yet `platform-server-commons` had a reference to that package, which has already been replaced with the new package as well.

This PR updates `platform-server-commons` to use its version without the reference to `@well-known-components/http-server`.