### PR TITLE
fix: run docs workflow with node 24 to match engines requirement

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,4 +17,5 @@ jobs:
       api-spec-file: 'docs/openapi.yaml'
       api-spec-name: 'social-service-api'
       output-bundle-file: 'docs/api-reference.yaml'
+      node-version: '24'
     secrets: inherit


### PR DESCRIPTION
## What

The **Publish docs** workflow fails on `yarn install`:

```
error social-service-ea@: The engine "node" is incompatible with this module. Expected version ">=24.0.0". Got "20.20.2"
```

The repo's `engines` field requires Node >= 24 since the uws/node-24 upgrade, but the shared `apps-docs.yml` workflow defaults its `node-version` input to `20`. The workflow only triggers on `docs/**` changes, so the first docs edit after the upgrade surfaced it.

## How

Pass `node-version: '24'` to the reusable workflow, matching `build.yml` (24.x).

## Verification

- `npx @redocly/cli lint docs/openapi.yaml` passes locally on Node 24, so the subsequent lint/bundle steps are unblocked.
- The publish job only runs on push to main; on this PR only the workflow syntax is exercised.