### PR TITLE
fix: prevent duplicate referral reward on concurrent finalize

### DIFF
--- a/src/adapters/referral-db.ts
+++ b/src/adapters/referral-db.ts
@@ -85,7 +85,7 @@ export async function createReferralDBComponent(
   const updateReferralProgress = async (
     invited_user: string,
     status: ReferralProgressStatus.SIGNED_UP | ReferralProgressStatus.TIER_GRANTED
-  ): Promise<void> => {
+  ): Promise<number> => {
     logger.debug(`Updating referral_progress for invited_user ${invited_user} with ${status}`)
     const fields: SQLStatement[] = []
     const now = Date.now()
@@ -103,8 +103,14 @@ export async function createReferralDBComponent(
       query = query.append(f)
     })
     query = query.append(SQL` WHERE invited_user = ${invited_user.toLowerCase()}`)
+    // Guard the tier-granted transition so it can only happen once: concurrent
+    // finalize calls for the same user must not each grant the referrer a reward.
+    if (status === ReferralProgressStatus.TIER_GRANTED) {
+      query = query.append(SQL` AND tier_granted = false`)
+    }
 
-    await pg.query(query)
+    const result = await pg.query(query)
+    return result.rowCount
   }
 
   async function hasReferralProgress(invited_user: string): Promise<boolean> {

--- a/src/logic/referral/referral.ts
+++ b/src/logic/referral/referral.ts
@@ -342,7 +342,17 @@ export async function createReferralComponent(
         newStatus: ReferralProgressStatus.TIER_GRANTED
       })
 
-      await referralDb.updateReferralProgress(invitedUser, ReferralProgressStatus.TIER_GRANTED)
+      const granted = await referralDb.updateReferralProgress(invitedUser, ReferralProgressStatus.TIER_GRANTED)
+
+      // If no row transitioned, another concurrent finalize already granted this
+      // referral. Stop here to avoid sending the referrer a duplicate reward.
+      if (!granted) {
+        logger.info('Referral already finalized by a concurrent request, skipping reward', {
+          invitedUser,
+          referrer
+        })
+        return
+      }
 
       const acceptedInvites = await referralDb.countAcceptedInvitesByReferrer(referrer)
 

--- a/src/types/referral-db.type.ts
+++ b/src/types/referral-db.type.ts
@@ -8,7 +8,7 @@ export interface IReferralDatabaseComponent {
   updateReferralProgress(
     invitedUser: string,
     status: ReferralProgressStatus.SIGNED_UP | ReferralProgressStatus.TIER_GRANTED
-  ): Promise<void>
+  ): Promise<number>
   hasReferralProgress(invitedUser: string): Promise<boolean>
   listAllReferralProgress(filter?: Pick<ReferralProgressFilter, 'limit' | 'offset'>): Promise<ReferralProgress[]>
   countAcceptedInvitesByReferrer(referrer: string): Promise<number>

--- a/test/unit/logic/referral.spec.ts
+++ b/test/unit/logic/referral.spec.ts
@@ -661,7 +661,7 @@ describe('referral-component', () => {
             status: ReferralProgressStatus.PENDING
           }
         ])
-        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(undefined)
+        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(1)
       })
 
       it('should update progress to signed up', async () => {
@@ -792,7 +792,7 @@ describe('referral-component', () => {
             status: ReferralProgressStatus.SIGNED_UP
           }
         ])
-        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(undefined)
+        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(1)
         mockReferralDb.countAcceptedInvitesByReferrer.mockResolvedValueOnce(5)
         mockRedis.get.mockResolvedValueOnce(['2024-01-01', '2024-01-02', '2024-01-03'])
       })
@@ -894,7 +894,7 @@ describe('referral-component', () => {
             status: ReferralProgressStatus.SIGNED_UP
           }
         ])
-        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(undefined)
+        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(1)
         mockReferralDb.countAcceptedInvitesByReferrer.mockResolvedValueOnce(5)
         mockRedis.get.mockResolvedValueOnce(['2024-01-01', '2024-01-02', '2024-01-03'])
       })
@@ -926,7 +926,7 @@ describe('referral-component', () => {
             status: ReferralProgressStatus.SIGNED_UP
           }
         ])
-        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(undefined)
+        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(1)
         mockReferralDb.countAcceptedInvitesByReferrer.mockResolvedValueOnce(5)
         mockRedis.get.mockResolvedValueOnce(['2024-01-01', '2024-01-02', '2024-01-03', '2024-01-04', '2024-01-05'])
       })
@@ -968,7 +968,7 @@ describe('referral-component', () => {
               status: ReferralProgressStatus.SIGNED_UP
             }
           ])
-          mockReferralDb.updateReferralProgress.mockResolvedValueOnce(undefined)
+          mockReferralDb.updateReferralProgress.mockResolvedValueOnce(1)
           mockReferralDb.countAcceptedInvitesByReferrer.mockResolvedValueOnce(invitedUsers)
           mockRedis.get.mockResolvedValueOnce(['2024-01-01', '2024-01-02', '2024-01-03'])
           mockRewards.sendReward.mockResolvedValueOnce([
@@ -1010,6 +1010,33 @@ describe('referral-component', () => {
       })
     })
 
