### PR TITLE
fix: stop duplicate-subscription log flood; add wsConnectionId + metric

### DIFF
--- a/src/adapters/rpc-server/rpc-server.ts
+++ b/src/adapters/rpc-server/rpc-server.ts
@@ -98,14 +98,15 @@ export async function createRpcServerComponent({
         // Don't throw - we want cleanup to continue even if this fails
       }
     },
-    attachUser({ transport, address }) {
+    attachUser({ transport, address, wsConnectionId }) {
       const eventEmitter = subscribersContext.getOrAddSubscriber(address)
       subscribersContext.addSubscriber(address, eventEmitter).catch((error) => {
         logger.error('Failed to add subscriber', { address, error })
       })
       rpcServer.attachTransport(transport, {
         subscribersContext,
-        address
+        address,
+        wsConnectionId
       })
     },
     detachUser(address) {

--- a/src/components.ts
+++ b/src/components.ts
@@ -294,7 +294,8 @@ export async function initComponents(): Promise<AppComponents> {
     subscribersContext,
     friendsDb,
     communityMembers,
-    registry
+    registry,
+    metrics
   })
 
   const rpcServer = await createRpcServerComponent({

--- a/src/controllers/handlers/rpc/subscribe-to-block-updates.ts
+++ b/src/controllers/handlers/rpc/subscribe-to-block-updates.ts
@@ -9,11 +9,9 @@ export function subscribeToBlockUpdatesService({
   const logger = logs.getLogger('subscribe-to-block-updates-service')
 
   return async function* (_request: Empty, context: RpcServerContext): AsyncGenerator<BlockUpdate> {
-    let cleanup: (() => void) | undefined
-
     // The blocked/unblocked user should know who blocked/unblocked them
     try {
-      cleanup = yield* updateHandler.handleSubscriptionUpdates<BlockUpdate, SubscriptionEventsEmitter['blockUpdate']>({
+      yield* updateHandler.handleSubscriptionUpdates<BlockUpdate, SubscriptionEventsEmitter['blockUpdate']>({
         rpcContext: context,
         eventName: 'blockUpdate',
         shouldRetrieveProfile: false,
@@ -25,9 +23,6 @@ export function subscribeToBlockUpdatesService({
     } catch (error: any) {
       logger.error('Error in block updates subscription:', error)
       throw error
-    } finally {
-      logger.info('Closing block updates subscription')
-      cleanup?.()
     }
   }
 }

--- a/src/controllers/handlers/rpc/subscribe-to-community-member-connectivity-updates.ts
+++ b/src/controllers/handlers/rpc/subscribe-to-community-member-connectivity-updates.ts
@@ -29,10 +29,8 @@ export function subscribeToCommunityMemberConnectivityUpdatesService({
     _request: Empty,
     context: RpcServerContext
   ): AsyncGenerator<CommunityMemberConnectivityUpdate> {
-    let cleanup: (() => void) | undefined
-
     try {
-      cleanup = yield* updateHandler.handleSubscriptionUpdates<
+      yield* updateHandler.handleSubscriptionUpdates<
         CommunityMemberConnectivityUpdate,
         SubscriptionEventsEmitter['communityMemberConnectivityUpdate']
       >({
@@ -46,9 +44,6 @@ export function subscribeToCommunityMemberConnectivityUpdatesService({
     } catch (error: any) {
       logger.error('Error in community member connectivity updates subscription:', error)
       throw error
-    } finally {
-      logger.info('Cleaning up community member connectivity updates subscription')
-      cleanup?.()
     }
   }
 }

--- a/src/controllers/handlers/rpc/subscribe-to-community-voice-chat-updates.ts
+++ b/src/controllers/handlers/rpc/subscribe-to-community-voice-chat-updates.ts
@@ -29,10 +29,8 @@ export function subscribeToCommunityVoiceChatUpdatesService({
   const logger = logs.getLogger('subscribe-to-community-voice-chat-updates-service')
 
   return async function* (_request: Empty, context: RpcServerContext): AsyncGenerator<CommunityVoiceChatUpdate> {
-    let cleanup: (() => void) | undefined
-
     try {
-      cleanup = yield* updateHandler.handleSubscriptionUpdates<
+      yield* updateHandler.handleSubscriptionUpdates<
         CommunityVoiceChatUpdate,
         SubscriptionEventsEmitter['communityVoiceChatUpdate']
       >({
@@ -47,9 +45,6 @@ export function subscribeToCommunityVoiceChatUpdatesService({
       const errorMessage = isErrorWithMessage(error) ? error.message : 'Unknown error'
       logger.error(`Error in community voice chat updates subscription: ${errorMessage}`)
       throw error
-    } finally {
-      logger.info('Closing community voice chat updates subscription')
-      cleanup?.()
     }
   }
 }

--- a/src/controllers/handlers/rpc/subscribe-to-friend-connectivity-updates.ts
+++ b/src/controllers/handlers/rpc/subscribe-to-friend-connectivity-updates.ts
@@ -12,8 +12,6 @@ export function subscribeToFriendConnectivityUpdatesService({
   const logger = logs.getLogger('subscribe-to-friend-connectivity-updates-service')
 
   return async function* (_request: Empty, context: RpcServerContext): AsyncGenerator<FriendConnectivityUpdate> {
-    let cleanup: (() => void) | undefined
-
     try {
       const onlinePeers = await peersStats.getConnectedPeers()
       const onlineFriends = await friendsDb.getOnlineFriends(context.address, onlinePeers)
@@ -26,7 +24,7 @@ export function subscribeToFriendConnectivityUpdatesService({
 
       yield* parsedProfiles
 
-      cleanup = yield* updateHandler.handleSubscriptionUpdates<
+      yield* updateHandler.handleSubscriptionUpdates<
         FriendConnectivityUpdate,
         SubscriptionEventsEmitter['friendConnectivityUpdate']
       >({
@@ -41,9 +39,6 @@ export function subscribeToFriendConnectivityUpdatesService({
     } catch (error: any) {
       logger.error('Error in friend connectivity updates subscription:', error)
       throw error
-    } finally {
-      logger.info('Cleaning up friend connectivity updates subscription')
-      cleanup?.()
     }
   }
 }

--- a/src/controllers/handlers/rpc/subscribe-to-friendship-updates.ts
+++ b/src/controllers/handlers/rpc/subscribe-to-friendship-updates.ts
@@ -9,13 +9,8 @@ export function subscribeToFriendshipUpdatesService({
   const logger = logs.getLogger('subscribe-to-friendship-updates-service')
 
   return async function* (_request: Empty, context: RpcServerContext): AsyncGenerator<FriendshipUpdate> {
-    let cleanup: (() => void) | undefined
-
     try {
-      cleanup = yield* updateHandler.handleSubscriptionUpdates<
-        FriendshipUpdate,
-        SubscriptionEventsEmitter['friendshipUpdate']
-      >({
+      yield* updateHandler.handleSubscriptionUpdates<FriendshipUpdate, SubscriptionEventsEmitter['friendshipUpdate']>({
         rpcContext: context,
         eventName: 'friendshipUpdate',
         getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
@@ -27,9 +22,6 @@ export function subscribeToFriendshipUpdatesService({
     } catch (error: any) {
       logger.error('Error in friendship updates subscription:', error)
       throw error
-    } finally {
-      logger.info('Closing friendship updates subscription')
-      cleanup?.()
     }
   }
 }

--- a/src/controllers/handlers/rpc/subscribe-to-private-voice-chat-updates.ts
+++ b/src/controllers/handlers/rpc/subscribe-to-private-voice-chat-updates.ts
@@ -53,10 +53,8 @@ export function subscribeToPrivateVoiceChatUpdatesService({
   const logger = logs.getLogger('subscribe-to-private-voice-chat-updates-service')
 
   return async function* (_request: Empty, context: RpcServerContext): AsyncGenerator<PrivateVoiceChatUpdate> {
-    let cleanup: (() => void) | undefined
-
     try {
-      cleanup = yield* updateHandler.handleSubscriptionUpdates<
+      yield* updateHandler.handleSubscriptionUpdates<
         PrivateVoiceChatUpdate,
         SubscriptionEventsEmitter['privateVoiceChatUpdate']
       >({
@@ -73,9 +71,6 @@ export function subscribeToPrivateVoiceChatUpdatesService({
         `Error in private voice chat updates subscription: ${isErrorWithMessage(error) ? error.message : 'Unknown error'}`
       )
       throw error
-    } finally {
-      logger.info('Closing private voice chat updates subscription')
-      cleanup?.()
     }
   }
 }

--- a/src/controllers/handlers/uws/ws-handler.ts
+++ b/src/controllers/handlers/uws/ws-handler.ts
@@ -158,7 +158,7 @@ export async function registerWsHandler(
         })
       })
 
-      rpcServer.attachUser({ transport, address })
+      rpcServer.attachUser({ transport, address, wsConnectionId: data.wsConnectionId })
     } catch (error: any) {
       logger.error(`Error verifying auth chain: ${error.message}`, {
         wsConnectionId: data.wsConnectionId

--- a/src/logic/updates.ts
+++ b/src/logic/updates.ts
@@ -52,9 +52,12 @@ async function processInBatches<T>(
 }
 
 export function createUpdateHandlerComponent(
-  components: Pick<AppComponents, 'logs' | 'subscribersContext' | 'friendsDb' | 'communityMembers' | 'registry'>
+  components: Pick<
+    AppComponents,
+    'logs' | 'subscribersContext' | 'friendsDb' | 'communityMembers' | 'registry' | 'metrics'
+  >
 ): IUpdateHandlerComponent {
-  const { logs, subscribersContext, friendsDb, communityMembers, registry } = components
+  const { logs, subscribersContext, friendsDb, communityMembers, registry, metrics } = components
   const logger = logs.getLogger('update-handler')
 
   function handleUpdate<T extends keyof SubscriptionEventsEmitter>(handler: UpdateHandler<T>) {
@@ -349,9 +352,14 @@ export function createUpdateHandlerComponent(
     // Clients can call the same stream RPC multiple times on a single connection,
     // each creating an additional generator + value queue that doubles memory usage.
     if (rpcContext.subscribersContext.hasActiveSubscription(normalizedAddress, eventNameString)) {
-      logger.warn('Duplicate subscription detected, ignoring', {
+      // Expected, benign outcome — the guard is doing its job. But it can fire at very high
+      // frequency during reconnect/re-subscribe churn, so count it as a metric (for alerting
+      // and graphing) and keep the per-occurrence line at debug so it never floods the logs.
+      metrics.increment('subscription_duplicates_total', { event: eventNameString })
+      logger.debug('Duplicate subscription detected, ignoring', {
         address: normalizedAddress,
-        event: eventNameString
+        event: eventNameString,
+        wsConnectionId: rpcContext.wsConnectionId ?? 'unknown'
       })
       return
     }
@@ -385,14 +393,18 @@ export function createUpdateHandlerComponent(
           logger.error(`Unable to parse ${eventNameString}`, { update: JSON.stringify(update) })
         }
       }
-    } catch (error) {
-      logger.error('Error in generator loop', {
-        error: JSON.stringify(error),
-        address: rpcContext.address,
-        event: eventNameString
-      })
-      throw error
+      // Intentionally no catch here: errors propagate to the per-service subscribe handler,
+      // which logs them with service-specific context and re-throws. A central catch would
+      // double-log every subscription error (and only as JSON.stringify(error) === "{}").
     } finally {
+      // Logged here (not in the per-service handler) so it only fires for subscriptions
+      // that were actually established — the duplicate guard above returns before this
+      // try/finally, so rejected duplicates no longer emit a misleading "cleaning up" line.
+      logger.info('Cleaning up subscription', {
+        address: normalizedAddress,
+        event: eventNameString,
+        wsConnectionId: rpcContext.wsConnectionId ?? 'unknown'
+      })
       await updatesGenerator.return(undefined)
       rpcContext.subscribersContext.unregisterGenerator(normalizedAddress, updatesGenerator)
       rpcContext.subscribersContext.clearActiveSubscription(normalizedAddress, eventNameString)

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -115,6 +115,11 @@ export const metricDeclarations = {
     type: IMetricsComponent.CounterType,
     help: 'Number of stale subscribers removed by reconciliation'
   },
+  subscription_duplicates_total: {
+    type: IMetricsComponent.CounterType,
+    help: 'Number of duplicate stream subscriptions rejected by the per-(address, event) guard',
+    labelNames: ['event']
+  },
   ai_compliance_validation_duration_seconds: {
     type: IMetricsComponent.HistogramType,
     help: 'Duration of AI compliance validation in seconds',

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -61,7 +61,7 @@ export interface IRpcClient extends IBaseComponent {
 }
 
 export type IRPCServerComponent = IBaseComponent & {
-  attachUser(user: { transport: Transport; address: string }): void
+  attachUser(user: { transport: Transport; address: string; wsConnectionId?: string }): void
   detachUser(address: string): void
   setServiceCreators(creators: RpcServiceCreators): void
 }

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -75,5 +75,9 @@ export type Subscribers = Record<string, Emitter<SubscriptionEventsEmitter>>
 
 export type RpcServerContext = {
   address: string
+  // Identifies the WebSocket connection backing this RPC context. Always set in
+  // production (populated by attachUser/attachTransport); optional so test contexts
+  // can omit it. Used to disambiguate which connection issued a subscription.
+  wsConnectionId?: string
   subscribersContext: ISubscribersContext
 }

--- a/test/components.ts
+++ b/test/components.ts
@@ -257,7 +257,8 @@ async function initComponents(): Promise<TestComponents> {
     subscribersContext,
     friendsDb,
     communityMembers,
-    registry
+    registry,
+    metrics
   })
   const communityVoice = await createCommunityVoiceComponent({
     logs,

--- a/test/unit/controllers/handlers/ws/ws-handler.spec.ts
+++ b/test/unit/controllers/handlers/ws/ws-handler.spec.ts
@@ -216,7 +216,8 @@ describe('ws-handler', () => {
         expect(updatedData.authenticating).toBe(false)
         expect(mockRpcServer.attachUser).toHaveBeenCalledWith({
           transport: expect.any(Object),
-          address: '0x123'
+          address: '0x123',
+          wsConnectionId: 'test-client-id'
         })
       })
 

--- a/test/unit/logic/updates.spec.ts
+++ b/test/unit/logic/updates.spec.ts
@@ -78,7 +78,8 @@ describe('Updates Handlers', () => {
       subscribersContext,
       friendsDb: mockFriendsDB,
       registry: mockRegistry,
-      communityMembers: mockCommunityMembers
+      communityMembers: mockCommunityMembers,
+      metrics: mockMetrics
     })
   })
 
@@ -1220,6 +1221,46 @@ describe('Updates Handlers', () => {
       }
     })
 
+    describe('and an active subscription already exists for the same address and event', () => {
+      let result: IteratorResult<unknown, unknown>
+      let clearActiveSubscriptionSpy: jest.SpyInstance
+
+      beforeEach(async () => {
+        mockMetrics.increment.mockClear()
+        clearActiveSubscriptionSpy = jest.spyOn(rpcContext.subscribersContext, 'clearActiveSubscription')
+        rpcContext.subscribersContext.setActiveSubscription('0x123', 'friendshipUpdate')
+
+        const generator = updateHandler.handleSubscriptionUpdates({
+          rpcContext,
+          eventName: 'friendshipUpdate',
+          shouldRetrieveProfile: true,
+          getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
+          shouldHandleUpdate: () => true,
+          parser
+        })
+
+        result = await generator.next()
+      })
+
+      it('should ignore the duplicate and complete the generator without yielding', () => {
+        expect(result.done).toBe(true)
+      })
+
+      it('should increment the duplicate subscriptions metric labelled with the event', () => {
+        expect(mockMetrics.increment).toHaveBeenCalledWith('subscription_duplicates_total', {
+          event: 'friendshipUpdate'
+        })
+      })
+
+      it('should not parse any update', () => {
+        expect(parser).not.toHaveBeenCalled()
+      })
+
+      it('should not clear the existing active subscription', () => {
+        expect(clearActiveSubscriptionSpy).not.toHaveBeenCalled()
+      })
+    })
+
     describe('and the emitter exists in context', () => {
       it('should use existing emitter from context', async () => {
         parser.mockResolvedValueOnce({ parsed: true })
@@ -1329,7 +1370,7 @@ describe('Updates Handlers', () => {
     })
 
     describe('and an error occurs in the generator loop', () => {
-      it('should handle errors in the generator loop', async () => {
+      it('should propagate the error to the caller', async () => {
         const error = new Error('Test error')
         parser.mockRejectedValueOnce(error)
 
@@ -1346,11 +1387,6 @@ describe('Updates Handlers', () => {
         rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
 
         await expect(resultPromise).rejects.toThrow('Test error')
-        expect(logger.error).toHaveBeenCalledWith('Error in generator loop', {
-          error: JSON.stringify(error),
-          address: '0x123',
-          event: 'friendshipUpdate'
-        })
       })
     })
 


### PR DESCRIPTION
## Problem

Production logs were flooded with paired lines, thousands per minute across a bounded set of addresses:

```
[INFO]    (subscribe-to-community-member-connectivity-updates-service): Cleaning up community member connectivity updates subscription
[WARNING] (update-handler): Duplicate subscription detected, ignoring    {"address":"0x…","event":"communityMemberConnectivityUpdate"}
```

Two distinct issues:

1. **Every rejected duplicate emitted a WARNING per occurrence.** A duplicate subscription is an *expected, benign* outcome — the per-`(address, event)` guard (added in #407 to prevent the OOM from doubled generators) is working as designed. At WARNING level, per occurrence, it floods the logs during any reconnect / re-subscribe churn.
2. **The "Cleaning up …" INFO fired on the duplicate path too.** The guard `return`s early, which unwinds the per-service generator's `finally` and logged a cleanup line even though nothing was set up — so each duplicate produced *two* misleading lines.

The flood itself was downstream of an undici keep-alive **socket leak** introduced by the native-fetch migration (#420) and fixed in #421: leaked sockets destabilised the service, dropping WebSocket connections and driving clients to reconnect/re-subscribe. This PR makes the logging resilient so a future destabilisation surfaces as a clean metric spike instead of a wall of warnings.

## Changes

- **New metric `subscription_duplicates_total`** (counter, labelled by `event`). Increment on each rejected duplicate and drop the per-occurrence line from `warn` → `debug`. Observability is preserved (graph/alert on the rate) with zero log volume at normal levels.
- **Thread `wsConnectionId` into the RPC context** (`attachUser` → `attachTransport`) so the duplicate and teardown logs identify the originating connection — lets you distinguish same-connection re-subscribe loops from reconnect storms.
- **Move the teardown log into `handleSubscriptionUpdates`'s `finally`** (at `info`), which is only reached for subscriptions that were actually established (the duplicate guard returns before that `try/finally`). Removes the now-redundant per-service `finally` logs across all six subscribe handlers and the dead `cleanup` no-op (the generator never returned a cleanup function, so `cleanup?.()` was always a no-op; the real teardown — `generator.return()` + `unregisterGenerator` + `clearActiveSubscription` — lives inside this `finally` and is unchanged).
- **De-duplicate error logging.** Errors were logged twice (the central `handleSubscriptionUpdates` catch *and* each per-service catch). Removed the central catch — it was the weaker of the two (`error: JSON.stringify(error)` serialises an `Error` to `"{}"`). Errors now propagate to the per-service handler, which logs them once with service-specific context and re-throws.

## Net effect

- Duplicate → one `debug` line (invisible at info/warn) + a metric tick.
- Real teardown → one structured `[INFO] Cleaning up subscription {event, address, wsConnectionId}`.
- Subscription error → one per-service error log (no longer doubled).

## Follow-ups (not in this PR)

- Add a dashboard/alert on `subscription_duplicates_total` rate by `event`.
- The subscriber state is keyed purely by address (no single-connection-per-address policy), which is what turns a reconnect storm into duplicate rejections. Worth scoping state per-connection if this recurs.

## Verification

- `yarn build` ✓
- `eslint` on changed files ✓
- Unit suite ✓ (incl. new tests: duplicate path ignored/no-yield, metric increment, no parse, and `clearActiveSubscription` not called on the duplicate path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)