### PR TITLE
chore: supress stand-alone telemetry transactions without parent context

### DIFF
--- a/src/utils/instrument.ts
+++ b/src/utils/instrument.ts
@@ -4,6 +4,29 @@ import { config } from 'dotenv'
 // Load .env file
 config()
 
+/**
+ * Patterns for standalone transactions that should be filtered out.
+ * These are typically Redis/DB operations from background processes
+ * that lack parent context and would otherwise appear as standalone transactions.
+ * IMPORTANT: Spans within a transaction are not filtered out.
+ * @see https://docs.sentry.io/platforms/node/configuration/sampling/#ignoring-standalone-transactions
+ */
+const FILTERED_TRANSACTION_PATTERNS = [
+  /^GET\s/,
+  /^SET\s/,
+  /^MGET/,
+  /^DEL\s/,
+  /^SADD\s/,
+  /^SREM\s/,
+  /^PUBLISH\s/,
+  /^HGET\s/,
+  /^HSET\s/,
+  /^HMGET/,
+  /^LPUSH\s/,
+  /^RPUSH\s/,
+  /^EXPIRE\s/
+]
+
 export function initSentry() {
   if (!process.env.SENTRY_DSN) {
     console.warn('SENTRY_DSN not found, skipping Sentry initialization')
@@ -16,6 +39,16 @@ export function initSentry() {
     release: `${process.env.SENTRY_RELEASE_PREFIX || 'social-service-ea'}@${process.env.CURRENT_VERSION || 'development'}`,
     integrations: [Sentry.onUncaughtExceptionIntegration(), Sentry.onUnhandledRejectionIntegration()],
     debug: process.env.SENTRY_DEBUG === 'true',
-    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE) || 0.001
+    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE) || 0.001,
+    beforeSendTransaction(event) {
+      const name = event.transaction || ''
+      for (const pattern of FILTERED_TRANSACTION_PATTERNS) {
+        if (pattern.test(name)) {
+          return null
+        }
+      }
+
+      return event
+    }
   })
 }


### PR DESCRIPTION
We are still having some stand-alone Redis transactions in Sentry despite the telemetry suppression at the code level. This PR adds a fallback to prevent them from arriving to Sentry in case a stand-alone (job) piece of code hasn't been excluded properly.