+    describe('when a concurrent finalize already granted the tier', () => {
+      beforeEach(() => {
+        mockReferralDb.findReferralProgress.mockResolvedValueOnce([
+          {
+            referrer: validReferrer,
+            invited_user: validInvitedUser,
+            status: ReferralProgressStatus.SIGNED_UP
+          }
+        ])
+        mockRedis.get.mockResolvedValueOnce(['2024-01-01', '2024-01-02', '2024-01-03'])
+        // The guarded UPDATE affects no rows because another request already granted it.
+        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(0)
+      })
+
+      it('should not send a reward nor publish an event', async () => {
+        await referralComponent.finalizeReferral(validInvitedUser)
+
+        expect(mockReferralDb.updateReferralProgress).toHaveBeenCalledWith(
+          validInvitedUser.toLowerCase(),
+          ReferralProgressStatus.TIER_GRANTED
+        )
+        expect(mockReferralDb.countAcceptedInvitesByReferrer).not.toHaveBeenCalled()
+        expect(mockRewards.sendReward).not.toHaveBeenCalled()
+        expect(mockSns.publishMessage).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when referral does not reach a tier milestone', () => {
       describe.each([
         { invitedUsers: 1, tier: 1 },
@@ -1030,7 +1057,7 @@ describe('referral-component', () => {
               status: ReferralProgressStatus.SIGNED_UP
             }
           ])
-          mockReferralDb.updateReferralProgress.mockResolvedValueOnce(undefined)
+          mockReferralDb.updateReferralProgress.mockResolvedValueOnce(1)
           mockReferralDb.countAcceptedInvitesByReferrer.mockResolvedValueOnce(invitedUsers)
           mockRedis.get.mockResolvedValueOnce(['2024-01-01', '2024-01-02', '2024-01-03'])
         })
@@ -1067,7 +1094,7 @@ describe('referral-component', () => {
               status: ReferralProgressStatus.SIGNED_UP
             }
           ])
-          mockReferralDb.updateReferralProgress.mockResolvedValueOnce(undefined)
+          mockReferralDb.updateReferralProgress.mockResolvedValueOnce(1)
           mockReferralDb.countAcceptedInvitesByReferrer.mockResolvedValueOnce(invitedUsers)
           mockRedis.get.mockResolvedValueOnce(['2024-01-01', '2024-01-02', '2024-01-03'])
         })
@@ -1112,7 +1139,7 @@ describe('referral-component', () => {
       })
 
       it('should not process the referral and not publish event', async () => {
-        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(undefined)
+        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(1)
         mockReferralDb.countAcceptedInvitesByReferrer.mockResolvedValueOnce(5)
 
         await referralComponent.finalizeReferral(validInvitedUser)
@@ -1139,7 +1166,7 @@ describe('referral-component', () => {
             status: ReferralProgressStatus.SIGNED_UP
           }
         ])
-        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(undefined)
+        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(1)
         mockReferralDb.countAcceptedInvitesByReferrer.mockResolvedValueOnce(5)
         mockRedis.get.mockResolvedValueOnce(['2024-01-01', '2024-01-02', '2024-01-03'])
         mockSns.publishMessage.mockRejectedValueOnce(new Error('SNS publish failed'))
@@ -1165,7 +1192,7 @@ describe('referral-component', () => {
             status: ReferralProgressStatus.SIGNED_UP
           }
         ])
-        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(undefined)
+        mockReferralDb.updateReferralProgress.mockResolvedValueOnce(1)
         mockReferralDb.countAcceptedInvitesByReferrer.mockResolvedValueOnce(100)
         mockRedis.get.mockResolvedValueOnce(['2024-01-01', '2024-01-02', '2024-01-03'])
       })
@@ -1189,7 +1216,7 @@ describe('referral-component', () => {
               status: ReferralProgressStatus.SIGNED_UP
             }
           ])
-          mockReferralDb.updateReferralProgress.mockResolvedValueOnce(undefined)
+          mockReferralDb.updateReferralProgress.mockResolvedValueOnce(1)
           mockReferralDb.countAcceptedInvitesByReferrer.mockResolvedValueOnce(100)
           mockRedis.get.mockResolvedValueOnce(['2024-01-01', '2024-01-02', '2024-01-03'])
         })


### PR DESCRIPTION
## What

`finalizeReferral` did a read-check-then-write that is not atomic: it returns early if the progress is already `TIER_GRANTED`, then later calls `updateReferralProgress(..., TIER_GRANTED)` and sends the referrer a reward. `updateReferralProgress` issued `UPDATE referral_progress SET ... WHERE invited_user = $1` with no state guard, so two concurrent login events for the same invited user both pass the early check, both update, and both reach `rewards.sendReward` + the SNS event — granting the referrer a **duplicate reward** (TOCTOU race).

## Change

- `updateReferralProgress`: for the `TIER_GRANTED` transition, guard the UPDATE with `AND tier_granted = false` so only one concurrent request can flip it, and return the affected `rowCount`.
- `finalizeReferral`: only proceed to count invites, publish the event and send the reward when the guarded update actually transitioned a row; otherwise log and return.
- Interface return type updated to `Promise<number>`.

## Verification

- `tsc --noEmit` clean; eslint clean on changed files.
- Unit suite `referral.spec.ts`: 74 passing — existing finalize tests updated to reflect the rowCount return, plus a new case asserting that a concurrent finalize (rowCount 0) sends no reward and publishes no event.
- (Integration tests require a DB and Node 24; covered by CI.)