### PR TITLE
fix: cancel unconsumed fetch response bodies to avoid undici socket leaks

### DIFF
--- a/src/adapters/archipelago-stats.ts
+++ b/src/adapters/archipelago-stats.ts
@@ -1,6 +1,6 @@
 import { AppComponents, IArchipelagoStatsComponent } from '../types'
 import { PEERS_CACHE_KEY } from '../utils/peers'
-import { discardResponseBody } from '../utils/fetch'
+import { fetchJson } from '../utils/fetch'
 
 export async function createArchipelagoStatsComponent({
   logs,
@@ -14,14 +14,10 @@ export async function createArchipelagoStatsComponent({
   return {
     async fetchPeers() {
       try {
-        const response = await fetcher.fetch(`${url}/peers`)
-
-        if (!response.ok) {
-          await discardResponseBody(response)
-          throw new Error(`Error fetching peers: ${response.statusText}`)
-        }
-
-        const { peers } = await response.json()
+        const { peers } = await fetchJson<{ peers: { id: string }[] }>(
+          () => fetcher.fetch(`${url}/peers`),
+          (r) => new Error(`Error fetching peers: ${r.statusText}`)
+        )
 
         return peers.map((peer: { id: string }) => peer.id)
       } catch (error: any) {

--- a/src/adapters/archipelago-stats.ts
+++ b/src/adapters/archipelago-stats.ts
@@ -1,6 +1,6 @@
 import { AppComponents, IArchipelagoStatsComponent } from '../types'
 import { PEERS_CACHE_KEY } from '../utils/peers'
-import { drainResponse } from '../utils/fetch'
+import { discardResponseBody } from '../utils/fetch'
 
 export async function createArchipelagoStatsComponent({
   logs,
@@ -17,7 +17,7 @@ export async function createArchipelagoStatsComponent({
         const response = await fetcher.fetch(`${url}/peers`)
 
         if (!response.ok) {
-          await drainResponse(response)
+          await discardResponseBody(response)
           throw new Error(`Error fetching peers: ${response.statusText}`)
         }
 

--- a/src/adapters/archipelago-stats.ts
+++ b/src/adapters/archipelago-stats.ts
@@ -1,5 +1,6 @@
 import { AppComponents, IArchipelagoStatsComponent } from '../types'
 import { PEERS_CACHE_KEY } from '../utils/peers'
+import { drainResponse } from '../utils/fetch'
 
 export async function createArchipelagoStatsComponent({
   logs,
@@ -16,6 +17,7 @@ export async function createArchipelagoStatsComponent({
         const response = await fetcher.fetch(`${url}/peers`)
 
         if (!response.ok) {
+          await drainResponse(response)
           throw new Error(`Error fetching peers: ${response.statusText}`)
         }
 

--- a/src/adapters/cdn-cache-invalidator.ts
+++ b/src/adapters/cdn-cache-invalidator.ts
@@ -1,6 +1,6 @@
 import { getCommunityThumbnailPath } from '../logic/community'
 import { AppComponents, ICdnCacheInvalidatorComponent } from '../types'
-import { drainResponse } from '../utils/fetch'
+import { discardResponseBody } from '../utils/fetch'
 
 export async function createCdnCacheInvalidatorComponent(
   components: Pick<AppComponents, 'config' | 'fetcher'>
@@ -24,7 +24,7 @@ export async function createCdnCacheInvalidatorComponent(
       }
     })
 
-    await drainResponse(response)
+    await discardResponseBody(response)
   }
 
   return { invalidateThumbnail }

--- a/src/adapters/cdn-cache-invalidator.ts
+++ b/src/adapters/cdn-cache-invalidator.ts
@@ -1,5 +1,6 @@
 import { getCommunityThumbnailPath } from '../logic/community'
 import { AppComponents, ICdnCacheInvalidatorComponent } from '../types'
+import { drainResponse } from '../utils/fetch'
 
 export async function createCdnCacheInvalidatorComponent(
   components: Pick<AppComponents, 'config' | 'fetcher'>
@@ -12,7 +13,7 @@ export async function createCdnCacheInvalidatorComponent(
 
   async function invalidateThumbnail(communityId: string): Promise<void> {
     const url = `${CDN_CACHE_INVALIDATOR_API_URL}/invalidate`
-    await fetcher.fetch(url, {
+    const response = await fetcher.fetch(url, {
       method: 'POST',
       body: JSON.stringify({
         files: [getCommunityThumbnailPath(communityId)],
@@ -22,6 +23,8 @@ export async function createCdnCacheInvalidatorComponent(
         Authorization: `Bearer ${CDN_CACHE_INVALIDATOR_API_TOKEN}`
       }
     })
+
+    await drainResponse(response)
   }
 
   return { invalidateThumbnail }

--- a/src/adapters/comms-gatekeeper.ts
+++ b/src/adapters/comms-gatekeeper.ts
@@ -2,7 +2,7 @@ import { ICommsGatekeeperComponent, AppComponents, PrivateMessagesPrivacy, Commu
 import { CommunityVoiceChatAction, CommunityVoiceChatProfileData } from '../logic/community-voice/types'
 import { CommunityVoiceChatStatus } from '../logic/community/types'
 import { isErrorWithMessage } from '../utils/errors'
-import { drainResponse } from '../utils/fetch'
+import { discardResponseBody } from '../utils/fetch'
 
 export class PrivateVoiceChatNotFoundError extends Error {
   constructor(callId: string) {
@@ -42,11 +42,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
-      await drainResponse(response)
+      await discardResponseBody(response)
       logger.info(`Updated user private message privacy metadata for user ${address} to ${privateMessagesPrivacy}`)
     } catch (error) {
       logger.error(
@@ -67,7 +67,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -100,7 +100,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -146,7 +146,7 @@ export const createCommsGatekeeperComponent = async ({
         const data = await response.json()
         usersInVoiceChat = data.users_in_voice_chat
       } else {
-        await drainResponse(response)
+        await discardResponseBody(response)
       }
     } catch (error) {
       logger.error(
@@ -199,7 +199,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -255,7 +255,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -288,11 +288,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
-      await drainResponse(response)
+      await discardResponseBody(response)
       logger.info(`Community voice chat room ended for community ${communityId} by ${userAddress}`)
     } catch (error) {
       logger.error(
@@ -328,11 +328,11 @@ export const createCommsGatekeeperComponent = async ({
       )
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
-      await drainResponse(response)
+      await discardResponseBody(response)
     } catch (error) {
       const action = isRaisingHand ? 'request to speak' : 'withdraw speak request'
       logger.error(
@@ -362,11 +362,11 @@ export const createCommsGatekeeperComponent = async ({
       )
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
-      await drainResponse(response)
+      await discardResponseBody(response)
     } catch (error) {
       logger.error(
         `Failed to reject speak request for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -391,11 +391,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
-      await drainResponse(response)
+      await discardResponseBody(response)
     } catch (error) {
       logger.error(
         `Failed to promote speaker for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -420,11 +420,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
-      await drainResponse(response)
+      await discardResponseBody(response)
     } catch (error) {
       logger.error(
         `Failed to demote speaker for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -474,12 +474,12 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (response.status === 404) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         return null
       }
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -522,7 +522,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -567,7 +567,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -597,11 +597,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
-      await drainResponse(response)
+      await discardResponseBody(response)
     } catch (error) {
       logger.error(
         `Failed to kick user from community voice chat for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -626,7 +626,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -664,11 +664,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
-      await drainResponse(response)
+      await discardResponseBody(response)
     } catch (error) {
       logger.error(
         `Failed to ${muted ? 'mute' : 'unmute'} user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`

--- a/src/adapters/comms-gatekeeper.ts
+++ b/src/adapters/comms-gatekeeper.ts
@@ -2,7 +2,7 @@ import { ICommsGatekeeperComponent, AppComponents, PrivateMessagesPrivacy, Commu
 import { CommunityVoiceChatAction, CommunityVoiceChatProfileData } from '../logic/community-voice/types'
 import { CommunityVoiceChatStatus } from '../logic/community/types'
 import { isErrorWithMessage } from '../utils/errors'
-import { discardResponseBody } from '../utils/fetch'
+import { discardResponseBody, fetchJson, fetchVoid } from '../utils/fetch'
 
 export class PrivateVoiceChatNotFoundError extends Error {
   constructor(callId: string) {
@@ -30,23 +30,19 @@ export const createCommsGatekeeperComponent = async ({
     privateMessagesPrivacy: PrivateMessagesPrivacy
   ): Promise<void> {
     try {
-      const response = await fetch(`${commsUrl}/users/${address}/private-messages-privacy`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        },
-        body: JSON.stringify({
-          private_messages_privacy: privateMessagesPrivacy
+      await fetchVoid(() =>
+        fetch(`${commsUrl}/users/${address}/private-messages-privacy`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          },
+          body: JSON.stringify({
+            private_messages_privacy: privateMessagesPrivacy
+          })
         })
-      })
+      )
 
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      await discardResponseBody(response)
       logger.info(`Updated user private message privacy metadata for user ${address} to ${privateMessagesPrivacy}`)
     } catch (error) {
       logger.error(
@@ -58,20 +54,15 @@ export const createCommsGatekeeperComponent = async ({
 
   async function isUserInAVoiceChat(address: string): Promise<boolean> {
     try {
-      const response = await fetch(`${commsUrl}/users/${address}/voice-chat-status`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        }
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      const data = await response.json()
+      const data = await fetchJson<{ is_user_in_voice_chat?: boolean }>(() =>
+        fetch(`${commsUrl}/users/${address}/voice-chat-status`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          }
+        })
+      )
       return Boolean(data.is_user_in_voice_chat)
     } catch (error) {
       logger.error(
@@ -87,24 +78,19 @@ export const createCommsGatekeeperComponent = async ({
     callerAddress: string
   ): Promise<Record<string, { connectionUrl: string }>> {
     try {
-      const response = await fetch(`${commsUrl}/private-voice-chat`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        },
-        body: JSON.stringify({
-          room_id: roomId,
-          user_addresses: [calleeAddress, callerAddress]
+      const body = await fetchJson<Record<string, { connection_url: string }>>(() =>
+        fetch(`${commsUrl}/private-voice-chat`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          },
+          body: JSON.stringify({
+            room_id: roomId,
+            user_addresses: [calleeAddress, callerAddress]
+          })
         })
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      const body = (await response.json()) as Record<string, { connection_url: string }>
+      )
 
       return Object.entries(body).reduce(
         (acc, [address, { connection_url }]) => {
@@ -189,21 +175,16 @@ export const createCommsGatekeeperComponent = async ({
         requestBody.profile_data = profileData
       }
 
-      const response = await fetch(`${commsUrl}/community-voice-chat`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        },
-        body: JSON.stringify(requestBody)
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      const data = await response.json()
+      const data = await fetchJson<{ connection_url: string }>(() =>
+        fetch(`${commsUrl}/community-voice-chat`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          },
+          body: JSON.stringify(requestBody)
+        })
+      )
       return { connectionUrl: data.connection_url }
     } catch (error) {
       logger.error(
@@ -245,21 +226,16 @@ export const createCommsGatekeeperComponent = async ({
         requestBody.profile_data = profileData
       }
 
-      const response = await fetch(`${commsUrl}/community-voice-chat`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        },
-        body: JSON.stringify(requestBody)
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      const data = await response.json()
+      const data = await fetchJson<{ connection_url: string }>(() =>
+        fetch(`${commsUrl}/community-voice-chat`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          },
+          body: JSON.stringify(requestBody)
+        })
+      )
       return { connectionUrl: data.connection_url }
     } catch (error) {
       logger.error(
@@ -276,23 +252,19 @@ export const createCommsGatekeeperComponent = async ({
    */
   async function endCommunityVoiceChatRoom(communityId: string, userAddress: string): Promise<void> {
     try {
-      const response = await fetch(`${commsUrl}/community-voice-chat/${communityId}`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        },
-        body: JSON.stringify({
-          user_address: userAddress
+      await fetchVoid(() =>
+        fetch(`${commsUrl}/community-voice-chat/${communityId}`, {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          },
+          body: JSON.stringify({
+            user_address: userAddress
+          })
         })
-      })
+      )
 
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      await discardResponseBody(response)
       logger.info(`Community voice chat room ended for community ${communityId} by ${userAddress}`)
     } catch (error) {
       logger.error(
@@ -316,23 +288,15 @@ export const createCommsGatekeeperComponent = async ({
     try {
       const method = isRaisingHand ? 'POST' : 'DELETE'
 
-      const response = await fetch(
-        `${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}/speak-request`,
-        {
+      await fetchVoid(() =>
+        fetch(`${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}/speak-request`, {
           method,
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${commsGateKeeperToken}`
           }
-        }
+        })
       )
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      await discardResponseBody(response)
     } catch (error) {
       const action = isRaisingHand ? 'request to speak' : 'withdraw speak request'
       logger.error(
@@ -350,23 +314,15 @@ export const createCommsGatekeeperComponent = async ({
    */
   async function rejectSpeakRequestInCommunityVoiceChat(communityId: string, userAddress: string): Promise<void> {
     try {
-      const response = await fetch(
-        `${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}/speak-request`,
-        {
+      await fetchVoid(() =>
+        fetch(`${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}/speak-request`, {
           method: 'DELETE',
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${commsGateKeeperToken}`
           }
-        }
+        })
       )
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      await discardResponseBody(response)
     } catch (error) {
       logger.error(
         `Failed to reject speak request for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -382,20 +338,15 @@ export const createCommsGatekeeperComponent = async ({
    */
   async function promoteSpeakerInCommunityVoiceChat(communityId: string, userAddress: string): Promise<void> {
     try {
-      const response = await fetch(`${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}/speaker`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        }
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      await discardResponseBody(response)
+      await fetchVoid(() =>
+        fetch(`${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}/speaker`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          }
+        })
+      )
     } catch (error) {
       logger.error(
         `Failed to promote speaker for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -411,20 +362,15 @@ export const createCommsGatekeeperComponent = async ({
    */
   async function demoteSpeakerInCommunityVoiceChat(communityId: string, userAddress: string): Promise<void> {
     try {
-      const response = await fetch(`${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}/speaker`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        }
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      await discardResponseBody(response)
+      await fetchVoid(() =>
+        fetch(`${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}/speaker`, {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          }
+        })
+      )
     } catch (error) {
       logger.error(
         `Failed to demote speaker for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -510,23 +456,18 @@ export const createCommsGatekeeperComponent = async ({
     }
 
     try {
-      const response = await fetch(`${commsUrl}/community-voice-chat/status`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        },
-        body: JSON.stringify({
-          community_ids: communityIds
+      const responseData = await fetchJson<{ data?: any[] }>(() =>
+        fetch(`${commsUrl}/community-voice-chat/status`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          },
+          body: JSON.stringify({
+            community_ids: communityIds
+          })
         })
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      const responseData = await response.json()
+      )
       const statuses = responseData.data || []
 
       // Map the response data to the expected format
@@ -558,20 +499,17 @@ export const createCommsGatekeeperComponent = async ({
     }>
   > {
     try {
-      const response = await fetch(`${commsUrl}/community-voice-chat/active`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        }
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      const data = await response.json()
+      const data = await fetchJson<{
+        data?: Array<{ communityId: string; participantCount: number; moderatorCount: number }>
+      }>(() =>
+        fetch(`${commsUrl}/community-voice-chat/active`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          }
+        })
+      )
       return data.data || []
     } catch (error) {
       logger.error(
@@ -588,20 +526,15 @@ export const createCommsGatekeeperComponent = async ({
    */
   async function kickUserFromCommunityVoiceChat(communityId: string, userAddress: string): Promise<void> {
     try {
-      const response = await fetch(`${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        }
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      await discardResponseBody(response)
+      await fetchVoid(() =>
+        fetch(`${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}`, {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          }
+        })
+      )
     } catch (error) {
       logger.error(
         `Failed to kick user from community voice chat for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -617,20 +550,15 @@ export const createCommsGatekeeperComponent = async ({
    */
   async function isUserInCommunityVoiceChat(userAddress: string): Promise<boolean> {
     try {
-      const response = await fetch(`${commsUrl}/users/${userAddress}/community-voice-chat-status`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        }
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      const data = await response.json()
+      const data = await fetchJson<{ isInCommunityVoiceChat: boolean }>(() =>
+        fetch(`${commsUrl}/users/${userAddress}/community-voice-chat-status`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          }
+        })
+      )
       return data.isInCommunityVoiceChat
     } catch (error) {
       logger.error(
@@ -652,23 +580,18 @@ export const createCommsGatekeeperComponent = async ({
     muted: boolean
   ): Promise<void> {
     try {
-      const response = await fetch(`${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}/mute`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${commsGateKeeperToken}`
-        },
-        body: JSON.stringify({
-          muted
+      await fetchVoid(() =>
+        fetch(`${commsUrl}/community-voice-chat/${communityId}/users/${userAddress}/mute`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${commsGateKeeperToken}`
+          },
+          body: JSON.stringify({
+            muted
+          })
         })
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Server responded with status ${response.status}`)
-      }
-
-      await discardResponseBody(response)
+      )
     } catch (error) {
       logger.error(
         `Failed to ${muted ? 'mute' : 'unmute'} user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`

--- a/src/adapters/comms-gatekeeper.ts
+++ b/src/adapters/comms-gatekeeper.ts
@@ -2,6 +2,7 @@ import { ICommsGatekeeperComponent, AppComponents, PrivateMessagesPrivacy, Commu
 import { CommunityVoiceChatAction, CommunityVoiceChatProfileData } from '../logic/community-voice/types'
 import { CommunityVoiceChatStatus } from '../logic/community/types'
 import { isErrorWithMessage } from '../utils/errors'
+import { drainResponse } from '../utils/fetch'
 
 export class PrivateVoiceChatNotFoundError extends Error {
   constructor(callId: string) {
@@ -41,8 +42,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
+
+      await drainResponse(response)
       logger.info(`Updated user private message privacy metadata for user ${address} to ${privateMessagesPrivacy}`)
     } catch (error) {
       logger.error(
@@ -63,6 +67,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -95,6 +100,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -139,6 +145,8 @@ export const createCommsGatekeeperComponent = async ({
       if (response.ok) {
         const data = await response.json()
         usersInVoiceChat = data.users_in_voice_chat
+      } else {
+        await drainResponse(response)
       }
     } catch (error) {
       logger.error(
@@ -191,6 +199,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -246,6 +255,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -278,9 +288,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
+      await drainResponse(response)
       logger.info(`Community voice chat room ended for community ${communityId} by ${userAddress}`)
     } catch (error) {
       logger.error(
@@ -316,8 +328,11 @@ export const createCommsGatekeeperComponent = async ({
       )
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
+
+      await drainResponse(response)
     } catch (error) {
       const action = isRaisingHand ? 'request to speak' : 'withdraw speak request'
       logger.error(
@@ -347,8 +362,11 @@ export const createCommsGatekeeperComponent = async ({
       )
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
+
+      await drainResponse(response)
     } catch (error) {
       logger.error(
         `Failed to reject speak request for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -373,8 +391,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
+
+      await drainResponse(response)
     } catch (error) {
       logger.error(
         `Failed to promote speaker for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -399,8 +420,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
+
+      await drainResponse(response)
     } catch (error) {
       logger.error(
         `Failed to demote speaker for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -450,10 +474,12 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (response.status === 404) {
+        await drainResponse(response)
         return null
       }
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -496,6 +522,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -540,6 +567,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -569,8 +597,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
+
+      await drainResponse(response)
     } catch (error) {
       logger.error(
         `Failed to kick user from community voice chat for user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
@@ -595,6 +626,7 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
 
@@ -632,8 +664,11 @@ export const createCommsGatekeeperComponent = async ({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Server responded with status ${response.status}`)
       }
+
+      await drainResponse(response)
     } catch (error) {
       logger.error(
         `Failed to ${muted ? 'mute' : 'unmute'} user ${userAddress} in community ${communityId}: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`

--- a/src/adapters/email.ts
+++ b/src/adapters/email.ts
@@ -1,5 +1,5 @@
 import { AppComponents, IEmailComponent } from '../types'
-import { drainResponse } from '../utils/fetch'
+import { discardResponseBody } from '../utils/fetch'
 
 export async function createEmailComponent(
   components: Pick<AppComponents, 'fetcher' | 'config'>
@@ -22,7 +22,7 @@ export async function createEmailComponent(
     })
 
     if (response.ok) {
-      await drainResponse(response)
+      await discardResponseBody(response)
       return
     }
 

--- a/src/adapters/email.ts
+++ b/src/adapters/email.ts
@@ -1,5 +1,5 @@
 import { AppComponents, IEmailComponent } from '../types'
-import { discardResponseBody } from '../utils/fetch'
+import { fetchVoid } from '../utils/fetch'
 
 export async function createEmailComponent(
   components: Pick<AppComponents, 'fetcher' | 'config'>
@@ -11,22 +11,19 @@ export async function createEmailComponent(
 
   async function sendEmail(email: string, subject: string, content: string): Promise<void> {
     const url = new URL('/notifications/email', notificationUrl).toString()
-    const response = await fetcher.fetch(url, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${internalApiKey}`
-      },
-      body: JSON.stringify({ subject, content, email })
-    })
-
-    if (response.ok) {
-      await discardResponseBody(response)
-      return
-    }
-
-    throw new Error(`Failed to fetch ${url}: ${response.status} ${await response.text()}`)
+    await fetchVoid(
+      () =>
+        fetcher.fetch(url, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${internalApiKey}`
+          },
+          body: JSON.stringify({ subject, content, email })
+        }),
+      async (r) => new Error(`Failed to fetch ${url}: ${r.status} ${await r.text()}`)
+    )
   }
 
   return {

--- a/src/adapters/email.ts
+++ b/src/adapters/email.ts
@@ -1,4 +1,5 @@
 import { AppComponents, IEmailComponent } from '../types'
+import { drainResponse } from '../utils/fetch'
 
 export async function createEmailComponent(
   components: Pick<AppComponents, 'fetcher' | 'config'>
@@ -21,6 +22,7 @@ export async function createEmailComponent(
     })
 
     if (response.ok) {
+      await drainResponse(response)
       return
     }
 

--- a/src/adapters/places-api.ts
+++ b/src/adapters/places-api.ts
@@ -1,5 +1,5 @@
 import { AppComponents, IPlacesApiComponent } from '../types'
-import { drainResponse } from '../utils/fetch'
+import { discardResponseBody } from '../utils/fetch'
 
 export type PlacesApiResponse = {
   total?: number
@@ -27,7 +27,7 @@ export async function createPlacesApiAdapter(
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error('Failed to get destinations')
       }
 

--- a/src/adapters/places-api.ts
+++ b/src/adapters/places-api.ts
@@ -1,4 +1,5 @@
 import { AppComponents, IPlacesApiComponent } from '../types'
+import { drainResponse } from '../utils/fetch'
 
 export type PlacesApiResponse = {
   total?: number
@@ -26,6 +27,7 @@ export async function createPlacesApiAdapter(
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error('Failed to get destinations')
       }
 

--- a/src/adapters/places-api.ts
+++ b/src/adapters/places-api.ts
@@ -1,5 +1,5 @@
 import { AppComponents, IPlacesApiComponent } from '../types'
-import { discardResponseBody } from '../utils/fetch'
+import { fetchJson } from '../utils/fetch'
 
 export type PlacesApiResponse = {
   total?: number
@@ -18,20 +18,17 @@ export async function createPlacesApiAdapter(
     getDestinations: async (placeIds: string[], worldNames: string[]): Promise<PlacesApiResponse['data']> => {
       if (placeIds.length === 0 && worldNames.length === 0) return []
 
-      const response = await fetcher.fetch(`${placesApiUrl}/api/destinations`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify([...placeIds, ...worldNames])
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error('Failed to get destinations')
-      }
-
-      const parsedResponse = (await response.json()) as PlacesApiResponse
+      const parsedResponse = await fetchJson<PlacesApiResponse>(
+        () =>
+          fetcher.fetch(`${placesApiUrl}/api/destinations`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify([...placeIds, ...worldNames])
+          }),
+        () => new Error('Failed to get destinations')
+      )
 
       return parsedResponse.data ?? []
     }

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -2,6 +2,7 @@ import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 import { AppComponents, IRegistryComponent } from '../types'
 import { extractMinimalProfile, getProfileUserId } from '../logic/profiles'
 import { withoutTracing } from '../utils/tracing'
+import { drainResponse } from '../utils/fetch'
 
 export const PROFILE_CACHE_PREFIX = 'catalyst:minimal:profile:'
 
@@ -61,6 +62,7 @@ export async function createRegistryComponent({
       })
 
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Failed to fetch profiles from registry: ${response.statusText}`)
       }
 
@@ -101,6 +103,7 @@ export async function createRegistryComponent({
     })
 
     if (!response.ok) {
+      await drainResponse(response)
       throw new Error(`Failed to fetch profile from registry: ${response.statusText}`)
     }
 

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -2,7 +2,7 @@ import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 import { AppComponents, IRegistryComponent } from '../types'
 import { extractMinimalProfile, getProfileUserId } from '../logic/profiles'
 import { withoutTracing } from '../utils/tracing'
-import { drainResponse } from '../utils/fetch'
+import { discardResponseBody } from '../utils/fetch'
 
 export const PROFILE_CACHE_PREFIX = 'catalyst:minimal:profile:'
 
@@ -62,7 +62,7 @@ export async function createRegistryComponent({
       })
 
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Failed to fetch profiles from registry: ${response.statusText}`)
       }
 
@@ -103,7 +103,7 @@ export async function createRegistryComponent({
     })
 
     if (!response.ok) {
-      await drainResponse(response)
+      await discardResponseBody(response)
       throw new Error(`Failed to fetch profile from registry: ${response.statusText}`)
     }
 

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -2,7 +2,7 @@ import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 import { AppComponents, IRegistryComponent } from '../types'
 import { extractMinimalProfile, getProfileUserId } from '../logic/profiles'
 import { withoutTracing } from '../utils/tracing'
-import { discardResponseBody } from '../utils/fetch'
+import { fetchJson } from '../utils/fetch'
 
 export const PROFILE_CACHE_PREFIX = 'catalyst:minimal:profile:'
 
@@ -56,17 +56,14 @@ export async function createRegistryComponent({
     let validProfiles: Profile[] = []
 
     if (idsToFetch.length > 0) {
-      const response = await fetcher.fetch(`${registryUrl}/profiles`, {
-        method: 'POST',
-        body: JSON.stringify({ ids: idsToFetch })
-      })
-
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Failed to fetch profiles from registry: ${response.statusText}`)
-      }
-
-      const registryResults = (await response.json()) as Profile[]
+      const registryResults = await fetchJson<Profile[]>(
+        () =>
+          fetcher.fetch(`${registryUrl}/profiles`, {
+            method: 'POST',
+            body: JSON.stringify({ ids: idsToFetch })
+          }),
+        (r) => new Error(`Failed to fetch profiles from registry: ${r.statusText}`)
+      )
 
       const minimalProfiles = registryResults.map(extractMinimalProfile).filter(Boolean) as Profile[]
       validProfiles = minimalProfiles
@@ -97,17 +94,14 @@ export async function createRegistryComponent({
       return cachedProfile
     }
 
-    const response = await fetcher.fetch(`${registryUrl}/profiles`, {
-      method: 'POST',
-      body: JSON.stringify({ ids: [id] })
-    })
-
-    if (!response.ok) {
-      await discardResponseBody(response)
-      throw new Error(`Failed to fetch profile from registry: ${response.statusText}`)
-    }
-
-    const registryResults = (await response.json()) as Profile[]
+    const registryResults = await fetchJson<Profile[]>(
+      () =>
+        fetcher.fetch(`${registryUrl}/profiles`, {
+          method: 'POST',
+          body: JSON.stringify({ ids: [id] })
+        }),
+      (r) => new Error(`Failed to fetch profile from registry: ${r.statusText}`)
+    )
 
     if (registryResults.length === 0) {
       throw new Error(`Profile not found: ${id}`)

--- a/src/logic/community/events.ts
+++ b/src/logic/community/events.ts
@@ -1,6 +1,6 @@
 import { AppComponents } from '../../types'
 import { ICommunityEventsComponent } from './types'
-import { drainResponse } from '../../utils/fetch'
+import { discardResponseBody } from '../../utils/fetch'
 
 type Event = {
   id: string
@@ -77,8 +77,8 @@ export async function createCommunityEventsComponent(
       const response = await fetcher.fetch(url)
 
       if (!response.ok) {
+        await discardResponseBody(response)
         logger.error('Failed to check live events', { communityId, status: response.status })
-        await drainResponse(response)
         return false
       }
 

--- a/src/logic/community/events.ts
+++ b/src/logic/community/events.ts
@@ -1,5 +1,6 @@
 import { AppComponents } from '../../types'
 import { ICommunityEventsComponent } from './types'
+import { drainResponse } from '../../utils/fetch'
 
 type Event = {
   id: string
@@ -77,6 +78,7 @@ export async function createCommunityEventsComponent(
 
       if (!response.ok) {
         logger.error('Failed to check live events', { communityId, status: response.status })
+        await drainResponse(response)
         return false
       }
 

--- a/src/logic/referral/referral.ts
+++ b/src/logic/referral/referral.ts
@@ -16,7 +16,7 @@ import {
   referralIpMatchRejectionMessage,
   referralSuspiciousTimingMessage
 } from '../../utils/slackMessages'
-import { discardResponseBody } from '../../utils/fetch'
+import { fetchJson } from '../../utils/fetch'
 
 const TIERS = [5, 10, 20, 25, 30, 50, 60, 75]
 const TIERS_IRL_SWAG = 100
@@ -132,12 +132,10 @@ export async function createReferralComponent(
 
   async function fetchDenyList(): Promise<Set<string>> {
     try {
-      const response = await fetch('https://config.decentraland.org/denylist.json')
-      if (!response.ok) {
-        await discardResponseBody(response)
-        throw new Error(`Failed to fetch deny list, status: ${response.status}`)
-      }
-      const data = await response.json()
+      const data = await fetchJson<{ users?: { wallet: string }[] }>(
+        () => fetch('https://config.decentraland.org/denylist.json'),
+        (r) => new Error(`Failed to fetch deny list, status: ${r.status}`)
+      )
       if (data.users && Array.isArray(data.users)) {
         return new Set(data.users.map((user: { wallet: string }) => user.wallet.toLocaleLowerCase()))
       } else {

--- a/src/logic/referral/referral.ts
+++ b/src/logic/referral/referral.ts
@@ -16,7 +16,7 @@ import {
   referralIpMatchRejectionMessage,
   referralSuspiciousTimingMessage
 } from '../../utils/slackMessages'
-import { drainResponse } from '../../utils/fetch'
+import { discardResponseBody } from '../../utils/fetch'
 
 const TIERS = [5, 10, 20, 25, 30, 50, 60, 75]
 const TIERS_IRL_SWAG = 100
@@ -134,7 +134,7 @@ export async function createReferralComponent(
     try {
       const response = await fetch('https://config.decentraland.org/denylist.json')
       if (!response.ok) {
-        await drainResponse(response)
+        await discardResponseBody(response)
         throw new Error(`Failed to fetch deny list, status: ${response.status}`)
       }
       const data = await response.json()

--- a/src/logic/referral/referral.ts
+++ b/src/logic/referral/referral.ts
@@ -16,6 +16,7 @@ import {
   referralIpMatchRejectionMessage,
   referralSuspiciousTimingMessage
 } from '../../utils/slackMessages'
+import { drainResponse } from '../../utils/fetch'
 
 const TIERS = [5, 10, 20, 25, 30, 50, 60, 75]
 const TIERS_IRL_SWAG = 100
@@ -133,6 +134,7 @@ export async function createReferralComponent(
     try {
       const response = await fetch('https://config.decentraland.org/denylist.json')
       if (!response.ok) {
+        await drainResponse(response)
         throw new Error(`Failed to fetch deny list, status: ${response.status}`)
       }
       const data = await response.json()

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,8 +1,9 @@
 // Native fetch (undici) keeps the keep-alive socket pinned until the response body is
 // consumed or cancelled. Any path that discards a response without reading its body
 // (a non-ok early return/throw, a void success path, or a fire-and-forget request)
-// must drain it first. Typed structurally so it accepts the global and undici Response.
-export async function drainResponse(response: {
+// must release it first. This cancels the body (aborts it without reading) rather than
+// reading it to completion. Typed structurally so it accepts the global and undici Response.
+export async function discardResponseBody(response: {
   bodyUsed: boolean
   body?: { cancel(): Promise<void> } | null
 }): Promise<void> {

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,12 @@
+// Native fetch (undici) keeps the keep-alive socket pinned until the response body is
+// consumed or cancelled. Any path that discards a response without reading its body
+// (a non-ok early return/throw, a void success path, or a fire-and-forget request)
+// must drain it first. Typed structurally so it accepts the global and undici Response.
+export async function drainResponse(response: {
+  bodyUsed: boolean
+  body?: { cancel(): Promise<void> } | null
+}): Promise<void> {
+  if (!response.bodyUsed) {
+    await response.body?.cancel().catch(() => undefined)
+  }
+}

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,3 +1,8 @@
+import type { IFetchComponent } from '@dcl/core-commons'
+
+// The Response type returned by the fetch component (the global/undici Response shipped with Node).
+type FetchResponse = Awaited<ReturnType<IFetchComponent['fetch']>>
+
 // Native fetch (undici) keeps the keep-alive socket pinned until the response body is
 // consumed or cancelled. Any path that discards a response without reading its body
 // (a non-ok early return/throw, a void success path, or a fire-and-forget request)
@@ -10,4 +15,40 @@ export async function discardResponseBody(response: {
   if (!response.bodyUsed) {
     await response.body?.cancel().catch(() => undefined)
   }
+}
+
+/**
+ * Fetches and parses JSON, ALWAYS releasing the body so the socket can't leak: on a non-ok
+ * response it discards the body and throws (a generic "Server responded with status N" error
+ * by default, or the error returned by `onError`); on ok it reads and returns the JSON.
+ * Prefer this over a raw fetch + manual discardResponseBody for request/response calls.
+ */
+export async function fetchJson<T>(
+  doFetch: () => Promise<FetchResponse>,
+  onError?: (response: FetchResponse) => Error | Promise<Error>
+): Promise<T> {
+  const response = await doFetch()
+  if (!response.ok) {
+    const error = onError ? await onError(response) : new Error(`Server responded with status ${response.status}`)
+    await discardResponseBody(response)
+    throw error
+  }
+  return (await response.json()) as T
+}
+
+/**
+ * Like fetchJson, but for endpoints whose response body is never read. Releases the body on
+ * EVERY path (success and failure) and throws on a non-ok response.
+ */
+export async function fetchVoid(
+  doFetch: () => Promise<FetchResponse>,
+  onError?: (response: FetchResponse) => Error | Promise<Error>
+): Promise<void> {
+  const response = await doFetch()
+  if (!response.ok) {
+    const error = onError ? await onError(response) : new Error(`Server responded with status ${response.status}`)
+    await discardResponseBody(response)
+    throw error
+  }
+  await discardResponseBody(response)
 }


### PR DESCRIPTION
## Problem

This service was recently migrated to native `fetch` (`@dcl/fetch-component`, backed by undici). Under undici, the keep-alive socket behind a `Response` stays **pinned until the body is consumed or cancelled**. No body-drain pass was done during the migration, so every fetch path that discards a response without reading its body (`.json()`/`.text()`/`.arrayBuffer()`) — a non-ok early `throw`/`return`, a void success path, or a fire-and-forget request — leaked that socket until GC reclaimed the response. Under load this exhausts the keep-alive pool.

## Fix

Add a small `drainResponse` helper that cancels the body **only when it hasn't already been read** (so it is a safe no-op on paths that consume the body), and apply it at every discard site.

```ts
export async function drainResponse(response: {
  bodyUsed: boolean
  body?: { cancel(): Promise<void> } | null
}): Promise<void> {
  if (!response.bodyUsed) {
    await response.body?.cancel().catch(() => undefined)
  }
}
```

### Sites drained

**`src/adapters/comms-gatekeeper.ts`**
- `!ok` throw branch of every method: `updateUserPrivateMessagePrivacyMetadata`, `isUserInAVoiceChat`, `getPrivateVoiceChatCredentials`, `getCommunityVoiceChatCredentials`, `createCommunityVoiceChatRoom`, `endCommunityVoiceChatRoom`, `requestToSpeakInCommunityVoiceChat`, `rejectSpeakRequestInCommunityVoiceChat`, `promoteSpeakerInCommunityVoiceChat`, `demoteSpeakerInCommunityVoiceChat`, `getCommunityVoiceChatStatus`, `getCommunitiesVoiceChatStatus`, `getAllActiveCommunityVoiceChats`, `kickUserFromCommunityVoiceChat`, `isUserInCommunityVoiceChat`, `muteSpeakerInCommunityVoiceChat`.
- **Success path also drained** for the void methods that never read the body on success: `updateUserPrivateMessagePrivacyMetadata`, `endCommunityVoiceChatRoom`, `requestToSpeakInCommunityVoiceChat`, `rejectSpeakRequestInCommunityVoiceChat`, `promoteSpeakerInCommunityVoiceChat`, `demoteSpeakerInCommunityVoiceChat`, `kickUserFromCommunityVoiceChat`, `muteSpeakerInCommunityVoiceChat`.
- `endPrivateVoiceChat`: added an `else { await drainResponse(response) }` so the `!ok` path drains.
- `getCommunityVoiceChatStatus`: drains both the `status === 404` return-null branch and the `!ok` throw branch.

**`src/adapters/places-api.ts`** — drain before the throw in the `!ok` branch.
**`src/adapters/archipelago-stats.ts`** — drain before the throw in the `!ok` branch.
**`src/adapters/registry.ts`** — both fetch sites (`getProfiles`, `getProfile`): drain before the throw in each `!ok` branch.
**`src/adapters/email.ts`** (`sendEmail`) — drain before the `ok` success `return` (the `!ok` path already reads `.text()`).
**`src/adapters/cdn-cache-invalidator.ts`** (`invalidateThumbnail`) — capture the previously fire-and-forget request and drain it.
**`src/logic/community/events.ts`** (`fetchLiveEvents`) — drain before the `!ok` `return false`.
**`src/logic/referral/referral.ts`** (`fetchDenyList`) — drain before the throw in the `!ok` branch.

### Left unchanged

**`src/adapters/rewards.ts`** already consumes the body on both paths (`.json()` on ok, `await response.text()` in the error message), so there is no leak — left as-is.

## Verification

- `yarn build` (tsc) — pass
- `eslint` on changed files — pass
- Full unit suite — **106 suites / 1596 tests** pass
- Full integration suite (docker: redis, nats, localstack, postgres) — **49 suites / 602 tests** pass

No test stub needed a `body.cancel` shim: all mocked `Response` objects set only `ok`/`status`/`json`/`text`, so `drainResponse` short-circuits on `response.body?` (undefined) as a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)