### PR TITLE
fix: Use peers stats instead of subscribers for broadcasting voice chat notifications

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -184,7 +184,7 @@ export async function initComponents(): Promise<AppComponents> {
   const peersStats = createPeersStatsComponent({ archipelagoStats, worldsStats })
   const communityThumbnail = await createCommunityThumbnailComponent({ config, storage })
 
-  const communityBroadcaster = createCommunityBroadcasterComponent({ sns, communitiesDb, subscribersContext })
+  const communityBroadcaster = createCommunityBroadcasterComponent({ sns, communitiesDb, peersStats })
   const communityRoles = createCommunityRolesComponent({ communitiesDb, logs })
 
   const communityPlaces = await createCommunityPlacesComponent({

--- a/src/logic/community/broadcaster.ts
+++ b/src/logic/community/broadcaster.ts
@@ -92,9 +92,9 @@ type BroadcastingEventHandler = (event: BroadcastableEvent, options?: BroadcastO
 type BroadcastingRegistry = Map<Events.SubType.Community, BroadcastingEventHandler>
 
 export function createCommunityBroadcasterComponent(
-  components: Pick<AppComponents, 'sns' | 'communitiesDb' | 'subscribersContext'>
+  components: Pick<AppComponents, 'sns' | 'communitiesDb' | 'peersStats'>
 ): ICommunityBroadcasterComponent {
-  const { sns, communitiesDb, subscribersContext } = components
+  const { sns, communitiesDb, peersStats } = components
 
   /**
    * Gets community member addresses with pagination support
@@ -117,7 +117,7 @@ export function createCommunityBroadcasterComponent(
     let filterByMembers: string[] | undefined
 
     if (onlyOnline) {
-      filterByMembers = subscribersContext.getSubscribersAddresses()
+      filterByMembers = await peersStats.getConnectedPeers()
     }
 
     while (hasMore) {


### PR DESCRIPTION
## Problem

The `subscribersContext` is an **in-memory cache** that only tracks WebSocket connections to the **current instance**. With multiple instances running, the SNS broadcast for `VOICE_CHAT_STARTED` was only notifying users connected to the instance that started the voice chat, missing users connected to other instances.

## Solution

Replaced `subscribersContext` with `peersStats` in the broadcaster. `peersStats` uses **Redis-backed data** from `archipelagoStats` and `worldsStats`, which is **shared across all instances**.

## Changes

1. **`src/logic/community/broadcaster.ts`**
   - Changed dependency from `subscribersContext` to `peersStats`
   - Updated `getCommunityMemberAddresses` to use `await peersStats.getConnectedPeers()` instead of `subscribersContext.getSubscribersAddresses()`

2. **`src/components.ts`**
   - Updated `createCommunityBroadcasterComponent` call to pass `peersStats` instead of `subscribersContext`

3. **`test/unit/logic/community-broadcaster.spec.ts`**
   - Updated tests to mock `peersStats.getConnectedPeers()` instead of using `subscribersContext.addSubscriber()`

## Result

Now when a voice chat is started, the broadcaster queries `peersStats.getConnectedPeers()` which returns all connected peers across **all instances** (from Archipelago + Worlds, stored in Redis). This ensures all online community members receive the SNS notification regardless of which instance they're connected to.