### PR TITLE
feat: sort community members by role (owner, moderator, member) then by joined_at

### DIFF
--- a/src/adapters/communities-db.ts
+++ b/src/adapters/communities-db.ts
@@ -156,7 +156,9 @@ export function createCommunitiesDBComponent(
           excludedAddresses ? SQL` AND cm.member_address <> ANY(${excludedAddresses.map(normalizeAddress)})` : SQL``
         )
         .append(roles ? SQL` AND cm.role = ANY(${roles})` : SQL``)
-        .append(SQL` ORDER BY cm.joined_at ASC`)
+        .append(
+          SQL` ORDER BY CASE cm.role WHEN 'owner' THEN 1 WHEN 'moderator' THEN 2 WHEN 'member' THEN 3 ELSE 4 END ASC, cm.joined_at ASC`
+        )
         .append(SQL` LIMIT ${pagination.limit}`)
         .append(SQL` OFFSET ${pagination.offset}`)
 

--- a/test/integration/get-community-members-controller.spec.ts
+++ b/test/integration/get-community-members-controller.spec.ts
@@ -185,40 +185,39 @@ test('Get Community Members Controller', function ({ components, spyComponents }
             expect(response.status).toBe(200)
             const result = await response.json()
 
-            expect(result.data.results).toEqual(
-              expect.arrayContaining([
-                expect.objectContaining({
-                  communityId,
-                  memberAddress: firstMemberAddress,
-                  hasClaimedName: true,
-                  joinedAt: expect.any(String),
-                  name: `Profile name ${firstMemberAddress}`,
-                  role: CommunityRole.Member,
-                  profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
-                  friendshipStatus: FriendshipStatus.NONE
-                }),
-                expect.objectContaining({
-                  communityId,
-                  memberAddress: secondMemberAddress,
-                  hasClaimedName: true,
-                  joinedAt: expect.any(String),
-                  name: `Profile name ${secondMemberAddress}`,
-                  role: CommunityRole.Member,
-                  profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
-                  friendshipStatus: FriendshipStatus.NONE
-                }),
-                expect.objectContaining({
-                  communityId,
-                  memberAddress: ownerAddress,
-                  hasClaimedName: true,
-                  joinedAt: expect.any(String),
-                  name: `Profile name ${ownerAddress}`,
-                  role: CommunityRole.Owner,
-                  profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
-                  friendshipStatus: FriendshipStatus.NONE
-                })
-              ])
-            )
+            // Verify members are sorted by role (owner first), then by joined_at
+            expect(result.data.results).toEqual([
+              expect.objectContaining({
+                communityId,
+                memberAddress: ownerAddress,
+                hasClaimedName: true,
+                joinedAt: expect.any(String),
+                name: `Profile name ${ownerAddress}`,
+                role: CommunityRole.Owner,
+                profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
+                friendshipStatus: FriendshipStatus.NONE
+              }),
+              expect.objectContaining({
+                communityId,
+                memberAddress: firstMemberAddress,
+                hasClaimedName: true,
+                joinedAt: expect.any(String),
+                name: `Profile name ${firstMemberAddress}`,
+                role: CommunityRole.Member,
+                profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
+                friendshipStatus: FriendshipStatus.NONE
+              }),
+              expect.objectContaining({
+                communityId,
+                memberAddress: secondMemberAddress,
+                hasClaimedName: true,
+                joinedAt: expect.any(String),
+                name: `Profile name ${secondMemberAddress}`,
+                role: CommunityRole.Member,
+                profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
+                friendshipStatus: FriendshipStatus.NONE
+              })
+            ])
           })
         })
 
@@ -353,40 +352,39 @@ test('Get Community Members Controller', function ({ components, spyComponents }
 
             expect(result.data.results).toHaveLength(3)
 
-            expect(result.data.results).toEqual(
-              expect.arrayContaining([
-                expect.objectContaining({
-                  communityId,
-                  memberAddress: firstMemberAddress,
-                  hasClaimedName: true,
-                  joinedAt: expect.any(String),
-                  name: `Profile name ${firstMemberAddress}`,
-                  role: CommunityRole.Member,
-                  profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
-                  friendshipStatus: FriendshipStatus.REQUEST_SENT
-                }),
-                expect.objectContaining({
-                  communityId,
-                  memberAddress: secondMemberAddress,
-                  hasClaimedName: true,
-                  joinedAt: expect.any(String),
-                  name: `Profile name ${secondMemberAddress}`,
-                  role: CommunityRole.Member,
-                  profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
-                  friendshipStatus: FriendshipStatus.ACCEPTED
-                }),
-                expect.objectContaining({
-                  communityId,
-                  memberAddress: ownerAddress,
-                  hasClaimedName: true,
-                  joinedAt: expect.any(String),
-                  name: `Profile name ${ownerAddress}`,
-                  role: CommunityRole.Owner,
-                  profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
-                  friendshipStatus: FriendshipStatus.NONE
-                })
-              ])
-            )
+            // Verify members are sorted by role (owner first), then by joined_at
+            expect(result.data.results).toEqual([
+              expect.objectContaining({
+                communityId,
+                memberAddress: ownerAddress,
+                hasClaimedName: true,
+                joinedAt: expect.any(String),
+                name: `Profile name ${ownerAddress}`,
+                role: CommunityRole.Owner,
+                profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
+                friendshipStatus: FriendshipStatus.NONE
+              }),
+              expect.objectContaining({
+                communityId,
+                memberAddress: firstMemberAddress,
+                hasClaimedName: true,
+                joinedAt: expect.any(String),
+                name: `Profile name ${firstMemberAddress}`,
+                role: CommunityRole.Member,
+                profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
+                friendshipStatus: FriendshipStatus.REQUEST_SENT
+              }),
+              expect.objectContaining({
+                communityId,
+                memberAddress: secondMemberAddress,
+                hasClaimedName: true,
+                joinedAt: expect.any(String),
+                name: `Profile name ${secondMemberAddress}`,
+                role: CommunityRole.Member,
+                profilePictureUrl: expect.stringContaining('https://profile-images.decentraland.org'),
+                friendshipStatus: FriendshipStatus.ACCEPTED
+              })
+            ])
           })
 
           it('should handle members with no friendship status correctly', async () => {


### PR DESCRIPTION
## Description

This PR updates the community members sorting to prioritize role hierarchy:

1. **Owners** appear first
2. **Moderators** appear second  
3. **Members** appear third

Within each role group, members are still sorted by `joined_at` (ascending).

## Changes

- Updated `getCommunityMembers` in `src/adapters/communities-db.ts` to use a CASE expression for role-based ordering
- Updated integration tests to verify the new ordering behavior

## SQL Change

```sql
ORDER BY CASE cm.role 
  WHEN 'owner' THEN 1 
  WHEN 'moderator' THEN 2 
  WHEN 'member' THEN 3 
  ELSE 4 
END ASC, cm.joined_at ASC
```