### PR TITLE
feat: allow fetching a member's publicly visible communities

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -691,8 +691,14 @@ paths:
       operationId: getMemberCommunities
       summary: List communities for a member
       description: |
-        Lists all communities a member belongs to.
-        This endpoint requires Signed Fetch authentication.
+        Lists communities a member belongs to.
+        This endpoint has optional Signed Fetch authentication.
+
+        **Visibility Rules:**
+        - When the authenticated caller is the member themselves, all of their communities are returned.
+        - Any other caller (another user or an unauthenticated request) only gets the member's
+          publicly visible communities: public privacy AND listed visibility. Private and unlisted
+          memberships are never exposed to third parties.
       security:
         - SignedFetch: []
       parameters:
@@ -722,7 +728,7 @@ paths:
               schema:
                 $ref: './schemas.yaml#/components/schemas/GetMemberCommunities200OkResponse'
         '401':
-          description: Unauthorized - Signed Fetch required
+          description: Unauthorized - Invalid Signed Fetch request
           content:
             application/json:
               schema:

--- a/src/adapters/communities-db.ts
+++ b/src/adapters/communities-db.ts
@@ -385,9 +385,12 @@ export function createCommunitiesDBComponent(
 
     async getCommunitiesCount(
       memberAddress: EthAddress,
-      options?: Pick<GetCommunitiesOptions, 'search' | 'onlyMemberOf' | 'roles' | 'communityIds' | 'includeUnlisted'>
+      options?: Pick<
+        GetCommunitiesOptions,
+        'search' | 'onlyMemberOf' | 'roles' | 'communityIds' | 'includeUnlisted' | 'onlyPublicVisible'
+      >
     ): Promise<number> {
-      const { search, onlyMemberOf, roles, communityIds, includeUnlisted } = options ?? {}
+      const { search, onlyMemberOf, roles, communityIds, includeUnlisted, onlyPublicVisible } = options ?? {}
       const normalizedMemberAddress = normalizeAddress(memberAddress)
 
       const membersJoin = getCommunityMembersJoin(normalizedMemberAddress, { onlyMemberOf, roles })
@@ -406,6 +409,7 @@ export function createCommunitiesDBComponent(
           // Otherwise, exclude unlisted communities from public listings
           onlyMemberOf || includeUnlisted ? SQL`` : SQL` AND c.unlisted = false`
         )
+        .append(onlyPublicVisible ? SQL` AND c.private = false AND c.unlisted = false` : SQL``)
         .append(SQL` AND cb.banned_address IS NULL`)
 
       if (search) {
@@ -470,12 +474,12 @@ export function createCommunitiesDBComponent(
 
     async getMemberCommunities(
       memberAddress: EthAddress,
-      options: Pick<GetCommunitiesOptions, 'pagination' | 'roles'>
+      options: Pick<GetCommunitiesOptions, 'pagination' | 'roles' | 'onlyPublicVisible'>
     ): Promise<MemberCommunity[]> {
       const normalizedMemberAddress = normalizeAddress(memberAddress)
 
       const baseQuery = SQL`
-        SELECT 
+        SELECT
           c.id,
           c.name,
           c.owner_address as "ownerAddress",
@@ -485,6 +489,7 @@ export function createCommunitiesDBComponent(
       `
         .append(options.roles ? SQL` AND cm.role = ANY(${options.roles})` : SQL``)
         .append(SQL` WHERE c.active = true`)
+        .append(options.onlyPublicVisible ? SQL` AND c.private = false AND c.unlisted = false` : SQL``)
 
       const query = withSearchAndPagination(baseQuery, {
         sortBy: 'role',

--- a/src/controllers/handlers/http/get-member-communities-handlers.ts
+++ b/src/controllers/handlers/http/get-member-communities-handlers.ts
@@ -17,7 +17,7 @@ export async function getMemberCommunitiesHandler(
     params: { address: memberAddress },
     verification
   } = context
-  const logger = logs.getLogger('get-member-communities-handler')
+  const logger = logs.getLogger('get-community-members-handler')
 
   logger.info(`Getting communities that ${memberAddress} is a member of`)
 

--- a/src/controllers/handlers/http/get-member-communities-handlers.ts
+++ b/src/controllers/handlers/http/get-member-communities-handlers.ts
@@ -1,7 +1,7 @@
 import { HandlerContextWithPath, HTTPResponse } from '../../../types'
 import { errorMessageOrDefault } from '../../../utils/errors'
 import { MemberCommunity } from '../../../logic/community'
-import { getPaginationParams, NotAuthorizedError } from '@dcl/platform-server-commons'
+import { getPaginationParams } from '@dcl/platform-server-commons'
 import { getPaginationResultProperties } from '../../../utils/pagination'
 import { PaginatedResponse } from '@dcl/schemas'
 import { normalizeAddress } from '../../../utils/address'
@@ -17,21 +17,22 @@ export async function getMemberCommunitiesHandler(
     params: { address: memberAddress },
     verification
   } = context
-  const logger = logs.getLogger('get-community-members-handler')
+  const logger = logs.getLogger('get-member-communities-handler')
 
   logger.info(`Getting communities that ${memberAddress} is a member of`)
 
   try {
-    const userAddress = verification!.auth.toLowerCase()
+    const userAddress = verification?.auth ? normalizeAddress(verification.auth) : undefined
     const normalizedMemberAddress = normalizeAddress(memberAddress)
     const pagination = getPaginationParams(context.url.searchParams)
 
-    if (userAddress !== normalizedMemberAddress) {
-      throw new NotAuthorizedError('You are not authorized to get communities for this member')
-    }
+    // Callers other than the member themselves only see publicly visible memberships
+    // (public privacy AND listed visibility). The member sees all of their communities.
+    const onlyPublicVisible = userAddress !== normalizedMemberAddress
 
     const { communities: communitiesData, total } = await communities.getMemberCommunities(normalizedMemberAddress, {
-      pagination
+      pagination,
+      onlyPublicVisible
     })
 
     return {
@@ -47,10 +48,6 @@ export async function getMemberCommunitiesHandler(
   } catch (error) {
     const message = errorMessageOrDefault(error)
     logger.error(`Error getting communities where ${memberAddress} is a member: ${message}`)
-
-    if (error instanceof NotAuthorizedError) {
-      throw error
-    }
 
     return {
       status: 500,

--- a/src/controllers/routes/http.routes.ts
+++ b/src/controllers/routes/http.routes.ts
@@ -99,7 +99,7 @@ export async function setupHttpRoutes(context: GlobalContext): Promise<Router<Gl
   router.post('/v1/communities/:id/members/:memberAddress/bans', signedFetchMiddleware(), banMemberHandler)
   router.delete('/v1/communities/:id/members/:memberAddress/bans', signedFetchMiddleware(), unbanMemberHandler)
 
-  router.get('/v1/members/:address/communities', signedFetchMiddleware(), getMemberCommunitiesHandler)
+  router.get('/v1/members/:address/communities', signedFetchMiddleware({ optional: true }), getMemberCommunitiesHandler)
 
   if (API_ADMIN_TOKEN) {
     router.post(

--- a/src/logic/community/communities.ts
+++ b/src/logic/community/communities.ts
@@ -327,11 +327,15 @@ export function createCommunityComponent(
 
     getMemberCommunities: async (
       memberAddress: string,
-      options: Pick<GetCommunitiesOptions, 'pagination' | 'roles'>
+      options: Pick<GetCommunitiesOptions, 'pagination' | 'roles' | 'onlyPublicVisible'>
     ): Promise<GetCommunitiesWithTotal<MemberCommunity>> => {
       const [communities, total] = await Promise.all([
         communitiesDb.getMemberCommunities(memberAddress, options),
-        communitiesDb.getCommunitiesCount(memberAddress, { onlyMemberOf: true, roles: options.roles })
+        communitiesDb.getCommunitiesCount(memberAddress, {
+          onlyMemberOf: true,
+          roles: options.roles,
+          onlyPublicVisible: options.onlyPublicVisible
+        })
       ])
 
       return { communities, total }

--- a/src/logic/community/types.ts
+++ b/src/logic/community/types.ts
@@ -42,7 +42,7 @@ export interface ICommunitiesComponent {
   ): Promise<GetCommunitiesWithTotal<CommunitySearchResult>>
   getMemberCommunities(
     memberAddress: string,
-    options: Pick<GetCommunitiesOptions, 'pagination' | 'roles'>
+    options: Pick<GetCommunitiesOptions, 'pagination' | 'roles' | 'onlyPublicVisible'>
   ): Promise<GetCommunitiesWithTotal<MemberCommunity>>
   getAllCommunitiesForModeration(
     options: GetCommunitiesOptions
@@ -385,6 +385,8 @@ export type GetCommunitiesOptions = {
   roles?: CommunityRole[]
   communityIds?: string[]
   includeUnlisted?: boolean
+  /** Restrict results to communities anyone can see: public privacy AND listed visibility. */
+  onlyPublicVisible?: boolean
 }
 
 export type GetCommunityMembersOptions = {

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -160,7 +160,7 @@ export interface ICommunitiesDatabaseComponent {
   ): Promise<Omit<AggregatedCommunityWithMemberAndFriendsData, 'ownerName'>[]>
   getCommunitiesCount(
     memberAddress: EthAddress,
-    options: Pick<GetCommunitiesOptions, 'search' | 'onlyMemberOf' | 'roles' | 'communityIds'>
+    options: Pick<GetCommunitiesOptions, 'search' | 'onlyMemberOf' | 'roles' | 'communityIds' | 'onlyPublicVisible'>
   ): Promise<number>
   getCommunitiesPublicInformation(
     options: GetCommunitiesOptions
@@ -188,7 +188,7 @@ export interface ICommunitiesDatabaseComponent {
   getCommunityMembersCount(communityId: string, options?: { filterByMembers?: string[] }): Promise<number>
   getMemberCommunities(
     memberAddress: EthAddress,
-    options: Pick<GetCommunitiesOptions, 'pagination' | 'roles'>
+    options: Pick<GetCommunitiesOptions, 'pagination' | 'roles' | 'onlyPublicVisible'>
   ): Promise<MemberCommunity[]>
   getOnlineMembersFromUserCommunities(
     userAddress: EthAddress,

--- a/test/integration/get-member-communities-controller.spec.ts
+++ b/test/integration/get-member-communities-controller.spec.ts
@@ -12,12 +12,14 @@ test('Get Member Communities Controller', function ({ components, spyComponents 
     let communityId1: string
     let communityId2: string
     let communityId3: string
+    let privateCommunityId: string
+    let unlistedCommunityId: string
 
     beforeEach(async () => {
       identity = await createTestIdentity()
       address = identity.realAccount.address.toLowerCase()
 
-      // Create three communities with different roles for the user
+      // Create three publicly visible communities with different roles for the user
       const result1 = await components.communitiesDb.createCommunity(
         mockCommunity({
           name: 'Owner Community',
@@ -45,6 +47,27 @@ test('Get Member Communities Controller', function ({ components, spyComponents 
       )
       communityId3 = result3.id
 
+      // Memberships that are not publicly visible: a private community and an unlisted one
+      const privateResult = await components.communitiesDb.createCommunity(
+        mockCommunity({
+          name: 'Private Community',
+          description: 'Test Description 4',
+          owner_address: '0x9876543210987654321098765432109876543210',
+          private: true
+        })
+      )
+      privateCommunityId = privateResult.id
+
+      const unlistedResult = await components.communitiesDb.createCommunity(
+        mockCommunity({
+          name: 'Unlisted Community',
+          description: 'Test Description 5',
+          owner_address: '0x9876543210987654321098765432109876543210',
+          unlisted: true
+        })
+      )
+      unlistedCommunityId = unlistedResult.id
+
       await components.communitiesDb.addCommunityMember({
         communityId: communityId1,
         memberAddress: address,
@@ -62,37 +85,91 @@ test('Get Member Communities Controller', function ({ components, spyComponents 
         memberAddress: address,
         role: CommunityRole.Member
       })
+
+      await components.communitiesDb.addCommunityMember({
+        communityId: privateCommunityId,
+        memberAddress: address,
+        role: CommunityRole.Member
+      })
+
+      await components.communitiesDb.addCommunityMember({
+        communityId: unlistedCommunityId,
+        memberAddress: address,
+        role: CommunityRole.Member
+      })
     })
 
     afterEach(async () => {
-      await components.communitiesDbHelper.forceCommunityMemberRemoval(communityId1, [address])
-      await components.communitiesDbHelper.forceCommunityMemberRemoval(communityId2, [address])
-      await components.communitiesDbHelper.forceCommunityMemberRemoval(communityId3, [address])
+      const communityIds = [communityId1, communityId2, communityId3, privateCommunityId, unlistedCommunityId]
 
-      await components.communitiesDbHelper.forceCommunityRemoval(communityId1)
-      await components.communitiesDbHelper.forceCommunityRemoval(communityId2)
-      await components.communitiesDbHelper.forceCommunityRemoval(communityId3)
+      for (const communityId of communityIds) {
+        await components.communitiesDbHelper.forceCommunityMemberRemoval(communityId, [address])
+        await components.communitiesDbHelper.forceCommunityRemoval(communityId)
+      }
     })
 
     describe('and the request is not signed', () => {
-      it('should respond with a 400 status code', async () => {
+      it('should respond with a 200 status code and only the publicly visible communities', async () => {
         const { localHttpFetch } = components
-        const response = await localHttpFetch.fetch(`/v1/members/${address}/communities`)
-        expect(response.status).toBe(400)
+        const response = await localHttpFetch.fetch(`/v1/members/${address}/communities?limit=10&offset=0`)
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body).toEqual({
+          data: {
+            results: [
+              {
+                id: communityId1,
+                name: 'Owner Community',
+                ownerAddress: address,
+                role: CommunityRole.Owner
+              },
+              {
+                id: communityId2,
+                name: 'Moderator Community',
+                ownerAddress: '0x9876543210987654321098765432109876543210',
+                role: CommunityRole.Moderator
+              },
+              {
+                id: communityId3,
+                name: 'Member Community',
+                ownerAddress: '0x9876543210987654321098765432109876543210',
+                role: CommunityRole.Member
+              }
+            ],
+            total: 3,
+            page: 1,
+            pages: 1,
+            limit: 10
+          }
+        })
       })
     })
 
     describe('and the request is signed', () => {
       describe("and requesting another user's communities", () => {
-        it('should respond with a 401 status code', async () => {
-          const otherAddress = '0x9876543210987654321098765432109876543210'
-          const response = await makeRequest(identity, `/v1/members/${otherAddress}/communities`)
-          expect(response.status).toBe(401)
+        let otherIdentity: Identity
+
+        beforeEach(async () => {
+          otherIdentity = await createTestIdentity()
+        })
+
+        it('should respond with a 200 status code and only the publicly visible communities', async () => {
+          const response = await makeRequest(otherIdentity, `/v1/members/${address}/communities?limit=10&offset=0`)
+          const body = await response.json()
+
+          expect(response.status).toBe(200)
+          expect(body.data.results.map((community: { id: string }) => community.id)).toEqual([
+            communityId1,
+            communityId2,
+            communityId3
+          ])
+          expect(body.data.total).toBe(3)
         })
       })
 
       describe('and requesting own communities', () => {
-        it('should respond with a 200 status code and the communities the user is a member of ordered by role', async () => {
+        it('should respond with a 200 status code and all the communities the user is a member of ordered by role', async () => {
           const response = await makeRequest(identity, `/v1/members/${address}/communities?limit=10&offset=0`)
           const body = await response.json()
 
@@ -117,9 +194,21 @@ test('Get Member Communities Controller', function ({ components, spyComponents 
                   name: 'Member Community',
                   ownerAddress: '0x9876543210987654321098765432109876543210',
                   role: CommunityRole.Member
+                },
+                {
+                  id: privateCommunityId,
+                  name: 'Private Community',
+                  ownerAddress: '0x9876543210987654321098765432109876543210',
+                  role: CommunityRole.Member
+                },
+                {
+                  id: unlistedCommunityId,
+                  name: 'Unlisted Community',
+                  ownerAddress: '0x9876543210987654321098765432109876543210',
+                  role: CommunityRole.Member
                 }
               ],
-              total: 3,
+              total: 5,
               page: 1,
               pages: 1,
               limit: 10
@@ -134,7 +223,7 @@ test('Get Member Communities Controller', function ({ components, spyComponents 
           expect(response.status).toBe(200)
           expect(body.data.results).toHaveLength(2)
           expect(body.data.page).toBe(2)
-          expect(body.data.pages).toBe(2)
+          expect(body.data.pages).toBe(3)
         })
       })
 

--- a/test/unit/controllers/handlers/http/get-member-communities-handler.spec.ts
+++ b/test/unit/controllers/handlers/http/get-member-communities-handler.spec.ts
@@ -1,0 +1,96 @@
+import { getMemberCommunitiesHandler } from '../../../../../src/controllers/handlers/http/get-member-communities-handlers'
+import { createLogsMockedComponent } from '../../../../mocks/components'
+import { createMockCommunitiesComponent } from '../../../../mocks/communities'
+import { CommunityRole } from '../../../../../src/types'
+import { ICommunitiesComponent, MemberCommunity } from '../../../../../src/logic/community'
+
+describe('getMemberCommunitiesHandler', () => {
+  let mockLogs: ReturnType<typeof createLogsMockedComponent>
+  let mockCommunities: jest.Mocked<ICommunitiesComponent>
+  let memberAddress: string
+  let memberCommunities: MemberCommunity[]
+
+  const makeRequest = (verification?: { auth: string; authMetadata: Record<string, unknown> }) =>
+    getMemberCommunitiesHandler({
+      components: { communities: mockCommunities, logs: mockLogs },
+      params: { address: memberAddress },
+      url: new URL(`http://localhost/v1/members/${memberAddress}/communities?limit=10&offset=0`),
+      verification
+    } as any)
+
+  beforeEach(() => {
+    memberAddress = '0x1234567890123456789012345678901234567890'
+    memberCommunities = [
+      {
+        id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        name: 'Public Community',
+        ownerAddress: memberAddress,
+        role: CommunityRole.Owner
+      } as MemberCommunity
+    ]
+    mockLogs = createLogsMockedComponent({})
+    mockCommunities = createMockCommunitiesComponent({})
+    mockCommunities.getMemberCommunities.mockResolvedValue({ communities: memberCommunities, total: 1 })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when the caller is the member themselves', () => {
+    it('should request all communities without the public-visible restriction', async () => {
+      const result = await makeRequest({ auth: memberAddress.toUpperCase(), authMetadata: {} })
+
+      expect(result.status).toBe(200)
+      expect(mockCommunities.getMemberCommunities).toHaveBeenCalledWith(memberAddress, {
+        pagination: { limit: 10, offset: 0 },
+        onlyPublicVisible: false
+      })
+    })
+  })
+
+  describe('when the caller is another authenticated user', () => {
+    it('should restrict the results to publicly visible communities', async () => {
+      const result = await makeRequest({ auth: '0x9876543210987654321098765432109876543210', authMetadata: {} })
+
+      expect(result.status).toBe(200)
+      expect(mockCommunities.getMemberCommunities).toHaveBeenCalledWith(memberAddress, {
+        pagination: { limit: 10, offset: 0 },
+        onlyPublicVisible: true
+      })
+    })
+  })
+
+  describe('when the caller is not authenticated', () => {
+    it('should restrict the results to publicly visible communities', async () => {
+      const result = await makeRequest(undefined)
+
+      expect(result.status).toBe(200)
+      expect(result.body).toEqual({
+        data: {
+          results: memberCommunities,
+          total: 1,
+          page: 1,
+          pages: 1,
+          limit: 10
+        }
+      })
+      expect(mockCommunities.getMemberCommunities).toHaveBeenCalledWith(memberAddress, {
+        pagination: { limit: 10, offset: 0 },
+        onlyPublicVisible: true
+      })
+    })
+  })
+
+  describe('when fetching the communities fails', () => {
+    beforeEach(() => {
+      mockCommunities.getMemberCommunities.mockRejectedValue(new Error('Unable to get member communities'))
+    })
+
+    it('should respond with a 500 status code', async () => {
+      const result = await makeRequest({ auth: memberAddress, authMetadata: {} })
+
+      expect(result.status).toBe(500)
+    })
+  })
+})

--- a/test/unit/logic/communities.spec.ts
+++ b/test/unit/logic/communities.spec.ts
@@ -862,6 +862,25 @@ describe('Community Component', () => {
       expect(mockCommunitiesDB.getMemberCommunities).toHaveBeenCalledWith(memberAddress, options)
       expect(mockCommunitiesDB.getCommunitiesCount).toHaveBeenCalledWith(memberAddress, { onlyMemberOf: true })
     })
+
+    describe('and only publicly visible communities are requested', () => {
+      it('should forward the restriction to both the listing and the count queries', async () => {
+        const restrictedOptions = { ...options, onlyPublicVisible: true }
+
+        const result = await communityComponent.getMemberCommunities(memberAddress, restrictedOptions)
+
+        expect(result).toEqual({
+          communities: mockMemberCommunities,
+          total: 1
+        })
+
+        expect(mockCommunitiesDB.getMemberCommunities).toHaveBeenCalledWith(memberAddress, restrictedOptions)
+        expect(mockCommunitiesDB.getCommunitiesCount).toHaveBeenCalledWith(memberAddress, {
+          onlyMemberOf: true,
+          onlyPublicVisible: true
+        })
+      })
+    })
   })
 
   describe('when creating a community', () => {


### PR DESCRIPTION
## What

`GET /v1/members/:address/communities` previously required signed fetch and only allowed the member themselves to query it (any other caller got a 401). It now uses optional signed fetch:

- When the authenticated caller is the member, the full list is returned (unchanged).
- Any other caller — another authenticated user or an unauthenticated request — gets only the member's publicly visible memberships: communities with public privacy AND listed visibility. Private and unlisted memberships are never exposed to third parties.

This enables member profiles to display the communities a user belongs to.

## How

- New `onlyPublicVisible` option in `GetCommunitiesOptions`, applied as `AND c.private = false AND c.unlisted = false` in both `getMemberCommunities` and `getCommunitiesCount`, so results and pagination totals filter consistently and don't leak the existence of private/unlisted memberships.
- The handler resolves the flag from the verification state: `onlyPublicVisible = caller !== :address` (addresses normalized on both sides).
- Route switched to `signedFetchMiddleware({ optional: true })`.
- `getManagedCommunitiesHandler` (admin) shares `getMemberCommunities` and does not pass the flag, so its behavior is unchanged.
- OpenAPI spec updated with the visibility rules.

## Verification

- Unit tests: new handler spec covering self / other user / anonymous / error paths, plus flag forwarding in the communities logic. Full unit suite passes (1584 tests).
- Integration tests: updated `get-member-communities-controller.spec.ts` with private and unlisted fixtures — unsigned and third-party requests return only the 3 publicly visible communities (total included), while the member sees all 5. Adjacent communities suites pass.