### PR TITLE
feat: support multiple concurrent connections per address (website + client)

### DIFF
--- a/src/adapters/rpc-server/rpc-server.ts
+++ b/src/adapters/rpc-server/rpc-server.ts
@@ -99,23 +99,21 @@ export async function createRpcServerComponent({
       }
     },
     attachUser({ transport, address, wsConnectionId }) {
-      const eventEmitter = subscribersContext.getOrAddSubscriber(address)
-      subscribersContext.addSubscriber(address, eventEmitter).catch((error) => {
-        logger.error('Failed to add subscriber', { address, error })
-      })
+      // Register this connection for the address (supports multiple concurrent connections
+      // per address, e.g. website + client). Marks the address online on the first one.
+      subscribersContext.addConnection(address, wsConnectionId)
       rpcServer.attachTransport(transport, {
         subscribersContext,
         address,
         wsConnectionId
       })
     },
-    detachUser(address) {
-      // Check if the user is subscribed locally before detaching
-      if (subscribersContext.getLocalSubscribersAddresses().find((a) => a === address)) {
-        // End all calls that the user is involved in
-        subscribersContext.removeSubscriber(address).catch((error) => {
-          logger.error('Failed to remove subscriber', { address, error })
-        })
+    detachUser(address, wsConnectionId) {
+      // Tear down only THIS connection. removeConnection returns true when it was the user's
+      // last connection — only then do we end their voice chat and mark them offline, so
+      // closing one session (e.g. the website) doesn't disrupt another (e.g. the client).
+      const wasLastConnection = subscribersContext.removeConnection(address, wsConnectionId)
+      if (wasLastConnection) {
         voice.endIncomingOrOutgoingPrivateVoiceChatForUser(address).catch((_) => {
           // Do nothing
         })

--- a/src/adapters/rpc-server/subscribers-context.ts
+++ b/src/adapters/rpc-server/subscribers-context.ts
@@ -60,6 +60,17 @@ export function createSubscribersContext(
     }
   }
 
+  // Clear and drop the shared per-address emitter. Callers must destroy the address's
+  // generators first so pending next() calls resolve before the handlers are cleared
+  // (prevents the deadlock).
+  function clearAddressEmitter(normalizedAddress: string): void {
+    const emitter = localSubscribers[normalizedAddress]
+    if (emitter) {
+      emitter.all.clear()
+      delete localSubscribers[normalizedAddress]
+    }
+  }
+
   /**
    * Tear down ALL state for an address (every connection it has). Used by the
    * reconciliation sweep and on shutdown — not on a normal single-connection disconnect.
@@ -79,10 +90,7 @@ export function createSubscribersContext(
       connectionsByAddress.delete(normalizedAddress)
     }
 
-    if (localSubscribers[normalizedAddress]) {
-      localSubscribers[normalizedAddress].all.clear()
-      delete localSubscribers[normalizedAddress]
-    }
+    clearAddressEmitter(normalizedAddress)
   }
 
   function getGeneratorsCount(): number {
@@ -281,17 +289,18 @@ export function createSubscribersContext(
     removeConnection(address: string, wsConnectionId: string): boolean {
       const normalizedAddress = normalizeAddress(address)
 
-      // Always tear down this connection's own streams/dedup state (idempotent).
-      destroyGeneratorsForConnection(wsConnectionId)
-      activeSubscriptions.delete(wsConnectionId)
-
       const connectionIds = connectionsByAddress.get(normalizedAddress)
       if (!connectionIds || !connectionIds.has(wsConnectionId)) {
-        // Connection already removed (e.g. close fired twice) — not a meaningful transition.
+        // Connection isn't tracked (e.g. close fired twice) — nothing to tear down.
         return false
       }
 
+      // Tear down only this connection's streams/dedup state. Each generator's destroy()
+      // calls emitter.off for its own handler, so sibling connections are untouched.
+      destroyGeneratorsForConnection(wsConnectionId)
+      activeSubscriptions.delete(wsConnectionId)
       connectionIds.delete(wsConnectionId)
+
       if (connectionIds.size > 0) {
         // Other connections for this address are still alive — keep the emitter & Redis entry.
         return false
@@ -299,10 +308,7 @@ export function createSubscribersContext(
 
       // Last connection for this address: clear the shared emitter and mark offline.
       connectionsByAddress.delete(normalizedAddress)
-      if (localSubscribers[normalizedAddress]) {
-        localSubscribers[normalizedAddress].all.clear()
-        delete localSubscribers[normalizedAddress]
-      }
+      clearAddressEmitter(normalizedAddress)
       redis.sRem(SUBSCRIBERS_SET_KEY, normalizedAddress).catch((error: any) => {
         logger.error('Failed to remove subscriber from Redis', {
           address: normalizedAddress,

--- a/src/adapters/rpc-server/subscribers-context.ts
+++ b/src/adapters/rpc-server/subscribers-context.ts
@@ -7,13 +7,11 @@ import { IWsPoolComponent } from '../../logic/ws-pool/types'
 const METRICS_INTERVAL_MS = 30_000
 const DEFAULT_RECONCILIATION_INTERVAL_MS = 300_000 // 5 minutes
 
-// NOTE: this component no longer maintains a global presence set in Redis. Fan-out is derived
-// per-instance from the local subscribers (every update is broadcast to every instance via
-// pub/sub, and delivery is local-only), which is crash-safe and avoids cross-instance presence
-// drift. `redis` is therefore unused here and kept in the signature only to avoid churning the
-// (many) call sites; it can be dropped from the DI in a follow-up.
+// Fan-out is derived per-instance from the local subscribers (every update is broadcast to
+// every instance via pub/sub, and delivery is local-only), which is crash-safe and avoids
+// cross-instance presence drift — so this component holds no shared/Redis state.
 export function createSubscribersContext(
-  components: Pick<AppComponents, 'redis' | 'logs' | 'metrics' | 'config'>,
+  components: Pick<AppComponents, 'logs' | 'metrics' | 'config'>,
   wsPool: IWsPoolComponent
 ): ISubscribersContext {
   const { logs, metrics, config } = components
@@ -184,14 +182,6 @@ export function createSubscribersContext(
     getSubscriber: (address: string): Emitter<SubscriptionEventsEmitter> | undefined => {
       const normalizedAddress = normalizeAddress(address)
       return localSubscribers[normalizedAddress]
-    },
-
-    /**
-     * Ensure and return the shared per-address emitter. No side effects beyond creating the
-     * emitter — the connection lifecycle is managed by addConnection/removeConnection.
-     */
-    getOrAddSubscriber: (address: string): Emitter<SubscriptionEventsEmitter> => {
-      return ensureEmitter(normalizeAddress(address))
     },
 
     /**

--- a/src/adapters/rpc-server/subscribers-context.ts
+++ b/src/adapters/rpc-server/subscribers-context.ts
@@ -17,45 +17,69 @@ export function createSubscribersContext(
   const { redis, logs, metrics, config } = components
   const logger = logs.getLogger('subscribers-context')
 
-  // Local in-memory emitters for WebSocket connections on this instance
+  // One shared in-memory emitter per address. The same address can be connected from
+  // multiple places at once (e.g. the website and the in-world client); every connection
+  // for the address attaches its own generators as listeners on this single emitter, so a
+  // pub/sub fan-out is a single emit that reaches all of them.
   const localSubscribers: Subscribers = {}
 
-  // Track active emitterToAsyncGenerator instances per subscriber so we can
-  // synchronously terminate them when the subscriber disconnects.
+  // Active emitterToAsyncGenerator instances per connection, so we can synchronously
+  // terminate exactly one connection's streams on disconnect without touching another
+  // connection for the same address. Key: wsConnectionId.
   const subscriberGenerators = new Map<string, Set<{ destroy(): void }>>()
 
-  // Track active subscriptions per address to prevent duplicate stream subscriptions.
-  // Key: address, Value: set of event names with an active subscription.
+  // Active subscriptions per connection, to prevent a single connection from opening the
+  // same stream twice (each would allocate another generator + value queue). Scoped per
+  // connection so two connections for the same address don't block each other.
+  // Key: wsConnectionId, Value: set of event names with an active subscription.
   const activeSubscriptions = new Map<string, Set<string>>()
+
+  // Live connections per address (reference count). The shared emitter and the Redis
+  // online entry live as long as at least one connection for the address is open.
+  // Key: normalized address, Value: set of wsConnectionIds.
+  const connectionsByAddress = new Map<string, Set<string>>()
 
   let metricsInterval: NodeJS.Timeout | null = null
   let reconciliationInterval: NodeJS.Timeout | null = null
 
-  function addLocalSubscriber(address: string, subscriber: Emitter<SubscriptionEventsEmitter>): void {
-    const normalizedAddress = normalizeAddress(address)
+  function ensureEmitter(normalizedAddress: string): Emitter<SubscriptionEventsEmitter> {
     if (!localSubscribers[normalizedAddress]) {
-      localSubscribers[normalizedAddress] = subscriber
+      localSubscribers[normalizedAddress] = mitt<SubscriptionEventsEmitter>()
     }
+    return localSubscribers[normalizedAddress]
   }
 
-  function destroyGeneratorsForAddress(address: string): void {
-    const generators = subscriberGenerators.get(address)
+  function destroyGeneratorsForConnection(wsConnectionId: string): void {
+    const generators = subscriberGenerators.get(wsConnectionId)
     if (generators) {
       for (const gen of generators) {
         gen.destroy()
       }
       generators.clear()
-      subscriberGenerators.delete(address)
+      subscriberGenerators.delete(wsConnectionId)
     }
   }
 
+  /**
+   * Tear down ALL state for an address (every connection it has). Used by the
+   * reconciliation sweep and on shutdown — not on a normal single-connection disconnect.
+   * Redis is handled by the callers (reconciliation/stop) so this stays side-effect free.
+   */
   function removeLocalSubscriber(address: string): void {
     const normalizedAddress = normalizeAddress(address)
+
+    const connectionIds = connectionsByAddress.get(normalizedAddress)
+    if (connectionIds) {
+      for (const wsConnectionId of connectionIds) {
+        // Destroy generators first so pending next() calls resolve before we clear the
+        // emitter handlers (prevents the deadlock).
+        destroyGeneratorsForConnection(wsConnectionId)
+        activeSubscriptions.delete(wsConnectionId)
+      }
+      connectionsByAddress.delete(normalizedAddress)
+    }
+
     if (localSubscribers[normalizedAddress]) {
-      // Destroy generators first so pending next() calls resolve before
-      // we clear the emitter handlers (prevents the deadlock).
-      destroyGeneratorsForAddress(normalizedAddress)
-      activeSubscriptions.delete(normalizedAddress)
       localSubscribers[normalizedAddress].all.clear()
       delete localSubscribers[normalizedAddress]
     }
@@ -86,9 +110,9 @@ export function createSubscribersContext(
   }
 
   /**
-   * Reconciliation sweep: removes local subscribers that no longer have an active
-   * WebSocket connection. This catches edge cases where the cleanup path in
-   * ws-handler failed to call removeSubscriber (e.g. due to a crash or race condition).
+   * Reconciliation sweep: removes local subscribers that no longer have any active
+   * WebSocket connection. This catches edge cases where the cleanup path in ws-handler
+   * failed to call removeConnection (e.g. due to a crash or race condition).
    */
   async function reconcileStaleSubscribers(): Promise<void> {
     try {
@@ -176,7 +200,7 @@ export function createSubscribersContext(
     getLocalSubscribersAddresses: () => Object.keys(localSubscribers).map(normalizeAddress),
 
     /**
-     * Get an existing subscriber without creating one if it doesn't exist.
+     * Get an existing subscriber emitter without creating one if it doesn't exist.
      * Use this in update handlers to avoid creating orphaned emitters.
      */
     getSubscriber: (address: string): Emitter<SubscriptionEventsEmitter> | undefined => {
@@ -210,32 +234,93 @@ export function createSubscribersContext(
       }
     },
 
+    /**
+     * Ensure and return the shared per-address emitter. No Redis side effects — the Redis
+     * online entry is reference-counted by addConnection/removeConnection.
+     */
     getOrAddSubscriber: (address: string): Emitter<SubscriptionEventsEmitter> => {
+      return ensureEmitter(normalizeAddress(address))
+    },
+
+    /**
+     * Register a live connection for an address. Creates the shared emitter if needed and,
+     * on the FIRST connection for the address, marks it online in Redis. Supports multiple
+     * concurrent connections per address.
+     */
+    addConnection(address: string, wsConnectionId: string): void {
       const normalizedAddress = normalizeAddress(address)
 
-      if (!localSubscribers[normalizedAddress]) {
-        addLocalSubscriber(normalizedAddress, mitt<SubscriptionEventsEmitter>())
-        // Also add to Redis for global tracking (fire-and-forget)
+      ensureEmitter(normalizedAddress)
+
+      let connectionIds = connectionsByAddress.get(normalizedAddress)
+      if (!connectionIds) {
+        connectionIds = new Set()
+        connectionsByAddress.set(normalizedAddress, connectionIds)
+      }
+
+      const isFirstConnection = connectionIds.size === 0
+      connectionIds.add(wsConnectionId)
+
+      if (isFirstConnection) {
+        // Offline -> online transition for this address (fire-and-forget).
         redis.sAdd(SUBSCRIBERS_SET_KEY, normalizedAddress).catch((error: any) => {
-          logger.error('Failed to add subscriber to Redis via getOrAddSubscriber', {
+          logger.error('Failed to add subscriber to Redis', {
             address: normalizedAddress,
             error: error?.message || error
           })
         })
       }
-
-      return localSubscribers[normalizedAddress]
     },
 
-    async addSubscriber(address: string, subscriber: Emitter<SubscriptionEventsEmitter>): Promise<void> {
+    /**
+     * Remove a connection for an address. Tears down only this connection's generators and
+     * active-subscription state — other connections for the same address are untouched.
+     * Returns true if this was the LAST connection for the address, in which case the shared
+     * emitter is cleared and the address is removed from the Redis online set.
+     */
+    removeConnection(address: string, wsConnectionId: string): boolean {
       const normalizedAddress = normalizeAddress(address)
 
-      // Add to local emitters
+      // Always tear down this connection's own streams/dedup state (idempotent).
+      destroyGeneratorsForConnection(wsConnectionId)
+      activeSubscriptions.delete(wsConnectionId)
+
+      const connectionIds = connectionsByAddress.get(normalizedAddress)
+      if (!connectionIds || !connectionIds.has(wsConnectionId)) {
+        // Connection already removed (e.g. close fired twice) — not a meaningful transition.
+        return false
+      }
+
+      connectionIds.delete(wsConnectionId)
+      if (connectionIds.size > 0) {
+        // Other connections for this address are still alive — keep the emitter & Redis entry.
+        return false
+      }
+
+      // Last connection for this address: clear the shared emitter and mark offline.
+      connectionsByAddress.delete(normalizedAddress)
+      if (localSubscribers[normalizedAddress]) {
+        localSubscribers[normalizedAddress].all.clear()
+        delete localSubscribers[normalizedAddress]
+      }
+      redis.sRem(SUBSCRIBERS_SET_KEY, normalizedAddress).catch((error: any) => {
+        logger.error('Failed to remove subscriber from Redis', {
+          address: normalizedAddress,
+          error: error?.message || error
+        })
+      })
+
+      return true
+    },
+
+    // Compatibility/test helpers. Production code uses addConnection/removeConnection for the
+    // reference-counted, per-connection lifecycle; these operate at the address level and do
+    // not track a connection, so prefer the connection-scoped methods outside of tests.
+    async addSubscriber(address: string, subscriber: Emitter<SubscriptionEventsEmitter>): Promise<void> {
+      const normalizedAddress = normalizeAddress(address)
       if (!localSubscribers[normalizedAddress]) {
         localSubscribers[normalizedAddress] = subscriber
       }
-
-      // Add to Redis set for global tracking
       try {
         await redis.sAdd(SUBSCRIBERS_SET_KEY, normalizedAddress)
       } catch (error: any) {
@@ -248,11 +333,7 @@ export function createSubscribersContext(
 
     async removeSubscriber(address: string): Promise<void> {
       const normalizedAddress = normalizeAddress(address)
-
-      // Remove from local emitters
       removeLocalSubscriber(normalizedAddress)
-
-      // Remove from Redis set
       try {
         await redis.sRem(SUBSCRIBERS_SET_KEY, normalizedAddress)
       } catch (error: any) {
@@ -263,49 +344,44 @@ export function createSubscribersContext(
       }
     },
 
-    registerGenerator(address: string, generator: { destroy(): void }): void {
-      const normalizedAddress = normalizeAddress(address)
-      let generators = subscriberGenerators.get(normalizedAddress)
+    registerGenerator(wsConnectionId: string, generator: { destroy(): void }): void {
+      let generators = subscriberGenerators.get(wsConnectionId)
       if (!generators) {
         generators = new Set()
-        subscriberGenerators.set(normalizedAddress, generators)
+        subscriberGenerators.set(wsConnectionId, generators)
       }
       generators.add(generator)
     },
 
-    unregisterGenerator(address: string, generator: { destroy(): void }): void {
-      const normalizedAddress = normalizeAddress(address)
-      const generators = subscriberGenerators.get(normalizedAddress)
+    unregisterGenerator(wsConnectionId: string, generator: { destroy(): void }): void {
+      const generators = subscriberGenerators.get(wsConnectionId)
       if (generators) {
         generators.delete(generator)
         if (generators.size === 0) {
-          subscriberGenerators.delete(normalizedAddress)
+          subscriberGenerators.delete(wsConnectionId)
         }
       }
     },
 
-    hasActiveSubscription(address: string, eventName: string): boolean {
-      const normalizedAddress = normalizeAddress(address)
-      return activeSubscriptions.get(normalizedAddress)?.has(eventName) ?? false
+    hasActiveSubscription(wsConnectionId: string, eventName: string): boolean {
+      return activeSubscriptions.get(wsConnectionId)?.has(eventName) ?? false
     },
 
-    setActiveSubscription(address: string, eventName: string): void {
-      const normalizedAddress = normalizeAddress(address)
-      let events = activeSubscriptions.get(normalizedAddress)
+    setActiveSubscription(wsConnectionId: string, eventName: string): void {
+      let events = activeSubscriptions.get(wsConnectionId)
       if (!events) {
         events = new Set()
-        activeSubscriptions.set(normalizedAddress, events)
+        activeSubscriptions.set(wsConnectionId, events)
       }
       events.add(eventName)
     },
 
-    clearActiveSubscription(address: string, eventName: string): void {
-      const normalizedAddress = normalizeAddress(address)
-      const events = activeSubscriptions.get(normalizedAddress)
+    clearActiveSubscription(wsConnectionId: string, eventName: string): void {
+      const events = activeSubscriptions.get(wsConnectionId)
       if (events) {
         events.delete(eventName)
         if (events.size === 0) {
-          activeSubscriptions.delete(normalizedAddress)
+          activeSubscriptions.delete(wsConnectionId)
         }
       }
     }

--- a/src/adapters/rpc-server/subscribers-context.ts
+++ b/src/adapters/rpc-server/subscribers-context.ts
@@ -4,17 +4,19 @@ import { normalizeAddress } from '../../utils/address'
 import { AppComponents } from '../../types/system'
 import { IWsPoolComponent } from '../../logic/ws-pool/types'
 
-const SUBSCRIBERS_SET_KEY = 'online_subscribers'
-
 const METRICS_INTERVAL_MS = 30_000
 const DEFAULT_RECONCILIATION_INTERVAL_MS = 300_000 // 5 minutes
-const SUBSCRIBERS_COUNT_WARNING_THRESHOLD = 10_000
 
+// NOTE: this component no longer maintains a global presence set in Redis. Fan-out is derived
+// per-instance from the local subscribers (every update is broadcast to every instance via
+// pub/sub, and delivery is local-only), which is crash-safe and avoids cross-instance presence
+// drift. `redis` is therefore unused here and kept in the signature only to avoid churning the
+// (many) call sites; it can be dropped from the DI in a follow-up.
 export function createSubscribersContext(
   components: Pick<AppComponents, 'redis' | 'logs' | 'metrics' | 'config'>,
   wsPool: IWsPoolComponent
 ): ISubscribersContext {
-  const { redis, logs, metrics, config } = components
+  const { logs, metrics, config } = components
   const logger = logs.getLogger('subscribers-context')
 
   // One shared in-memory emitter per address. The same address can be connected from
@@ -34,8 +36,8 @@ export function createSubscribersContext(
   // Key: wsConnectionId, Value: set of event names with an active subscription.
   const activeSubscriptions = new Map<string, Set<string>>()
 
-  // Live connections per address (reference count). The shared emitter and the Redis
-  // online entry live as long as at least one connection for the address is open.
+  // Live connections per address (reference count). The shared emitter lives as long as at
+  // least one connection for the address is open.
   // Key: normalized address, Value: set of wsConnectionIds.
   const connectionsByAddress = new Map<string, Set<string>>()
 
@@ -74,7 +76,6 @@ export function createSubscribersContext(
   /**
    * Tear down ALL state for an address (every connection it has). Used by the
    * reconciliation sweep and on shutdown — not on a normal single-connection disconnect.
-   * Redis is handled by the callers (reconciliation/stop) so this stays side-effect free.
    */
   function removeLocalSubscriber(address: string): void {
     const normalizedAddress = normalizeAddress(address)
@@ -101,17 +102,10 @@ export function createSubscribersContext(
     return count
   }
 
-  async function reportMetrics(): Promise<void> {
+  function reportMetrics(): void {
     try {
-      const localCount = Object.keys(localSubscribers).length
-      const generatorsCount = getGeneratorsCount()
-
-      metrics.observe('subscribers_local_count', {}, localCount)
-      metrics.observe('subscribers_generators_count', {}, generatorsCount)
-
-      // SCARD is O(1) — safe to call frequently
-      const redisCount = await redis.sCard(SUBSCRIBERS_SET_KEY)
-      metrics.observe('subscribers_redis_set_size', {}, redisCount)
+      metrics.observe('subscribers_local_count', {}, Object.keys(localSubscribers).length)
+      metrics.observe('subscribers_generators_count', {}, getGeneratorsCount())
     } catch (error: any) {
       logger.error('Failed to report subscriber metrics', { error: error?.message || error })
     }
@@ -122,7 +116,7 @@ export function createSubscribersContext(
    * WebSocket connection. This catches edge cases where the cleanup path in ws-handler
    * failed to call removeConnection (e.g. due to a crash or race condition).
    */
-  async function reconcileStaleSubscribers(): Promise<void> {
+  function reconcileStaleSubscribers(): void {
     try {
       const activeAddresses = new Set(wsPool.getAuthenticatedAddresses())
       const localAddresses = Object.keys(localSubscribers).map(normalizeAddress)
@@ -140,14 +134,6 @@ export function createSubscribersContext(
 
       for (const address of staleAddresses) {
         removeLocalSubscriber(address)
-        try {
-          await redis.sRem(SUBSCRIBERS_SET_KEY, address)
-        } catch (error: any) {
-          logger.error('Failed to remove stale subscriber from Redis', {
-            address,
-            error: error?.message || error
-          })
-        }
       }
 
       metrics.increment('subscribers_stale_cleaned', {}, staleAddresses.length)
@@ -161,13 +147,8 @@ export function createSubscribersContext(
       const reconciliationIntervalMs =
         (await config.getNumber('SUBSCRIBER_RECONCILIATION_INTERVAL_MS')) ?? DEFAULT_RECONCILIATION_INTERVAL_MS
 
-      metricsInterval = setInterval(() => {
-        reportMetrics().catch(() => {})
-      }, METRICS_INTERVAL_MS)
-
-      reconciliationInterval = setInterval(() => {
-        reconcileStaleSubscribers().catch(() => {})
-      }, reconciliationIntervalMs)
+      metricsInterval = setInterval(reportMetrics, METRICS_INTERVAL_MS)
+      reconciliationInterval = setInterval(reconcileStaleSubscribers, reconciliationIntervalMs)
 
       logger.info('Subscribers context started', {
         metricsIntervalMs: METRICS_INTERVAL_MS,
@@ -184,17 +165,6 @@ export function createSubscribersContext(
       if (reconciliationInterval) {
         clearInterval(reconciliationInterval)
         reconciliationInterval = null
-      }
-
-      // Clean up all local subscribers from Redis on shutdown
-      const localAddresses = Object.keys(localSubscribers).map(normalizeAddress)
-      if (localAddresses.length > 0) {
-        try {
-          await redis.sRem(SUBSCRIBERS_SET_KEY, localAddresses)
-          logger.info(`Removed ${localAddresses.length} subscribers from Redis on shutdown`)
-        } catch (error: any) {
-          logger.error('Failed to remove subscribers from Redis on shutdown', { error: error?.message || error })
-        }
       }
 
       // Destroy all generators and clear local emitters
@@ -216,44 +186,17 @@ export function createSubscribersContext(
       return localSubscribers[normalizedAddress]
     },
 
-    async getSubscribersAddresses(): Promise<string[]> {
-      try {
-        // Use SSCAN instead of SMEMBERS to avoid loading the entire set at once,
-        // which can spike memory if the set has accumulated stale entries.
-        const addresses: string[] = []
-        for await (const member of redis.client.sScanIterator(SUBSCRIBERS_SET_KEY, { COUNT: 100 })) {
-          addresses.push(member)
-        }
-
-        if (addresses.length > SUBSCRIBERS_COUNT_WARNING_THRESHOLD) {
-          logger.warn('Redis subscribers set is unusually large', {
-            count: addresses.length,
-            threshold: SUBSCRIBERS_COUNT_WARNING_THRESHOLD
-          })
-        }
-
-        return addresses.map(normalizeAddress)
-      } catch (error: any) {
-        logger.error('Failed to get subscribers from Redis, falling back to local', {
-          error: error?.message || error
-        })
-        // Fallback to local subscribers if Redis fails
-        return Object.keys(localSubscribers).map(normalizeAddress)
-      }
-    },
-
     /**
-     * Ensure and return the shared per-address emitter. No Redis side effects — the Redis
-     * online entry is reference-counted by addConnection/removeConnection.
+     * Ensure and return the shared per-address emitter. No side effects beyond creating the
+     * emitter — the connection lifecycle is managed by addConnection/removeConnection.
      */
     getOrAddSubscriber: (address: string): Emitter<SubscriptionEventsEmitter> => {
       return ensureEmitter(normalizeAddress(address))
     },
 
     /**
-     * Register a live connection for an address. Creates the shared emitter if needed and,
-     * on the FIRST connection for the address, marks it online in Redis. Supports multiple
-     * concurrent connections per address.
+     * Register a live connection for an address, creating the shared emitter if needed.
+     * Supports multiple concurrent connections per address.
      */
     addConnection(address: string, wsConnectionId: string): void {
       const normalizedAddress = normalizeAddress(address)
@@ -265,26 +208,14 @@ export function createSubscribersContext(
         connectionIds = new Set()
         connectionsByAddress.set(normalizedAddress, connectionIds)
       }
-
-      const isFirstConnection = connectionIds.size === 0
       connectionIds.add(wsConnectionId)
-
-      if (isFirstConnection) {
-        // Offline -> online transition for this address (fire-and-forget).
-        redis.sAdd(SUBSCRIBERS_SET_KEY, normalizedAddress).catch((error: any) => {
-          logger.error('Failed to add subscriber to Redis', {
-            address: normalizedAddress,
-            error: error?.message || error
-          })
-        })
-      }
     },
 
     /**
      * Remove a connection for an address. Tears down only this connection's generators and
      * active-subscription state — other connections for the same address are untouched.
      * Returns true if this was the LAST connection for the address, in which case the shared
-     * emitter is cleared and the address is removed from the Redis online set.
+     * emitter is cleared.
      */
     removeConnection(address: string, wsConnectionId: string): boolean {
       const normalizedAddress = normalizeAddress(address)
@@ -302,19 +233,13 @@ export function createSubscribersContext(
       connectionIds.delete(wsConnectionId)
 
       if (connectionIds.size > 0) {
-        // Other connections for this address are still alive — keep the emitter & Redis entry.
+        // Other connections for this address are still alive — keep the emitter.
         return false
       }
 
-      // Last connection for this address: clear the shared emitter and mark offline.
+      // Last connection for this address: clear the shared emitter.
       connectionsByAddress.delete(normalizedAddress)
       clearAddressEmitter(normalizedAddress)
-      redis.sRem(SUBSCRIBERS_SET_KEY, normalizedAddress).catch((error: any) => {
-        logger.error('Failed to remove subscriber from Redis', {
-          address: normalizedAddress,
-          error: error?.message || error
-        })
-      })
 
       return true
     },

--- a/src/adapters/rpc-server/subscribers-context.ts
+++ b/src/adapters/rpc-server/subscribers-context.ts
@@ -319,37 +319,6 @@ export function createSubscribersContext(
       return true
     },
 
-    // Compatibility/test helpers. Production code uses addConnection/removeConnection for the
-    // reference-counted, per-connection lifecycle; these operate at the address level and do
-    // not track a connection, so prefer the connection-scoped methods outside of tests.
-    async addSubscriber(address: string, subscriber: Emitter<SubscriptionEventsEmitter>): Promise<void> {
-      const normalizedAddress = normalizeAddress(address)
-      if (!localSubscribers[normalizedAddress]) {
-        localSubscribers[normalizedAddress] = subscriber
-      }
-      try {
-        await redis.sAdd(SUBSCRIBERS_SET_KEY, normalizedAddress)
-      } catch (error: any) {
-        logger.error('Failed to add subscriber to Redis', {
-          address: normalizedAddress,
-          error: error?.message || error
-        })
-      }
-    },
-
-    async removeSubscriber(address: string): Promise<void> {
-      const normalizedAddress = normalizeAddress(address)
-      removeLocalSubscriber(normalizedAddress)
-      try {
-        await redis.sRem(SUBSCRIBERS_SET_KEY, normalizedAddress)
-      } catch (error: any) {
-        logger.error('Failed to remove subscriber from Redis', {
-          address: normalizedAddress,
-          error: error?.message || error
-        })
-      }
-    },
-
     registerGenerator(wsConnectionId: string, generator: { destroy(): void }): void {
       let generators = subscriberGenerators.get(wsConnectionId)
       if (!generators) {

--- a/src/components.ts
+++ b/src/components.ts
@@ -180,7 +180,7 @@ export async function initComponents(): Promise<AppComponents> {
 
   const storage = await createS3Adapter({ config })
   const wsPool = createWsPoolComponent({ logs, metrics })
-  const subscribersContext = createSubscribersContext({ redis, logs, metrics, config }, wsPool)
+  const subscribersContext = createSubscribersContext({ logs, metrics, config }, wsPool)
   const peersStats = createPeersStatsComponent({ archipelagoStats, worldsStats })
   const communityThumbnail = await createCommunityThumbnailComponent({ config, storage })
 

--- a/src/controllers/handlers/uws/ws-handler.ts
+++ b/src/controllers/handlers/uws/ws-handler.ts
@@ -49,7 +49,7 @@ export async function registerWsHandler(
 
   function safeDetachUser(address: string, wsConnectionId: string) {
     try {
-      rpcServer.detachUser(address)
+      rpcServer.detachUser(address, wsConnectionId)
     } catch (error: any) {
       logger.error('Error detaching user during cleanup', {
         error: error.message,
@@ -147,7 +147,7 @@ export async function registerWsHandler(
           wsConnectionId: data.wsConnectionId,
           address
         })
-        rpcServer.detachUser(address)
+        rpcServer.detachUser(address, data.wsConnectionId)
       })
 
       transport.on('error', (error: unknown) => {

--- a/src/logic/updates.ts
+++ b/src/logic/updates.ts
@@ -103,7 +103,10 @@ export function createUpdateHandlerComponent(
   })
 
   const friendConnectivityUpdateHandler = handleUpdate<'friendConnectivityUpdate'>(async (update) => {
-    const onlineSubscribers = await subscribersContext.getSubscribersAddresses()
+    // Derive recipients from THIS instance's local subscribers: every update is broadcast to
+    // every instance via pub/sub and delivery is local-only, so each instance fans out to its
+    // own connected subscribers (crash-safe, no global presence set needed).
+    const onlineSubscribers = subscribersContext.getLocalSubscribersAddresses()
     const friends = await friendsDb.getOnlineFriends(update.address, onlineSubscribers)
 
     // Notify friends about connectivity change, yielding event loop for large friend lists
@@ -120,7 +123,10 @@ export function createUpdateHandlerComponent(
   })
 
   const communityMemberConnectivityUpdateHandler = handleUpdate<'communityMemberConnectivityUpdate'>(async (update) => {
-    const onlineSubscribers = await subscribersContext.getSubscribersAddresses()
+    // Derive recipients from THIS instance's local subscribers: every update is broadcast to
+    // every instance via pub/sub and delivery is local-only, so each instance fans out to its
+    // own connected subscribers (crash-safe, no global presence set needed).
+    const onlineSubscribers = subscribersContext.getLocalSubscribersAddresses()
     const batches = communityMembers.getOnlineMembersFromUserCommunities(update.memberAddress, onlineSubscribers)
 
     for await (const batch of batches) {
@@ -213,7 +219,10 @@ export function createUpdateHandlerComponent(
 
     logger.info('Community member status update', { update: JSON.stringify(update) })
 
-    const onlineSubscribers = await subscribersContext.getSubscribersAddresses()
+    // Derive recipients from THIS instance's local subscribers: every update is broadcast to
+    // every instance via pub/sub and delivery is local-only, so each instance fans out to its
+    // own connected subscribers (crash-safe, no global presence set needed).
+    const onlineSubscribers = subscribersContext.getLocalSubscribersAddresses()
     const batches = communityMembers.getOnlineMembersFromCommunity(
       communityId,
       onlineSubscribers.filter((address) => address !== normalizedMemberAddress)
@@ -255,7 +264,10 @@ export function createUpdateHandlerComponent(
   const communityDeletedUpdateHandler = handleUpdate<'communityDeletedUpdate'>(async (update) => {
     const { communityId } = update
 
-    const onlineSubscribers = await subscribersContext.getSubscribersAddresses()
+    // Derive recipients from THIS instance's local subscribers: every update is broadcast to
+    // every instance via pub/sub and delivery is local-only, so each instance fans out to its
+    // own connected subscribers (crash-safe, no global presence set needed).
+    const onlineSubscribers = subscribersContext.getLocalSubscribersAddresses()
     const batches = communityMembers.getOnlineMembersFromCommunity(communityId, onlineSubscribers)
 
     for await (const batch of batches) {
@@ -282,7 +294,7 @@ export function createUpdateHandlerComponent(
 
     // Get all online subscribers, excluding the creator if present (creator already knows about their action)
     const creatorAddress = update.creatorAddress?.toLowerCase()
-    const allOnlineSubscribers = await subscribersContext.getSubscribersAddresses()
+    const allOnlineSubscribers = subscribersContext.getLocalSubscribersAddresses()
     const onlineSubscribers = allOnlineSubscribers.filter((address) => !creatorAddress || address !== creatorAddress)
 
     try {

--- a/src/logic/updates.ts
+++ b/src/logic/updates.ts
@@ -390,7 +390,7 @@ export function createUpdateHandlerComponent(
 
     // The shared per-address emitter is created when the connection attaches (addConnection).
     // If it's gone, the connection is no longer attached — don't resurrect an orphan emitter
-    // that would be invisible to the Redis-backed online set / fan-out.
+    // that wouldn't be tracked as a live connection and would be invisible to the local fan-out.
     const eventEmitter = rpcContext.subscribersContext.getSubscriber(normalizedAddress)
     if (!eventEmitter) {
       logger.warn('No subscriber emitter for address; connection no longer attached', {

--- a/src/logic/updates.ts
+++ b/src/logic/updates.ts
@@ -347,11 +347,19 @@ export function createUpdateHandlerComponent(
   }: SubscriptionHandlerParams<T, U>): AsyncGenerator<T> {
     const normalizedAddress = normalizeAddress(rpcContext.address)
     const eventNameString = String(eventName)
-    // Dedup + generator tracking are scoped per CONNECTION (not per address): the same
-    // address can be connected from multiple places at once (website + client), and each
-    // connection must get its own working subscription. Falls back to the address only if a
-    // context somehow lacks a connection id (e.g. a unit test).
-    const connectionId = rpcContext.wsConnectionId ?? normalizedAddress
+
+    // Subscriptions are scoped per CONNECTION: the same address can be connected from
+    // multiple places at once (website + client) and each connection gets its own stream.
+    // wsConnectionId is always set in production (assigned at WS upgrade and threaded through
+    // attachUser/attachTransport); fail loud rather than silently mis-key if it is missing.
+    const connectionId = rpcContext.wsConnectionId
+    if (!connectionId) {
+      logger.error('Cannot handle subscription without a wsConnectionId', {
+        address: normalizedAddress,
+        event: eventNameString
+      })
+      return
+    }
 
     // Guard against the SAME connection opening the same stream twice — each extra generator
     // allocates another value queue and doubles that connection's memory.
@@ -363,13 +371,25 @@ export function createUpdateHandlerComponent(
       logger.debug('Duplicate subscription detected, ignoring', {
         address: normalizedAddress,
         event: eventNameString,
-        wsConnectionId: rpcContext.wsConnectionId ?? 'unknown'
+        wsConnectionId: connectionId
       })
       return
     }
-    rpcContext.subscribersContext.setActiveSubscription(connectionId, eventNameString)
 
-    const eventEmitter = rpcContext.subscribersContext.getOrAddSubscriber(normalizedAddress)
+    // The shared per-address emitter is created when the connection attaches (addConnection).
+    // If it's gone, the connection is no longer attached — don't resurrect an orphan emitter
+    // that would be invisible to the Redis-backed online set / fan-out.
+    const eventEmitter = rpcContext.subscribersContext.getSubscriber(normalizedAddress)
+    if (!eventEmitter) {
+      logger.warn('No subscriber emitter for address; connection no longer attached', {
+        address: normalizedAddress,
+        event: eventNameString,
+        wsConnectionId: connectionId
+      })
+      return
+    }
+
+    rpcContext.subscribersContext.setActiveSubscription(connectionId, eventNameString)
 
     const updatesGenerator = emitterToAsyncGenerator(eventEmitter, eventName)
     rpcContext.subscribersContext.registerGenerator(connectionId, updatesGenerator)
@@ -407,7 +427,7 @@ export function createUpdateHandlerComponent(
       logger.info('Cleaning up subscription', {
         address: normalizedAddress,
         event: eventNameString,
-        wsConnectionId: rpcContext.wsConnectionId ?? 'unknown'
+        wsConnectionId: connectionId
       })
       await updatesGenerator.return(undefined)
       rpcContext.subscribersContext.unregisterGenerator(connectionId, updatesGenerator)

--- a/src/logic/updates.ts
+++ b/src/logic/updates.ts
@@ -347,11 +347,15 @@ export function createUpdateHandlerComponent(
   }: SubscriptionHandlerParams<T, U>): AsyncGenerator<T> {
     const normalizedAddress = normalizeAddress(rpcContext.address)
     const eventNameString = String(eventName)
+    // Dedup + generator tracking are scoped per CONNECTION (not per address): the same
+    // address can be connected from multiple places at once (website + client), and each
+    // connection must get its own working subscription. Falls back to the address only if a
+    // context somehow lacks a connection id (e.g. a unit test).
+    const connectionId = rpcContext.wsConnectionId ?? normalizedAddress
 
-    // Guard against duplicate subscriptions for the same (address, event) pair.
-    // Clients can call the same stream RPC multiple times on a single connection,
-    // each creating an additional generator + value queue that doubles memory usage.
-    if (rpcContext.subscribersContext.hasActiveSubscription(normalizedAddress, eventNameString)) {
+    // Guard against the SAME connection opening the same stream twice — each extra generator
+    // allocates another value queue and doubles that connection's memory.
+    if (rpcContext.subscribersContext.hasActiveSubscription(connectionId, eventNameString)) {
       // Expected, benign outcome — the guard is doing its job. But it can fire at very high
       // frequency during reconnect/re-subscribe churn, so count it as a metric (for alerting
       // and graphing) and keep the per-occurrence line at debug so it never floods the logs.
@@ -363,12 +367,12 @@ export function createUpdateHandlerComponent(
       })
       return
     }
-    rpcContext.subscribersContext.setActiveSubscription(normalizedAddress, eventNameString)
+    rpcContext.subscribersContext.setActiveSubscription(connectionId, eventNameString)
 
     const eventEmitter = rpcContext.subscribersContext.getOrAddSubscriber(normalizedAddress)
 
     const updatesGenerator = emitterToAsyncGenerator(eventEmitter, eventName)
-    rpcContext.subscribersContext.registerGenerator(normalizedAddress, updatesGenerator)
+    rpcContext.subscribersContext.registerGenerator(connectionId, updatesGenerator)
 
     try {
       for await (const update of updatesGenerator) {
@@ -406,8 +410,8 @@ export function createUpdateHandlerComponent(
         wsConnectionId: rpcContext.wsConnectionId ?? 'unknown'
       })
       await updatesGenerator.return(undefined)
-      rpcContext.subscribersContext.unregisterGenerator(normalizedAddress, updatesGenerator)
-      rpcContext.subscribersContext.clearActiveSubscription(normalizedAddress, eventNameString)
+      rpcContext.subscribersContext.unregisterGenerator(connectionId, updatesGenerator)
+      rpcContext.subscribersContext.clearActiveSubscription(connectionId, eventNameString)
     }
   }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -107,10 +107,6 @@ export const metricDeclarations = {
     type: IMetricsComponent.GaugeType,
     help: 'Number of active async generators across all subscribers'
   },
-  subscribers_redis_set_size: {
-    type: IMetricsComponent.GaugeType,
-    help: 'Number of subscribers in the Redis online_subscribers set'
-  },
   subscribers_stale_cleaned: {
     type: IMetricsComponent.CounterType,
     help: 'Number of stale subscribers removed by reconciliation'

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -350,14 +350,14 @@ export type ISubscribersContext = IBaseComponent & {
    */
   getSubscriber: (address: string) => Emitter<SubscriptionEventsEmitter> | undefined
   /**
-   * Register a live connection for an address. Marks the address online in Redis on the
+   * Register a live connection for an address, creating the shared emitter on the
    * first connection. Multiple concurrent connections per address are supported.
    */
   addConnection: (address: string, wsConnectionId: string) => void
   /**
    * Remove a connection for an address. Tears down only that connection's generators and
    * active-subscription state. Returns true if it was the last connection for the address
-   * (the shared emitter is cleared and the address is removed from the Redis online set).
+   * (the shared emitter is cleared).
    */
   removeConnection: (address: string, wsConnectionId: string) => boolean
   registerGenerator: (wsConnectionId: string, generator: { destroy(): void }) => void

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -343,7 +343,6 @@ export interface ICdnCacheInvalidatorComponent {
 
 export type ISubscribersContext = IBaseComponent & {
   getSubscribers: () => Subscribers
-  getSubscribersAddresses: () => Promise<string[]>
   getLocalSubscribersAddresses: () => string[]
   /**
    * Get an existing subscriber without creating one if it doesn't exist.

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -350,11 +350,6 @@ export type ISubscribersContext = IBaseComponent & {
    */
   getSubscriber: (address: string) => Emitter<SubscriptionEventsEmitter> | undefined
   /**
-   * Ensure and return the shared per-address emitter. No Redis side effects — the online
-   * entry is reference-counted by addConnection/removeConnection.
-   */
-  getOrAddSubscriber: (address: string) => Emitter<SubscriptionEventsEmitter>
-  /**
    * Register a live connection for an address. Marks the address online in Redis on the
    * first connection. Multiple concurrent connections per address are supported.
    */

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -366,10 +366,6 @@ export type ISubscribersContext = IBaseComponent & {
    * (the shared emitter is cleared and the address is removed from the Redis online set).
    */
   removeConnection: (address: string, wsConnectionId: string) => boolean
-  /** Compatibility/test helper — prefer addConnection. Registers a local emitter + marks online. */
-  addSubscriber: (address: string, subscriber: Emitter<SubscriptionEventsEmitter>) => Promise<void>
-  /** Compatibility/test helper — prefer removeConnection. Tears down all of an address's state. */
-  removeSubscriber: (address: string) => Promise<void>
   registerGenerator: (wsConnectionId: string, generator: { destroy(): void }) => void
   unregisterGenerator: (wsConnectionId: string, generator: { destroy(): void }) => void
   hasActiveSubscription: (wsConnectionId: string, eventName: string) => boolean

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -61,8 +61,8 @@ export interface IRpcClient extends IBaseComponent {
 }
 
 export type IRPCServerComponent = IBaseComponent & {
-  attachUser(user: { transport: Transport; address: string; wsConnectionId?: string }): void
-  detachUser(address: string): void
+  attachUser(user: { transport: Transport; address: string; wsConnectionId: string }): void
+  detachUser(address: string, wsConnectionId: string): void
   setServiceCreators(creators: RpcServiceCreators): void
 }
 
@@ -350,14 +350,31 @@ export type ISubscribersContext = IBaseComponent & {
    * Use this in update handlers to avoid creating orphaned emitters.
    */
   getSubscriber: (address: string) => Emitter<SubscriptionEventsEmitter> | undefined
+  /**
+   * Ensure and return the shared per-address emitter. No Redis side effects — the online
+   * entry is reference-counted by addConnection/removeConnection.
+   */
   getOrAddSubscriber: (address: string) => Emitter<SubscriptionEventsEmitter>
+  /**
+   * Register a live connection for an address. Marks the address online in Redis on the
+   * first connection. Multiple concurrent connections per address are supported.
+   */
+  addConnection: (address: string, wsConnectionId: string) => void
+  /**
+   * Remove a connection for an address. Tears down only that connection's generators and
+   * active-subscription state. Returns true if it was the last connection for the address
+   * (the shared emitter is cleared and the address is removed from the Redis online set).
+   */
+  removeConnection: (address: string, wsConnectionId: string) => boolean
+  /** Compatibility/test helper — prefer addConnection. Registers a local emitter + marks online. */
   addSubscriber: (address: string, subscriber: Emitter<SubscriptionEventsEmitter>) => Promise<void>
+  /** Compatibility/test helper — prefer removeConnection. Tears down all of an address's state. */
   removeSubscriber: (address: string) => Promise<void>
-  registerGenerator: (address: string, generator: { destroy(): void }) => void
-  unregisterGenerator: (address: string, generator: { destroy(): void }) => void
-  hasActiveSubscription: (address: string, eventName: string) => boolean
-  setActiveSubscription: (address: string, eventName: string) => void
-  clearActiveSubscription: (address: string, eventName: string) => void
+  registerGenerator: (wsConnectionId: string, generator: { destroy(): void }) => void
+  unregisterGenerator: (wsConnectionId: string, generator: { destroy(): void }) => void
+  hasActiveSubscription: (wsConnectionId: string, eventName: string) => boolean
+  setActiveSubscription: (wsConnectionId: string, eventName: string) => void
+  clearActiveSubscription: (wsConnectionId: string, eventName: string) => void
 }
 
 export type ITracingComponent = IBaseComponent & {

--- a/test/components.ts
+++ b/test/components.ts
@@ -160,7 +160,7 @@ async function initComponents(): Promise<TestComponents> {
   const sns = createSNSMockedComponent({})
   const storage = await createS3Adapter({ config })
   const wsPool = createWsPoolComponent({ logs, metrics })
-  const subscribersContext = createSubscribersContext({ redis, logs, metrics, config }, wsPool)
+  const subscribersContext = createSubscribersContext({ logs, metrics, config }, wsPool)
   const archipelagoStats = await createArchipelagoStatsComponent({ logs, config, redis, fetcher })
   const worldsStats = await createWorldsStatsComponent({ logs, redis })
   const commsGatekeeper = await createCommsGatekeeperComponent({ logs, config, fetcher })

--- a/test/integration/rpc-subscriptions-controller.spec.ts
+++ b/test/integration/rpc-subscriptions-controller.spec.ts
@@ -1,0 +1,120 @@
+import { test } from '../components'
+import { createTestIdentity, Identity } from './utils/auth'
+import { connectAuthenticatedRpcClient } from './utils/rpc-client'
+import { BLOCK_UPDATES_CHANNEL } from '../../src/adapters/pubsub'
+
+// Mirrors SUBSCRIBERS_SET_KEY in src/adapters/rpc-server/subscribers-context.ts.
+const ONLINE_SUBSCRIBERS_KEY = 'online_subscribers'
+// Generous window for the subscribe RPC round-trip to register the server-side listener
+// before we publish, and for fire-and-forget Redis writes / WS close handling to settle.
+const SETTLE_MS = 1500
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function nextWithTimeout<T>(iterator: AsyncIterator<T>, ms = 5000): Promise<T> {
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error('Timed out waiting for a stream value')), ms)
+  )
+  const result = (await Promise.race([iterator.next(), timeout])) as IteratorResult<T>
+  if (result.done) {
+    throw new Error('Stream ended before yielding a value')
+  }
+  return result.value
+}
+
+// Exercises the end-to-end multi-connection path: a single wallet address connected from two
+// independent WebSocket connections (website + client), both subscribing over real @dcl/rpc,
+// with fan-out driven through the real Redis pub/sub channel.
+test('RPC subscriptions with multiple connections per address', ({ components }) => {
+  let identity: Identity
+  let address: string
+  let clientA: Awaited<ReturnType<typeof connectAuthenticatedRpcClient>>
+  let clientB: Awaited<ReturnType<typeof connectAuthenticatedRpcClient>>
+
+  beforeEach(async () => {
+    identity = await createTestIdentity()
+    address = identity.realAccount.address.toLowerCase()
+    clientA = await connectAuthenticatedRpcClient(components, identity)
+    clientB = await connectAuthenticatedRpcClient(components, identity)
+  })
+
+  afterEach(async () => {
+    clientA?.close()
+    clientB?.close()
+    await sleep(SETTLE_MS)
+  })
+
+  describe('when both connections subscribe to block updates', () => {
+    it('should deliver a block update to both connections', async () => {
+      const streamA = clientA.client.subscribeToBlockUpdates({})
+      const streamB = clientB.client.subscribeToBlockUpdates({})
+
+      const nextA = nextWithTimeout(streamA)
+      const nextB = nextWithTimeout(streamB)
+      await sleep(SETTLE_MS)
+
+      await components.pubsub.publishInChannel(BLOCK_UPDATES_CHANNEL, {
+        blockerAddress: '0x1111111111111111111111111111111111111111',
+        blockedAddress: address,
+        isBlocked: true
+      })
+
+      const [updateForA, updateForB] = await Promise.all([nextA, nextB])
+
+      expect(updateForA.isBlocked).toBe(true)
+      expect(updateForB.isBlocked).toBe(true)
+      expect(updateForA.address.toLowerCase()).toEqual('0x1111111111111111111111111111111111111111')
+      expect(updateForB.address.toLowerCase()).toEqual('0x1111111111111111111111111111111111111111')
+    })
+  })
+
+  describe('when one of the two connections disconnects', () => {
+    it('should keep delivering updates to the remaining connection', async () => {
+      const streamA = clientA.client.subscribeToBlockUpdates({})
+      const streamB = clientB.client.subscribeToBlockUpdates({})
+
+      const firstA = nextWithTimeout(streamA)
+      const firstB = nextWithTimeout(streamB)
+      await sleep(SETTLE_MS)
+
+      await components.pubsub.publishInChannel(BLOCK_UPDATES_CHANNEL, {
+        blockerAddress: '0x2222222222222222222222222222222222222222',
+        blockedAddress: address,
+        isBlocked: true
+      })
+      await Promise.all([firstA, firstB])
+
+      // Close one connection; the other must keep working.
+      clientA.close()
+      await sleep(SETTLE_MS)
+
+      const secondB = nextWithTimeout(streamB)
+      await components.pubsub.publishInChannel(BLOCK_UPDATES_CHANNEL, {
+        blockerAddress: '0x3333333333333333333333333333333333333333',
+        blockedAddress: address,
+        isBlocked: false
+      })
+
+      const updateForB = await secondB
+      expect(updateForB.isBlocked).toBe(false)
+      expect(updateForB.address.toLowerCase()).toEqual('0x3333333333333333333333333333333333333333')
+    })
+  })
+
+  describe('when tracking the address in the Redis online set', () => {
+    it('should keep the address online until the last connection closes', async () => {
+      await sleep(SETTLE_MS)
+      expect(await components.redis.client.sIsMember(ONLINE_SUBSCRIBERS_KEY, address)).toBe(true)
+
+      // One connection left: still online.
+      clientA.close()
+      await sleep(SETTLE_MS)
+      expect(await components.redis.client.sIsMember(ONLINE_SUBSCRIBERS_KEY, address)).toBe(true)
+
+      // Last connection closed: now offline.
+      clientB.close()
+      await sleep(SETTLE_MS)
+      expect(await components.redis.client.sIsMember(ONLINE_SUBSCRIBERS_KEY, address)).toBe(false)
+    })
+  })
+})

--- a/test/integration/rpc-subscriptions-controller.spec.ts
+++ b/test/integration/rpc-subscriptions-controller.spec.ts
@@ -3,10 +3,8 @@ import { createTestIdentity, Identity } from './utils/auth'
 import { connectAuthenticatedRpcClient } from './utils/rpc-client'
 import { BLOCK_UPDATES_CHANNEL } from '../../src/adapters/pubsub'
 
-// Mirrors SUBSCRIBERS_SET_KEY in src/adapters/rpc-server/subscribers-context.ts.
-const ONLINE_SUBSCRIBERS_KEY = 'online_subscribers'
 // Generous window for the subscribe RPC round-trip to register the server-side listener
-// before we publish, and for fire-and-forget Redis writes / WS close handling to settle.
+// before we publish, and for WS close handling to settle.
 const SETTLE_MS = 1500
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -98,23 +96,6 @@ test('RPC subscriptions with multiple connections per address', ({ components })
       const updateForB = await secondB
       expect(updateForB.isBlocked).toBe(false)
       expect(updateForB.address.toLowerCase()).toEqual('0x3333333333333333333333333333333333333333')
-    })
-  })
-
-  describe('when tracking the address in the Redis online set', () => {
-    it('should keep the address online until the last connection closes', async () => {
-      await sleep(SETTLE_MS)
-      expect(await components.redis.client.sIsMember(ONLINE_SUBSCRIBERS_KEY, address)).toBe(true)
-
-      // One connection left: still online.
-      clientA.close()
-      await sleep(SETTLE_MS)
-      expect(await components.redis.client.sIsMember(ONLINE_SUBSCRIBERS_KEY, address)).toBe(true)
-
-      // Last connection closed: now offline.
-      clientB.close()
-      await sleep(SETTLE_MS)
-      expect(await components.redis.client.sIsMember(ONLINE_SUBSCRIBERS_KEY, address)).toBe(false)
     })
   })
 })

--- a/test/integration/utils/rpc-client.ts
+++ b/test/integration/utils/rpc-client.ts
@@ -1,10 +1,61 @@
 import { createRpcClient, TransportEvents } from '@dcl/rpc'
 import { loadService } from '@dcl/rpc/dist/codegen'
 import { SocialServiceDefinition } from '@dcl/protocol/out-js/decentraland/social_service/v2/social_service_v2.gen'
-import { createTestIdentity, createAuthHeaders } from './auth'
+import { createTestIdentity, createAuthHeaders, Identity } from './auth'
 import { FromTsProtoServiceDefinition, RawClient } from '@dcl/rpc/dist/codegen-types'
 import { IRpcClient, type TestComponents } from '../../../src/types'
 import { createWebSocketTransport, Transport } from './transport'
+
+/**
+ * Connects a single authenticated RPC client over a real WebSocket using the GIVEN identity.
+ * Unlike createRpcClientComponent (which mints a fresh random identity per connect), this lets
+ * a test open multiple concurrent connections for the SAME address (e.g. website + client).
+ */
+export async function connectAuthenticatedRpcClient(
+  { config, logs }: Pick<TestComponents, 'config' | 'logs'>,
+  identity: Identity
+): Promise<{
+  client: RawClient<FromTsProtoServiceDefinition<typeof SocialServiceDefinition>>
+  authAddress: string
+  close: () => void
+}> {
+  const logger = logs.getLogger('test:rpc-multi-client')
+  const port = await config.getString('RPC_SERVER_PORT')
+  const serverUrl = `ws://127.0.0.1:${port}`
+  const headers = createAuthHeaders('get', '/', {}, identity)
+  const authMessage = new TextEncoder().encode(JSON.stringify(headers))
+  const transport = createWebSocketTransport(serverUrl)
+
+  const client = await new Promise<RawClient<FromTsProtoServiceDefinition<typeof SocialServiceDefinition>>>(
+    (resolve, reject) => {
+      const timeoutId = setTimeout(() => reject(new Error('Connection timeout')), 10000)
+      transport.on('connect', async () => {
+        try {
+          transport.sendMessage(authMessage)
+          const rpcClient = await createRpcClient(transport)
+          const rpcPort = await rpcClient.createPort('test-multi-client')
+          const service = loadService(rpcPort, SocialServiceDefinition)
+          clearTimeout(timeoutId)
+          resolve(service)
+        } catch (error) {
+          clearTimeout(timeoutId)
+          reject(error as Error)
+        }
+      })
+      transport.on('error', (error) => {
+        logger.error('Transport error during connect', { error: (error as Error)?.message })
+        clearTimeout(timeoutId)
+        reject(error as Error)
+      })
+    }
+  )
+
+  return {
+    client,
+    authAddress: identity.realAccount.address.toLowerCase(),
+    close: () => transport.close()
+  }
+}
 
 export async function createRpcClientComponent({
   config,

--- a/test/unit/adapters/rpc-server.spec.ts
+++ b/test/unit/adapters/rpc-server.spec.ts
@@ -3,13 +3,10 @@ import {
   IRPCServerComponent,
   ISubscribersContext,
   IUpdateHandlerComponent,
-  ICacheComponent,
-  IRedisComponent,
   RpcServerContext
 } from '../../../src/types'
 import { RpcServer, Transport, createRpcServer } from '@dcl/rpc'
 import { mockConfig, mockFriendsDB, mockMetrics, mockPubSub, mockUWs } from '../../mocks/components'
-import { createRedisMock } from '../../mocks/components/redis'
 import { createLogsMockedComponent } from '../../mocks/components/logs'
 import { createWsPoolMockedComponent } from '../../mocks/components/ws-pool'
 import {
@@ -42,28 +39,13 @@ describe('createRpcServerComponent', () => {
   let subscribersContext: ISubscribersContext
   let endIncomingOrOutgoingPrivateVoiceChatForUserMock: jest.Mock
   let mockUpdateHandler: jest.Mocked<IUpdateHandlerComponent>
-  let mockRedis: jest.Mocked<IRedisComponent & ICacheComponent>
   let mockLogs: jest.Mocked<ILoggerComponent>
 
   beforeEach(async () => {
     endIncomingOrOutgoingPrivateVoiceChatForUserMock = jest.fn()
-    mockRedis = createRedisMock({})
     mockLogs = createLogsMockedComponent()
 
-    // Set up Redis mock with state tracking
-    const addressesSet = new Set<string>()
-    mockRedis.sAdd.mockImplementation(async (_key: string, address: string) => {
-      addressesSet.add(address)
-      return 1
-    })
-    mockRedis.sRem.mockImplementation(async (_key: string, addresses: string | string[]) => {
-      const toRemove = Array.isArray(addresses) ? addresses : [addresses]
-      toRemove.forEach((addr) => addressesSet.delete(addr))
-      return toRemove.length
-    })
-    mockRedis.sMembers.mockImplementation(async () => Array.from(addressesSet))
-
-    subscribersContext = createSubscribersContext({ redis: mockRedis, logs: mockLogs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
+    subscribersContext = createSubscribersContext({ logs: mockLogs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
 
     rpcServerMock = createRpcServer({
       logger: mockLogs.getLogger('rpcServer-test')
@@ -204,7 +186,7 @@ describe('createRpcServerComponent', () => {
     it('should create and store a new emitter for the user', () => {
       rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId })
 
-      const subscriber = subscribersContext.getOrAddSubscriber(address)
+      const subscriber = subscribersContext.getSubscriber(address)!
       expect(subscriber).toBeDefined()
       expect(subscriber.all).toBeDefined()
       expect(subscribersContext.getLocalSubscribersAddresses()).toContain(address)
@@ -212,10 +194,10 @@ describe('createRpcServerComponent', () => {
 
     it('should not override existing subscriber for the same address', () => {
       rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId })
-      const firstSubscriber = subscribersContext.getOrAddSubscriber(address)
+      const firstSubscriber = subscribersContext.getSubscriber(address)!
 
       rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId: 'conn-2' })
-      const secondSubscriber = subscribersContext.getOrAddSubscriber(address)
+      const secondSubscriber = subscribersContext.getSubscriber(address)!
 
       expect(secondSubscriber).toBe(firstSubscriber)
     })
@@ -226,8 +208,8 @@ describe('createRpcServerComponent', () => {
       rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId })
       rpcServer.attachUser({ transport: mockTransport, address: address2, wsConnectionId: 'conn-2' })
 
-      const subscriber1 = subscribersContext.getOrAddSubscriber(address)
-      const subscriber2 = subscribersContext.getOrAddSubscriber(address2)
+      const subscriber1 = subscribersContext.getSubscriber(address)!
+      const subscriber2 = subscribersContext.getSubscriber(address2)!
 
       expect(subscriber1).not.toBe(subscriber2)
       expect(subscribersContext.getLocalSubscribersAddresses()).toContain(address)
@@ -255,7 +237,7 @@ describe('createRpcServerComponent', () => {
     })
 
     it('should clear subscriber events when detaching', () => {
-      const subscriber = subscribersContext.getOrAddSubscriber(address)
+      const subscriber = subscribersContext.getSubscriber(address)!
       const clearSpy = jest.spyOn(subscriber.all, 'clear')
 
       rpcServer.detachUser(address, wsConnectionId)

--- a/test/unit/adapters/rpc-server.spec.ts
+++ b/test/unit/adapters/rpc-server.spec.ts
@@ -231,7 +231,7 @@ describe('createRpcServerComponent', () => {
 
       rpcServer.detachUser(address, wsConnectionId)
 
-      // Wait for async removeSubscriber to complete
+      // detach tears down synchronously; give any fire-and-forget cleanup a tick to settle
       await new Promise((resolve) => setTimeout(resolve, 10))
       expect(subscribersContext.getLocalSubscribersAddresses()).not.toContain(address)
     })
@@ -257,11 +257,31 @@ describe('createRpcServerComponent', () => {
       expect(endIncomingOrOutgoingPrivateVoiceChatForUserMock).toHaveBeenCalledWith(address)
     })
 
+    it('should not end the private voice chat when a non-last connection detaches', () => {
+      // Same address connected from a second place (e.g. website + in-world client).
+      rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId: 'conn-2' })
+      endIncomingOrOutgoingPrivateVoiceChatForUserMock.mockClear()
+
+      rpcServer.detachUser(address, wsConnectionId)
+
+      expect(endIncomingOrOutgoingPrivateVoiceChatForUserMock).not.toHaveBeenCalled()
+    })
+
+    it('should end the private voice chat only once the last connection detaches', () => {
+      rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId: 'conn-2' })
+
+      rpcServer.detachUser(address, wsConnectionId)
+      expect(endIncomingOrOutgoingPrivateVoiceChatForUserMock).not.toHaveBeenCalled()
+
+      rpcServer.detachUser(address, 'conn-2')
+      expect(endIncomingOrOutgoingPrivateVoiceChatForUserMock).toHaveBeenCalledWith(address)
+    })
+
     it('should handle multiple detach calls for same user', async () => {
       rpcServer.detachUser(address, wsConnectionId)
       rpcServer.detachUser(address, wsConnectionId)
 
-      // Wait for async removeSubscriber to complete
+      // detach tears down synchronously; give any fire-and-forget cleanup a tick to settle
       await new Promise((resolve) => setTimeout(resolve, 10))
       expect(subscribersContext.getLocalSubscribersAddresses()).not.toContain(address)
     })

--- a/test/unit/adapters/rpc-server.spec.ts
+++ b/test/unit/adapters/rpc-server.spec.ts
@@ -189,18 +189,20 @@ describe('createRpcServerComponent', () => {
 
   describe('attachUser', () => {
     const address = '0x123'
+    const wsConnectionId = 'conn-1'
 
     it('should attach a user and register transport events', () => {
-      rpcServer.attachUser({ transport: mockTransport, address })
+      rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId })
 
       expect(attachTransportMock).toHaveBeenCalledWith(mockTransport, {
         subscribersContext: expect.any(Object),
-        address
+        address,
+        wsConnectionId
       })
     })
 
     it('should create and store a new emitter for the user', () => {
-      rpcServer.attachUser({ transport: mockTransport, address })
+      rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId })
 
       const subscriber = subscribersContext.getOrAddSubscriber(address)
       expect(subscriber).toBeDefined()
@@ -209,10 +211,10 @@ describe('createRpcServerComponent', () => {
     })
 
     it('should not override existing subscriber for the same address', () => {
-      rpcServer.attachUser({ transport: mockTransport, address })
+      rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId })
       const firstSubscriber = subscribersContext.getOrAddSubscriber(address)
 
-      rpcServer.attachUser({ transport: mockTransport, address })
+      rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId: 'conn-2' })
       const secondSubscriber = subscribersContext.getOrAddSubscriber(address)
 
       expect(secondSubscriber).toBe(firstSubscriber)
@@ -221,8 +223,8 @@ describe('createRpcServerComponent', () => {
     it('should maintain separate subscribers for different addresses', () => {
       const address2 = '0x456'
 
-      rpcServer.attachUser({ transport: mockTransport, address })
-      rpcServer.attachUser({ transport: mockTransport, address: address2 })
+      rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId })
+      rpcServer.attachUser({ transport: mockTransport, address: address2, wsConnectionId: 'conn-2' })
 
       const subscriber1 = subscribersContext.getOrAddSubscriber(address)
       const subscriber2 = subscribersContext.getOrAddSubscriber(address2)
@@ -235,16 +237,17 @@ describe('createRpcServerComponent', () => {
 
   describe('detachUser', () => {
     const address = '0x123'
+    const wsConnectionId = 'conn-1'
 
     beforeEach(() => {
-      rpcServer.attachUser({ transport: mockTransport, address })
+      rpcServer.attachUser({ transport: mockTransport, address, wsConnectionId })
       endIncomingOrOutgoingPrivateVoiceChatForUserMock.mockResolvedValue(undefined)
     })
 
     it('should remove subscriber when detaching user', async () => {
       expect(subscribersContext.getLocalSubscribersAddresses()).toContain(address)
 
-      rpcServer.detachUser(address)
+      rpcServer.detachUser(address, wsConnectionId)
 
       // Wait for async removeSubscriber to complete
       await new Promise((resolve) => setTimeout(resolve, 10))
@@ -255,7 +258,7 @@ describe('createRpcServerComponent', () => {
       const subscriber = subscribersContext.getOrAddSubscriber(address)
       const clearSpy = jest.spyOn(subscriber.all, 'clear')
 
-      rpcServer.detachUser(address)
+      rpcServer.detachUser(address, wsConnectionId)
 
       expect(clearSpy).toHaveBeenCalled()
     })
@@ -263,18 +266,18 @@ describe('createRpcServerComponent', () => {
     it('should handle detaching non-existent user', () => {
       const nonExistentAddress = '0x456'
 
-      expect(() => rpcServer.detachUser(nonExistentAddress)).not.toThrow()
+      expect(() => rpcServer.detachUser(nonExistentAddress, wsConnectionId)).not.toThrow()
       expect(subscribersContext.getLocalSubscribersAddresses()).not.toContain(nonExistentAddress)
     })
 
     it('should end the incoming or outgoing private voice chat for the user when detaching', () => {
-      rpcServer.detachUser(address)
+      rpcServer.detachUser(address, wsConnectionId)
       expect(endIncomingOrOutgoingPrivateVoiceChatForUserMock).toHaveBeenCalledWith(address)
     })
 
     it('should handle multiple detach calls for same user', async () => {
-      rpcServer.detachUser(address)
-      rpcServer.detachUser(address)
+      rpcServer.detachUser(address, wsConnectionId)
+      rpcServer.detachUser(address, wsConnectionId)
 
       // Wait for async removeSubscriber to complete
       await new Promise((resolve) => setTimeout(resolve, 10))

--- a/test/unit/adapters/rpc-server/services/subscribe-to-block-updates.spec.ts
+++ b/test/unit/adapters/rpc-server/services/subscribe-to-block-updates.spec.ts
@@ -1,9 +1,8 @@
 import { subscribeToBlockUpdatesService } from '../../../../../src/controllers/handlers/rpc/subscribe-to-block-updates'
 import { Empty } from '@dcl/protocol/out-js/google/protobuf/empty.gen'
-import { ICacheComponent, IRedisComponent, RpcServerContext } from '../../../../../src/types'
+import { RpcServerContext } from '../../../../../src/types'
 import { createMockUpdateHandlerComponent } from '../../../../mocks/components'
 import { createSubscribersContext } from '../../../../../src/adapters/rpc-server'
-import { createRedisMock } from '../../../../mocks/components/redis'
 import { createLogsMockedComponent } from '../../../../mocks/components/logs'
 import { mockMetrics } from '../../../../mocks/components/metrics'
 import { mockConfig } from '../../../../mocks/components/config'
@@ -15,7 +14,6 @@ describe('when subscribing to block updates', () => {
   let rpcContext: RpcServerContext
   let mockUpdateHandler: jest.Mocked<any>
   let subscribersContext: any
-  let redis: jest.Mocked<IRedisComponent & ICacheComponent>
   let logs: jest.Mocked<ILoggerComponent>
 
   const mockUpdate = {
@@ -25,9 +23,8 @@ describe('when subscribing to block updates', () => {
   }
 
   beforeEach(() => {
-    redis = createRedisMock({})
     logs = createLogsMockedComponent()
-    subscribersContext = createSubscribersContext({ redis, logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
+    subscribersContext = createSubscribersContext({ logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
     mockUpdateHandler = createMockUpdateHandlerComponent({})
 
     subscribeToBlockUpdates = subscribeToBlockUpdatesService({

--- a/test/unit/adapters/rpc-server/services/subscribe-to-community-member-connectivity-updates.spec.ts
+++ b/test/unit/adapters/rpc-server/services/subscribe-to-community-member-connectivity-updates.spec.ts
@@ -1,9 +1,8 @@
 import { Empty } from '@dcl/protocol/out-js/google/protobuf/empty.gen'
-import { ICacheComponent, IRedisComponent, RpcServerContext, SubscriptionEventsEmitter } from '../../../../../src/types'
+import { RpcServerContext, SubscriptionEventsEmitter } from '../../../../../src/types'
 import { subscribeToCommunityMemberConnectivityUpdatesService } from '../../../../../src/controllers/handlers/rpc/subscribe-to-community-member-connectivity-updates'
 import { createMockUpdateHandlerComponent } from '../../../../mocks/components'
 import { createSubscribersContext } from '../../../../../src/adapters/rpc-server'
-import { createRedisMock } from '../../../../mocks/components/redis'
 import { createLogsMockedComponent } from '../../../../mocks/components/logs'
 import { mockMetrics } from '../../../../mocks/components/metrics'
 import { mockConfig } from '../../../../mocks/components/config'
@@ -19,7 +18,6 @@ describe('when subscribing to community member connectivity updates', () => {
   let rpcContext: RpcServerContext
   let mockUpdateHandler: jest.Mocked<any>
   let subscribersContext: any
-  let redis: jest.Mocked<IRedisComponent & ICacheComponent>
   let logs: jest.Mocked<ILoggerComponent>
 
   const mockUpdate = {
@@ -29,9 +27,8 @@ describe('when subscribing to community member connectivity updates', () => {
   }
 
   beforeEach(() => {
-    redis = createRedisMock({})
     logs = createLogsMockedComponent()
-    subscribersContext = createSubscribersContext({ redis, logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
+    subscribersContext = createSubscribersContext({ logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
     mockUpdateHandler = createMockUpdateHandlerComponent({})
 
     subscribeToCommunityMemberConnectivityUpdates = subscribeToCommunityMemberConnectivityUpdatesService({

--- a/test/unit/adapters/rpc-server/services/subscribe-to-community-voice-chat-updates.spec.ts
+++ b/test/unit/adapters/rpc-server/services/subscribe-to-community-voice-chat-updates.spec.ts
@@ -6,22 +6,18 @@ import {
 } from '@dcl/protocol/out-js/decentraland/social_service/v2/social_service_v2.gen'
 import { subscribeToCommunityVoiceChatUpdatesService } from '../../../../../src/controllers/handlers/rpc/subscribe-to-community-voice-chat-updates'
 import {
-  ICacheComponent,
-  IRedisComponent,
   IUpdateHandlerComponent,
   RpcServerContext,
   SubscriptionEventsEmitter
 } from '../../../../../src/types'
 import { createLogsMockedComponent, createMockUpdateHandlerComponent } from '../../../../mocks/components'
 import { createSubscribersContext } from '../../../../../src/adapters/rpc-server'
-import { createRedisMock } from '../../../../mocks/components/redis'
 import { mockMetrics } from '../../../../mocks/components/metrics'
 import { mockConfig } from '../../../../mocks/components/config'
 import { createWsPoolMockedComponent } from '../../../../mocks/components/ws-pool'
 
 describe('when subscribing to community voice chat updates', () => {
   let logs: jest.Mocked<ILoggerComponent>
-  let redis: jest.Mocked<IRedisComponent & ICacheComponent>
   let service: ReturnType<typeof subscribeToCommunityVoiceChatUpdatesService>
   let rpcContext: RpcServerContext
   let mockUpdateHandler: jest.Mocked<IUpdateHandlerComponent>
@@ -34,7 +30,6 @@ describe('when subscribing to community voice chat updates', () => {
     communityId = 'test-community-123'
     voiceChatId = 'test-voice-chat-456'
     logs = createLogsMockedComponent()
-    redis = createRedisMock({})
     mockUpdateHandler = createMockUpdateHandlerComponent({})
 
     service = subscribeToCommunityVoiceChatUpdatesService({
@@ -43,7 +38,7 @@ describe('when subscribing to community voice chat updates', () => {
 
     rpcContext = {
       address: userAddress,
-      subscribersContext: createSubscribersContext({ redis, logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
+      subscribersContext: createSubscribersContext({ logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
     }
   })
 

--- a/test/unit/adapters/rpc-server/services/subscribe-to-friend-connectivity-updates.spec.ts
+++ b/test/unit/adapters/rpc-server/services/subscribe-to-friend-connectivity-updates.spec.ts
@@ -1,5 +1,5 @@
 import { Empty } from '@dcl/protocol/out-js/google/protobuf/empty.gen'
-import { ICacheComponent, IRedisComponent, RpcServerContext } from '../../../../../src/types'
+import { RpcServerContext } from '../../../../../src/types'
 import {
   mockFriendsDB,
   createMockPeersStatsComponent,
@@ -11,7 +11,6 @@ import { ConnectivityStatus } from '@dcl/protocol/out-js/decentraland/social_ser
 import { createMockProfile } from '../../../../mocks/profile'
 import { parseProfileToFriend } from '../../../../../src/logic/friends'
 import { createSubscribersContext } from '../../../../../src/adapters/rpc-server'
-import { createRedisMock } from '../../../../mocks/components/redis'
 import { createLogsMockedComponent } from '../../../../mocks/components/logs'
 import { mockMetrics } from '../../../../mocks/components/metrics'
 import { mockConfig } from '../../../../mocks/components/config'
@@ -26,7 +25,6 @@ describe('when subscribing to friend connectivity updates', () => {
   let mockPeersStats: jest.Mocked<IPeersStatsComponent>
   let subscribersContext: any
   let mockFriendProfile: any
-  let redis: jest.Mocked<IRedisComponent & ICacheComponent>
   let logs: jest.Mocked<ILoggerComponent>
 
   const friend = {
@@ -34,9 +32,8 @@ describe('when subscribing to friend connectivity updates', () => {
   }
 
   beforeEach(() => {
-    redis = createRedisMock({})
     logs = createLogsMockedComponent()
-    subscribersContext = createSubscribersContext({ redis, logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
+    subscribersContext = createSubscribersContext({ logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
     mockUpdateHandler = createMockUpdateHandlerComponent({})
     mockPeersStats = createMockPeersStatsComponent()
     mockFriendProfile = createMockProfile('0x456')

--- a/test/unit/adapters/rpc-server/services/subscribe-to-friendship-updates.spec.ts
+++ b/test/unit/adapters/rpc-server/services/subscribe-to-friendship-updates.spec.ts
@@ -1,11 +1,10 @@
 import { subscribeToFriendshipUpdatesService } from '../../../../../src/controllers/handlers/rpc/subscribe-to-friendship-updates'
 import { Empty } from '@dcl/protocol/out-js/google/protobuf/empty.gen'
-import { Action, ICacheComponent, IRedisComponent, RpcServerContext } from '../../../../../src/types'
+import { Action, RpcServerContext } from '../../../../../src/types'
 import { createMockUpdateHandlerComponent } from '../../../../mocks/components'
 import { createMockProfile } from '../../../../mocks/profile'
 import { parseProfileToFriend } from '../../../../../src/logic/friends'
 import { createSubscribersContext } from '../../../../../src/adapters/rpc-server'
-import { createRedisMock } from '../../../../mocks/components/redis'
 import { createLogsMockedComponent } from '../../../../mocks/components/logs'
 import { mockMetrics } from '../../../../mocks/components/metrics'
 import { mockConfig } from '../../../../mocks/components/config'
@@ -18,7 +17,6 @@ describe('when subscribing to friendship updates', () => {
   let mockUpdateHandler: jest.Mocked<any>
   let subscribersContext: any
   let mockFriendProfile: any
-  let redis: jest.Mocked<IRedisComponent & ICacheComponent>
   let logs: jest.Mocked<ILoggerComponent>
 
   const mockUpdate = {
@@ -30,9 +28,8 @@ describe('when subscribing to friendship updates', () => {
   }
 
   beforeEach(() => {
-    redis = createRedisMock({})
     logs = createLogsMockedComponent()
-    subscribersContext = createSubscribersContext({ redis, logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
+    subscribersContext = createSubscribersContext({ logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
     mockUpdateHandler = createMockUpdateHandlerComponent({})
     mockFriendProfile = createMockProfile('0x456')
 

--- a/test/unit/adapters/rpc-server/services/subscribe-to-private-voice-chat-updates.spec.ts
+++ b/test/unit/adapters/rpc-server/services/subscribe-to-private-voice-chat-updates.spec.ts
@@ -2,15 +2,12 @@ import { ILoggerComponent } from '@well-known-components/interfaces'
 import { Empty } from '@dcl/protocol/out-js/google/protobuf/empty.gen'
 import { subscribeToPrivateVoiceChatUpdatesService } from '../../../../../src/controllers/handlers/rpc/subscribe-to-private-voice-chat-updates'
 import {
-  ICacheComponent,
-  IRedisComponent,
   IUpdateHandlerComponent,
   RpcServerContext,
   SubscriptionEventsEmitter
 } from '../../../../../src/types'
 import { createLogsMockedComponent, createMockUpdateHandlerComponent } from '../../../../mocks/components'
 import { createSubscribersContext } from '../../../../../src/adapters/rpc-server'
-import { createRedisMock } from '../../../../mocks/components/redis'
 import { mockMetrics } from '../../../../mocks/components/metrics'
 import { mockConfig } from '../../../../mocks/components/config'
 import { createWsPoolMockedComponent } from '../../../../mocks/components/ws-pool'
@@ -22,7 +19,6 @@ import { VoiceChatStatus } from '../../../../../src/logic/voice/types'
 
 describe('when subscribing to private voice chat updates', () => {
   let logs: jest.Mocked<ILoggerComponent>
-  let redis: jest.Mocked<IRedisComponent & ICacheComponent>
   let service: ReturnType<typeof subscribeToPrivateVoiceChatUpdatesService>
   let rpcContext: RpcServerContext
   let mockUpdateHandler: jest.Mocked<IUpdateHandlerComponent>
@@ -35,7 +31,6 @@ describe('when subscribing to private voice chat updates', () => {
     calleeAddress = '0xC001010101010101010101010101010101010101'
     callId = '1'
     logs = createLogsMockedComponent()
-    redis = createRedisMock({})
     mockUpdateHandler = createMockUpdateHandlerComponent({})
 
     service = subscribeToPrivateVoiceChatUpdatesService({
@@ -44,7 +39,7 @@ describe('when subscribing to private voice chat updates', () => {
 
     rpcContext = {
       address: callerAddress,
-      subscribersContext: createSubscribersContext({ redis, logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
+      subscribersContext: createSubscribersContext({ logs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
     }
   })
 

--- a/test/unit/adapters/subscribers-context.spec.ts
+++ b/test/unit/adapters/subscribers-context.spec.ts
@@ -1,6 +1,5 @@
 import { createSubscribersContext } from '../../../src/adapters/rpc-server/subscribers-context'
-import mitt from 'mitt'
-import { ICacheComponent, IRedisComponent, SubscriptionEventsEmitter } from '../../../src/types'
+import { ICacheComponent, IRedisComponent } from '../../../src/types'
 import { createRedisMock } from '../../mocks/components/redis'
 import { createLogsMockedComponent } from '../../mocks/components/logs'
 import { mockMetrics } from '../../mocks/components/metrics'
@@ -23,8 +22,10 @@ describe('SubscribersContext Component', () => {
 
   function createTestContext() {
     return {
-      context: createSubscribersContext({ redis: mockRedis, logs: mockLogs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent()),
-      subscriber: mitt<SubscriptionEventsEmitter>(),
+      context: createSubscribersContext(
+        { redis: mockRedis, logs: mockLogs, metrics: mockMetrics, config: mockConfig },
+        createWsPoolMockedComponent()
+      ),
       address: '0x123'
     }
   }
@@ -37,50 +38,109 @@ describe('SubscribersContext Component', () => {
     })
   })
 
-  describe('when managing subscribers', () => {
-    describe('and adding a subscriber', () => {
-      it('should add a new subscriber locally and to Redis', async () => {
-        const { context, subscriber, address } = createTestContext()
+  describe('when adding connections for an address', () => {
+    describe('and it is the first connection for the address', () => {
+      let context: ReturnType<typeof createTestContext>['context']
+      let address: string
 
-        await context.addSubscriber(address, subscriber)
-
-        expect(context.getSubscribers()[address]).toBe(subscriber)
-        expect(mockRedis.sAdd).toHaveBeenCalledWith('online_subscribers', address)
+      beforeEach(() => {
+        ;({ context, address } = createTestContext())
+        context.addConnection(address, 'conn-1')
       })
 
-      it('should preserve existing subscriber when adding duplicate', async () => {
-        const { context, subscriber, address } = createTestContext()
-        const newSubscriber = mitt<SubscriptionEventsEmitter>()
+      it('should create the shared emitter for the address', () => {
+        expect(context.getSubscriber(address)).toBeDefined()
+      })
 
-        await context.addSubscriber(address, subscriber)
-        await context.addSubscriber(address, newSubscriber)
-
-        expect(context.getSubscribers()[address]).toBe(subscriber)
-        // Should still attempt to add to Redis (idempotent)
-        expect(mockRedis.sAdd).toHaveBeenCalledTimes(2)
+      it('should mark the address online in Redis', () => {
+        expect(mockRedis.sAdd).toHaveBeenCalledWith('online_subscribers', address)
       })
     })
 
-    describe('and removing a subscriber', () => {
-      it('should remove existing subscriber locally and from Redis', async () => {
-        const { context, subscriber, address } = createTestContext()
-        const clearSpy = jest.spyOn(subscriber.all, 'clear')
+    describe('and a second connection for the same address is added', () => {
+      let context: ReturnType<typeof createTestContext>['context']
+      let address: string
 
-        await context.addSubscriber(address, subscriber)
-        await context.removeSubscriber(address)
-
-        expect(context.getSubscribers()[address]).toBeUndefined()
-        expect(clearSpy).toHaveBeenCalled()
-        expect(mockRedis.sRem).toHaveBeenCalledWith('online_subscribers', address)
+      beforeEach(() => {
+        ;({ context, address } = createTestContext())
+        context.addConnection(address, 'conn-1')
+        context.addConnection(address, 'conn-2')
       })
 
-      it('should handle removing non-existent subscriber gracefully', async () => {
-        const { context, address } = createTestContext()
+      it('should not mark the address online in Redis a second time', () => {
+        expect(mockRedis.sAdd).toHaveBeenCalledTimes(1)
+      })
 
-        await context.removeSubscriber(address)
+      it('should keep a single shared emitter for the address', () => {
+        expect(context.getLocalSubscribersAddresses()).toEqual([address])
+      })
+    })
+  })
 
-        expect(context.getSubscribers()[address]).toBeUndefined()
+  describe('when removing connections for an address', () => {
+    describe('and other connections for the address remain', () => {
+      let context: ReturnType<typeof createTestContext>['context']
+      let address: string
+      let wasLast: boolean
+
+      beforeEach(() => {
+        ;({ context, address } = createTestContext())
+        context.addConnection(address, 'conn-1')
+        context.addConnection(address, 'conn-2')
+        wasLast = context.removeConnection(address, 'conn-1')
+      })
+
+      it('should report that it was not the last connection', () => {
+        expect(wasLast).toBe(false)
+      })
+
+      it('should keep the shared emitter alive', () => {
+        expect(context.getSubscriber(address)).toBeDefined()
+      })
+
+      it('should not remove the address from Redis', () => {
+        expect(mockRedis.sRem).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and it is the last connection for the address', () => {
+      let context: ReturnType<typeof createTestContext>['context']
+      let address: string
+      let wasLast: boolean
+
+      beforeEach(() => {
+        ;({ context, address } = createTestContext())
+        context.addConnection(address, 'conn-1')
+        wasLast = context.removeConnection(address, 'conn-1')
+      })
+
+      it('should report that it was the last connection', () => {
+        expect(wasLast).toBe(true)
+      })
+
+      it('should clear the shared emitter', () => {
+        expect(context.getSubscriber(address)).toBeUndefined()
+      })
+
+      it('should remove the address from Redis', () => {
         expect(mockRedis.sRem).toHaveBeenCalledWith('online_subscribers', address)
+      })
+    })
+
+    describe('and the connection was already removed', () => {
+      let context: ReturnType<typeof createTestContext>['context']
+      let address: string
+      let wasLast: boolean
+
+      beforeEach(() => {
+        ;({ context, address } = createTestContext())
+        context.addConnection(address, 'conn-1')
+        context.removeConnection(address, 'conn-1')
+        wasLast = context.removeConnection(address, 'conn-1')
+      })
+
+      it('should report that it was not the last connection (idempotent)', () => {
+        expect(wasLast).toBe(false)
       })
     })
   })
@@ -91,7 +151,6 @@ describe('SubscribersContext Component', () => {
         const { context } = createTestContext()
         const expectedAddresses = ['0x123', '0x456', '0x789']
 
-        // Mock sScanIterator to return an async iterable
         ;(mockRedis.client as any).sScanIterator = jest.fn().mockReturnValue(
           (async function* () {
             for (const addr of expectedAddresses) {
@@ -107,14 +166,13 @@ describe('SubscribersContext Component', () => {
       })
 
       it('should fallback to local subscribers when Redis fails', async () => {
-        const { context, subscriber, address } = createTestContext()
+        const { context, address } = createTestContext()
 
-        // Mock sScanIterator to throw
         ;(mockRedis.client as any).sScanIterator = jest.fn().mockImplementation(() => {
           throw new Error('Redis error')
         })
 
-        await context.addSubscriber(address, subscriber)
+        context.addConnection(address, 'conn-1')
         const addresses = await context.getSubscribersAddresses()
 
         expect(addresses).toEqual([address])
@@ -122,28 +180,26 @@ describe('SubscribersContext Component', () => {
     })
 
     describe('and getting local subscriber addresses', () => {
-      it('should return only local subscriber addresses', async () => {
+      it('should return only local subscriber addresses', () => {
         const { context } = createTestContext()
         const addresses = ['0x123', '0x456', '0x789']
 
-        for (const address of addresses) {
-          await context.addSubscriber(address, mitt())
-        }
+        addresses.forEach((address, index) => context.addConnection(address, `conn-${index}`))
 
         expect(context.getLocalSubscribersAddresses()).toEqual(addresses)
       })
     })
 
     describe('and using getOrAddSubscriber', () => {
-      it('should return existing subscriber', async () => {
-        const { context, subscriber, address } = createTestContext()
+      it('should return the existing emitter on subsequent calls', () => {
+        const { context, address } = createTestContext()
 
-        await context.addSubscriber(address, subscriber)
+        const emitter = context.getOrAddSubscriber(address)
 
-        expect(context.getOrAddSubscriber(address)).toBe(subscriber)
+        expect(context.getOrAddSubscriber(address)).toBe(emitter)
       })
 
-      it('should create and return new subscriber if none exists', () => {
+      it('should create and return a new emitter if none exists', () => {
         const { context, address } = createTestContext()
 
         const newSubscriber = context.getOrAddSubscriber(address)
@@ -152,72 +208,118 @@ describe('SubscribersContext Component', () => {
         expect(newSubscriber.all).toBeDefined()
       })
 
-      it('should add new subscriber to Redis for global tracking', async () => {
+      it('should NOT touch Redis (online tracking is reference-counted by addConnection)', () => {
         const { context, address } = createTestContext()
 
         context.getOrAddSubscriber(address)
 
-        // Wait for the async Redis call
-        await new Promise((resolve) => setTimeout(resolve, 10))
-        expect(mockRedis.sAdd).toHaveBeenCalledWith('online_subscribers', address)
+        expect(mockRedis.sAdd).not.toHaveBeenCalled()
       })
     })
   })
 
-  describe('when managing generators', () => {
-    it('should register and unregister generators', async () => {
-      const { context, subscriber, address } = createTestContext()
-      await context.addSubscriber(address, subscriber)
+  describe('when managing generators per connection', () => {
+    it('should destroy a connection generators when that connection is removed', () => {
+      const { context, address } = createTestContext()
+      context.addConnection(address, 'conn-1')
 
-      const mockGenerator = { destroy: jest.fn() }
-      context.registerGenerator(address, mockGenerator)
-      context.unregisterGenerator(address, mockGenerator)
+      const generator = { destroy: jest.fn() }
+      context.registerGenerator('conn-1', generator)
 
-      // After unregister, removing the subscriber should not call destroy
-      await context.removeSubscriber(address)
-      expect(mockGenerator.destroy).not.toHaveBeenCalled()
+      context.removeConnection(address, 'conn-1')
+
+      expect(generator.destroy).toHaveBeenCalledTimes(1)
     })
 
-    it('should call destroy on all registered generators when removing a subscriber', async () => {
-      const { context, subscriber, address } = createTestContext()
-      await context.addSubscriber(address, subscriber)
+    it('should only destroy the removed connection generators, not other connections for the same address', () => {
+      const { context, address } = createTestContext()
+      context.addConnection(address, 'conn-1')
+      context.addConnection(address, 'conn-2')
 
-      const gen1 = { destroy: jest.fn() }
-      const gen2 = { destroy: jest.fn() }
-      context.registerGenerator(address, gen1)
-      context.registerGenerator(address, gen2)
+      const generatorForConnection1 = { destroy: jest.fn() }
+      const generatorForConnection2 = { destroy: jest.fn() }
+      context.registerGenerator('conn-1', generatorForConnection1)
+      context.registerGenerator('conn-2', generatorForConnection2)
 
-      await context.removeSubscriber(address)
+      context.removeConnection(address, 'conn-1')
 
-      expect(gen1.destroy).toHaveBeenCalledTimes(1)
-      expect(gen2.destroy).toHaveBeenCalledTimes(1)
+      expect(generatorForConnection1.destroy).toHaveBeenCalledTimes(1)
+      expect(generatorForConnection2.destroy).not.toHaveBeenCalled()
     })
 
-    it('should call destroy on generators before clearing emitter handlers', async () => {
-      const { context, subscriber, address } = createTestContext()
-      await context.addSubscriber(address, subscriber)
+    it('should not destroy a generator that was unregistered before the connection was removed', () => {
+      const { context, address } = createTestContext()
+      context.addConnection(address, 'conn-1')
+
+      const generator = { destroy: jest.fn() }
+      context.registerGenerator('conn-1', generator)
+      context.unregisterGenerator('conn-1', generator)
+
+      context.removeConnection(address, 'conn-1')
+
+      expect(generator.destroy).not.toHaveBeenCalled()
+    })
+
+    it('should destroy generators before clearing the emitter handlers on the last connection', () => {
+      const { context, address } = createTestContext()
+      context.addConnection(address, 'conn-1')
 
       const callOrder: string[] = []
-      const clearSpy = jest.spyOn(subscriber.all, 'clear').mockImplementation(() => {
+      const emitter = context.getSubscriber(address)!
+      const clearSpy = jest.spyOn(emitter.all, 'clear').mockImplementation(() => {
         callOrder.push('clear')
       })
-      const gen = {
+      const generator = {
         destroy: jest.fn().mockImplementation(() => {
           callOrder.push('destroy')
         })
       }
-      context.registerGenerator(address, gen)
+      context.registerGenerator('conn-1', generator)
 
-      await context.removeSubscriber(address)
+      context.removeConnection(address, 'conn-1')
 
       expect(callOrder).toEqual(['destroy', 'clear'])
       clearSpy.mockRestore()
     })
 
-    it('should handle unregister for non-existent address gracefully', () => {
+    it('should handle unregister for an unknown connection gracefully', () => {
       const { context } = createTestContext()
-      const mockGenerator = { destroy: jest.fn() }
-      expect(() => context.unregisterGenerator('0xnonexistent', mockGenerator)).not.toThrow()
+      const generator = { destroy: jest.fn() }
+
+      expect(() => context.unregisterGenerator('conn-unknown', generator)).not.toThrow()
+    })
+  })
+
+  describe('when tracking active subscriptions per connection', () => {
+    it('should report no active subscription initially', () => {
+      const { context } = createTestContext()
+
+      expect(context.hasActiveSubscription('conn-1', 'friendshipUpdate')).toBe(false)
+    })
+
+    it('should report an active subscription after it is set', () => {
+      const { context } = createTestContext()
+
+      context.setActiveSubscription('conn-1', 'friendshipUpdate')
+
+      expect(context.hasActiveSubscription('conn-1', 'friendshipUpdate')).toBe(true)
+    })
+
+    it('should report no active subscription after it is cleared', () => {
+      const { context } = createTestContext()
+      context.setActiveSubscription('conn-1', 'friendshipUpdate')
+
+      context.clearActiveSubscription('conn-1', 'friendshipUpdate')
+
+      expect(context.hasActiveSubscription('conn-1', 'friendshipUpdate')).toBe(false)
+    })
+
+    it('should track active subscriptions independently per connection', () => {
+      const { context } = createTestContext()
+
+      context.setActiveSubscription('conn-1', 'friendshipUpdate')
+
+      expect(context.hasActiveSubscription('conn-2', 'friendshipUpdate')).toBe(false)
     })
   })
 
@@ -226,9 +328,7 @@ describe('SubscribersContext Component', () => {
       const { context } = createTestContext()
       const addresses = ['0x123', '0x456']
 
-      for (const address of addresses) {
-        await context.addSubscriber(address, mitt())
-      }
+      addresses.forEach((address, index) => context.addConnection(address, `conn-${index}`))
 
       await context.stop?.()
 
@@ -236,22 +336,22 @@ describe('SubscribersContext Component', () => {
       expect(context.getSubscribers()).toEqual({})
     })
 
-    it('should destroy all generators for all subscribers on stop', async () => {
+    it('should destroy all generators for all connections on stop', async () => {
       const { context } = createTestContext()
       const addresses = ['0x123', '0x456']
       const generators: { destroy: jest.Mock }[] = []
 
-      for (const address of addresses) {
-        await context.addSubscriber(address, mitt())
-        const gen = { destroy: jest.fn() }
-        generators.push(gen)
-        context.registerGenerator(address, gen)
-      }
+      addresses.forEach((address, index) => {
+        context.addConnection(address, `conn-${index}`)
+        const generator = { destroy: jest.fn() }
+        generators.push(generator)
+        context.registerGenerator(`conn-${index}`, generator)
+      })
 
       await context.stop?.()
 
-      for (const gen of generators) {
-        expect(gen.destroy).toHaveBeenCalledTimes(1)
+      for (const generator of generators) {
+        expect(generator.destroy).toHaveBeenCalledTimes(1)
       }
     })
   })

--- a/test/unit/adapters/subscribers-context.spec.ts
+++ b/test/unit/adapters/subscribers-context.spec.ts
@@ -298,4 +298,56 @@ describe('SubscribersContext Component', () => {
       }
     })
   })
+
+  describe('when reconciling stale subscribers on the interval', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should remove local subscribers with no authenticated connection and keep the live ones', async () => {
+      const wsPool = createWsPoolMockedComponent({
+        // Only 0x123 is still authenticated; 0x456 has no live connection.
+        getAuthenticatedAddresses: jest.fn().mockReturnValue(['0x123'])
+      })
+      const context = createSubscribersContext(
+        { logs: mockLogs, metrics: mockMetrics, config: mockConfig },
+        wsPool
+      )
+      context.addConnection('0x123', 'conn-1')
+      context.addConnection('0x456', 'conn-2')
+
+      await context.start?.({} as any)
+      // Default reconciliation interval is 5 minutes (config returns undefined in tests).
+      jest.advanceTimersByTime(300_000)
+
+      expect(context.getSubscriber('0x123')).toBeDefined()
+      expect(context.getSubscriber('0x456')).toBeUndefined()
+
+      await context.stop?.()
+    })
+
+    it('should destroy the generators of a reconciled stale subscriber', async () => {
+      const wsPool = createWsPoolMockedComponent({
+        getAuthenticatedAddresses: jest.fn().mockReturnValue([])
+      })
+      const context = createSubscribersContext(
+        { logs: mockLogs, metrics: mockMetrics, config: mockConfig },
+        wsPool
+      )
+      context.addConnection('0x456', 'conn-2')
+      const generator = { destroy: jest.fn() }
+      context.registerGenerator('conn-2', generator)
+
+      await context.start?.({} as any)
+      jest.advanceTimersByTime(300_000)
+
+      expect(generator.destroy).toHaveBeenCalledTimes(1)
+
+      await context.stop?.()
+    })
+  })
 })

--- a/test/unit/adapters/subscribers-context.spec.ts
+++ b/test/unit/adapters/subscribers-context.spec.ts
@@ -51,10 +51,6 @@ describe('SubscribersContext Component', () => {
       it('should create the shared emitter for the address', () => {
         expect(context.getSubscriber(address)).toBeDefined()
       })
-
-      it('should mark the address online in Redis', () => {
-        expect(mockRedis.sAdd).toHaveBeenCalledWith('online_subscribers', address)
-      })
     })
 
     describe('and a second connection for the same address is added', () => {
@@ -65,10 +61,6 @@ describe('SubscribersContext Component', () => {
         ;({ context, address } = createTestContext())
         context.addConnection(address, 'conn-1')
         context.addConnection(address, 'conn-2')
-      })
-
-      it('should not mark the address online in Redis a second time', () => {
-        expect(mockRedis.sAdd).toHaveBeenCalledTimes(1)
       })
 
       it('should keep a single shared emitter for the address', () => {
@@ -97,10 +89,6 @@ describe('SubscribersContext Component', () => {
       it('should keep the shared emitter alive', () => {
         expect(context.getSubscriber(address)).toBeDefined()
       })
-
-      it('should not remove the address from Redis', () => {
-        expect(mockRedis.sRem).not.toHaveBeenCalled()
-      })
     })
 
     describe('and it is the last connection for the address', () => {
@@ -120,10 +108,6 @@ describe('SubscribersContext Component', () => {
 
       it('should clear the shared emitter', () => {
         expect(context.getSubscriber(address)).toBeUndefined()
-      })
-
-      it('should remove the address from Redis', () => {
-        expect(mockRedis.sRem).toHaveBeenCalledWith('online_subscribers', address)
       })
     })
 
@@ -169,39 +153,6 @@ describe('SubscribersContext Component', () => {
   })
 
   describe('when querying subscribers', () => {
-    describe('and getting global subscriber addresses', () => {
-      it('should return addresses from Redis using sScanIterator', async () => {
-        const { context } = createTestContext()
-        const expectedAddresses = ['0x123', '0x456', '0x789']
-
-        ;(mockRedis.client as any).sScanIterator = jest.fn().mockReturnValue(
-          (async function* () {
-            for (const addr of expectedAddresses) {
-              yield addr
-            }
-          })()
-        )
-
-        const addresses = await context.getSubscribersAddresses()
-
-        expect(addresses).toEqual(expectedAddresses)
-        expect((mockRedis.client as any).sScanIterator).toHaveBeenCalledWith('online_subscribers', { COUNT: 100 })
-      })
-
-      it('should fallback to local subscribers when Redis fails', async () => {
-        const { context, address } = createTestContext()
-
-        ;(mockRedis.client as any).sScanIterator = jest.fn().mockImplementation(() => {
-          throw new Error('Redis error')
-        })
-
-        context.addConnection(address, 'conn-1')
-        const addresses = await context.getSubscribersAddresses()
-
-        expect(addresses).toEqual([address])
-      })
-    })
-
     describe('and getting local subscriber addresses', () => {
       it('should return only local subscriber addresses', () => {
         const { context } = createTestContext()
@@ -229,14 +180,6 @@ describe('SubscribersContext Component', () => {
 
         expect(newSubscriber).toBeDefined()
         expect(newSubscriber.all).toBeDefined()
-      })
-
-      it('should NOT touch Redis (online tracking is reference-counted by addConnection)', () => {
-        const { context, address } = createTestContext()
-
-        context.getOrAddSubscriber(address)
-
-        expect(mockRedis.sAdd).not.toHaveBeenCalled()
       })
     })
   })
@@ -347,7 +290,7 @@ describe('SubscribersContext Component', () => {
   })
 
   describe('when stopping the component', () => {
-    it('should remove all local subscribers from Redis', async () => {
+    it('should clear all local subscribers', async () => {
       const { context } = createTestContext()
       const addresses = ['0x123', '0x456']
 
@@ -355,7 +298,6 @@ describe('SubscribersContext Component', () => {
 
       await context.stop?.()
 
-      expect(mockRedis.sRem).toHaveBeenCalledWith('online_subscribers', addresses)
       expect(context.getSubscribers()).toEqual({})
     })
 

--- a/test/unit/adapters/subscribers-context.spec.ts
+++ b/test/unit/adapters/subscribers-context.spec.ts
@@ -143,6 +143,29 @@ describe('SubscribersContext Component', () => {
         expect(wasLast).toBe(false)
       })
     })
+
+    describe('and the connection is not tracked for the address', () => {
+      let context: ReturnType<typeof createTestContext>['context']
+      let address: string
+      let generator: { destroy: jest.Mock }
+      let wasLast: boolean
+
+      beforeEach(() => {
+        ;({ context, address } = createTestContext())
+        // No addConnection for this id, so the connection is not tracked for the address.
+        generator = { destroy: jest.fn() }
+        context.registerGenerator('untracked-conn', generator)
+        wasLast = context.removeConnection(address, 'untracked-conn')
+      })
+
+      it('should report that it was not the last connection', () => {
+        expect(wasLast).toBe(false)
+      })
+
+      it('should not tear down generators for a connection it is not tracking', () => {
+        expect(generator.destroy).not.toHaveBeenCalled()
+      })
+    })
   })
 
   describe('when querying subscribers', () => {

--- a/test/unit/adapters/subscribers-context.spec.ts
+++ b/test/unit/adapters/subscribers-context.spec.ts
@@ -1,6 +1,4 @@
 import { createSubscribersContext } from '../../../src/adapters/rpc-server/subscribers-context'
-import { ICacheComponent, IRedisComponent } from '../../../src/types'
-import { createRedisMock } from '../../mocks/components/redis'
 import { createLogsMockedComponent } from '../../mocks/components/logs'
 import { mockMetrics } from '../../mocks/components/metrics'
 import { mockConfig } from '../../mocks/components/config'
@@ -8,11 +6,9 @@ import { createWsPoolMockedComponent } from '../../mocks/components/ws-pool'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 
 describe('SubscribersContext Component', () => {
-  let mockRedis: jest.Mocked<IRedisComponent & ICacheComponent>
   let mockLogs: jest.Mocked<ILoggerComponent>
 
   beforeEach(() => {
-    mockRedis = createRedisMock({})
     mockLogs = createLogsMockedComponent()
   })
 
@@ -23,7 +19,7 @@ describe('SubscribersContext Component', () => {
   function createTestContext() {
     return {
       context: createSubscribersContext(
-        { redis: mockRedis, logs: mockLogs, metrics: mockMetrics, config: mockConfig },
+        { logs: mockLogs, metrics: mockMetrics, config: mockConfig },
         createWsPoolMockedComponent()
       ),
       address: '0x123'
@@ -164,24 +160,6 @@ describe('SubscribersContext Component', () => {
       })
     })
 
-    describe('and using getOrAddSubscriber', () => {
-      it('should return the existing emitter on subsequent calls', () => {
-        const { context, address } = createTestContext()
-
-        const emitter = context.getOrAddSubscriber(address)
-
-        expect(context.getOrAddSubscriber(address)).toBe(emitter)
-      })
-
-      it('should create and return a new emitter if none exists', () => {
-        const { context, address } = createTestContext()
-
-        const newSubscriber = context.getOrAddSubscriber(address)
-
-        expect(newSubscriber).toBeDefined()
-        expect(newSubscriber.all).toBeDefined()
-      })
-    })
   })
 
   describe('when managing generators per connection', () => {

--- a/test/unit/controllers/handlers/ws/ws-handler.spec.ts
+++ b/test/unit/controllers/handlers/ws/ws-handler.spec.ts
@@ -293,7 +293,7 @@ describe('ws-handler', () => {
       await wsHandlers.close(mockWs, 1000, Buffer.from('normal closure'))
 
       expect(authData.transport.close).toHaveBeenCalled()
-      expect(mockRpcServer.detachUser).toHaveBeenCalledWith('0x123')
+      expect(mockRpcServer.detachUser).toHaveBeenCalledWith('0x123', 'test-client-id')
       expect(mockMetrics.increment).toHaveBeenCalledWith('ws_close_codes', { code: 1000 })
       expect(unregisterConnection).toHaveBeenCalledWith(authData)
       expect(authData.connectionStartTime).toBeDefined()

--- a/test/unit/logic/updates.spec.ts
+++ b/test/unit/logic/updates.spec.ts
@@ -2,7 +2,7 @@ import { ConnectivityStatus } from '@dcl/protocol/out-js/decentraland/social_ser
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 import { createUpdateHandlerComponent } from '../../../src/logic/updates'
 import { mockRegistry, mockFriendsDB } from '../../mocks/components'
-import mitt, { Emitter } from 'mitt'
+import { Emitter } from 'mitt'
 import {
   Action,
   IUpdateHandlerComponent,
@@ -62,8 +62,8 @@ describe('Updates Handlers', () => {
     })
 
     subscribersContext = createSubscribersContext({ redis: mockRedis, logs: mockLogs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
-    await subscribersContext.addSubscriber('0x456', mitt<SubscriptionEventsEmitter>())
-    await subscribersContext.addSubscriber('0x789', mitt<SubscriptionEventsEmitter>())
+    subscribersContext.addConnection('0x456', 'conn-456')
+    subscribersContext.addConnection('0x789', 'conn-789')
 
     mockCommunityMembers = createMockCommunityMembersComponent({})
     mockRegistry.getProfile.mockResolvedValue(createMockProfile('0x456'))
@@ -538,7 +538,7 @@ describe('Updates Handlers', () => {
         describe('and the affected member is not subscribed', () => {
           beforeEach(() => {
             // Remove the affected member from subscribers
-            subscribersContext.removeSubscriber('0x123')
+            subscribersContext.removeConnection('0x123', 'conn-123')
           })
 
           it('should not emit any updates to other members or the affected member', async () => {
@@ -573,7 +573,7 @@ describe('Updates Handlers', () => {
         describe('and the affected member is not subscribed', () => {
           beforeEach(() => {
             // Remove the affected member from subscribers
-            subscribersContext.removeSubscriber('0x123')
+            subscribersContext.removeConnection('0x123', 'conn-123')
           })
 
           it('should emit connectivity update to all online members but not notify the affected member', async () => {
@@ -656,7 +656,7 @@ describe('Updates Handlers', () => {
         describe('and the affected member is not subscribed', () => {
           beforeEach(() => {
             // Remove the affected member from subscribers
-            subscribersContext.removeSubscriber('0x123')
+            subscribersContext.removeConnection('0x123', 'conn-123')
           })
 
           it('should emit connectivity update to all online members across multiple batches but not notify the affected member', async () => {
@@ -1185,7 +1185,6 @@ describe('Updates Handlers', () => {
   })
 
   describe('when handling subscription updates', () => {
-    let eventEmitter: Emitter<SubscriptionEventsEmitter>
     let parser: jest.Mock
     let rpcContext: RpcServerContext
     let subscribersContext: ISubscribersContext
@@ -1195,7 +1194,6 @@ describe('Updates Handlers', () => {
     beforeEach(async () => {
       friendshipUpdate = { id: '1', to: '0x456', from: '0x123', action: Action.REQUEST, timestamp: Date.now() }
       blockUpdate = { blockerAddress: '0x456', blockedAddress: '0x123', isBlocked: true }
-      eventEmitter = mitt<SubscriptionEventsEmitter>()
       parser = jest.fn()
 
       mockRegistry.getProfile.mockResolvedValue(mockProfile)
@@ -1222,10 +1220,11 @@ describe('Updates Handlers', () => {
       })
 
       subscribersContext = createSubscribersContext({ redis: mockRedis, logs: mockLogs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
-      await subscribersContext.addSubscriber('0x123', eventEmitter)
+      subscribersContext.addConnection('0x123', 'conn-123')
 
       rpcContext = {
         address: '0x123',
+        wsConnectionId: 'conn-123',
         subscribersContext
       }
     })
@@ -1237,7 +1236,7 @@ describe('Updates Handlers', () => {
       beforeEach(async () => {
         mockMetrics.increment.mockClear()
         clearActiveSubscriptionSpy = jest.spyOn(rpcContext.subscribersContext, 'clearActiveSubscription')
-        rpcContext.subscribersContext.setActiveSubscription('0x123', 'friendshipUpdate')
+        rpcContext.subscribersContext.setActiveSubscription('conn-123', 'friendshipUpdate')
 
         const generator = updateHandler.handleSubscriptionUpdates({
           rpcContext,
@@ -1531,7 +1530,7 @@ describe('Updates Handlers', () => {
 
         // First next() starts the generator and triggers registration
         const resultPromise = generator.next()
-        expect(registerSpy).toHaveBeenCalledWith('0x123', expect.objectContaining({ destroy: expect.any(Function) }))
+        expect(registerSpy).toHaveBeenCalledWith('conn-123', expect.objectContaining({ destroy: expect.any(Function) }))
 
         rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
         await resultPromise
@@ -1539,7 +1538,7 @@ describe('Updates Handlers', () => {
         // Return the generator to trigger finally block
         await generator.return(undefined)
 
-        expect(unregisterSpy).toHaveBeenCalledWith('0x123', expect.objectContaining({ destroy: expect.any(Function) }))
+        expect(unregisterSpy).toHaveBeenCalledWith('conn-123', expect.objectContaining({ destroy: expect.any(Function) }))
       })
 
       it('should unregister generator even when an error occurs', async () => {
@@ -1584,9 +1583,9 @@ describe('Updates Handlers', () => {
 
     describe('and there are online community members', () => {
       beforeEach(() => {
-        subscribersContext.addSubscriber('0xmember1', mitt<SubscriptionEventsEmitter>())
-        subscribersContext.addSubscriber('0xmember2', mitt<SubscriptionEventsEmitter>())
-        subscribersContext.addSubscriber('0xmember3', mitt<SubscriptionEventsEmitter>())
+        subscribersContext.addConnection('0xmember1', 'conn-member1')
+        subscribersContext.addConnection('0xmember2', 'conn-member2')
+        subscribersContext.addConnection('0xmember3', 'conn-member3')
       })
 
       it('should notify all online community members about the deletion', async () => {

--- a/test/unit/logic/updates.spec.ts
+++ b/test/unit/logic/updates.spec.ts
@@ -7,8 +7,6 @@ import {
   Action,
   IUpdateHandlerComponent,
   ISubscribersContext,
-  ICacheComponent,
-  IRedisComponent,
   SubscriptionEventsEmitter,
   RpcServerContext
 } from '../../../src/types'
@@ -16,7 +14,6 @@ import { CommunityVoiceChatStatus as ProtocolCommunityVoiceChatStatus } from '@d
 import { sleep } from '../../../src/utils/timer'
 import { createMockProfile, mockProfile } from '../../mocks/profile'
 import { createSubscribersContext } from '../../../src/adapters/rpc-server/subscribers-context'
-import { createRedisMock } from '../../mocks/components/redis'
 import { createLogsMockedComponent } from '../../mocks/components/logs'
 import { mockMetrics } from '../../mocks/components/metrics'
 import { mockConfig } from '../../mocks/components/config'
@@ -26,10 +23,18 @@ import { ICommunityMembersComponent } from '../../../src/logic/community/types'
 import { createMockCommunityMembersComponent } from '../../mocks/communities'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 
+// Ensure an address has a live connection (so it is a local subscriber) and return its shared
+// emitter. Mirrors how production creates emitters — via a connection, never orphaned.
+function emitterFor(ctx: ISubscribersContext, address: string): Emitter<SubscriptionEventsEmitter> {
+  if (!ctx.getSubscriber(address)) {
+    ctx.addConnection(address, `test-conn-${address}`)
+  }
+  return ctx.getSubscriber(address)!
+}
+
 describe('Updates Handlers', () => {
   let mockLogs: jest.Mocked<ILoggerComponent>
   let logger: ReturnType<ILoggerComponent['getLogger']>
-  let mockRedis: jest.Mocked<IRedisComponent & ICacheComponent>
   let subscribersContext: ISubscribersContext
   let updateHandler: IUpdateHandlerComponent
   let mockCommunityMembers: jest.Mocked<ICommunityMembersComponent>
@@ -38,30 +43,8 @@ describe('Updates Handlers', () => {
   beforeEach(async () => {
     mockLogs = createLogsMockedComponent()
     logger = mockLogs.getLogger('test')
-    mockRedis = createRedisMock({})
 
-    // Set up Redis mock with state tracking
-    const addressesSet = new Set<string>()
-    mockRedis.sAdd.mockImplementation(async (_key: string, address: string) => {
-      addressesSet.add(address)
-      return 1
-    })
-    mockRedis.sRem.mockImplementation(async (_key: string, addresses: string | string[]) => {
-      const toRemove = Array.isArray(addresses) ? addresses : [addresses]
-      toRemove.forEach((addr) => addressesSet.delete(addr))
-      return toRemove.length
-    })
-    mockRedis.sMembers.mockImplementation(async () => Array.from(addressesSet))
-    ;(mockRedis.client as any).sScanIterator = jest.fn().mockImplementation(() => {
-      const addresses = Array.from(addressesSet)
-      return (async function* () {
-        for (const addr of addresses) {
-          yield addr
-        }
-      })()
-    })
-
-    subscribersContext = createSubscribersContext({ redis: mockRedis, logs: mockLogs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
+    subscribersContext = createSubscribersContext({ logs: mockLogs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
     subscribersContext.addConnection('0x456', 'conn-456')
     subscribersContext.addConnection('0x789', 'conn-789')
 
@@ -86,7 +69,7 @@ describe('Updates Handlers', () => {
   describe('when handling friendship updates', () => {
     describe('and the target subscriber exists', () => {
       it('should emit friendship update to the target subscriber', () => {
-        const subscriber = subscribersContext.getOrAddSubscriber('0x456')
+        const subscriber = emitterFor(subscribersContext, '0x456')
         const emitSpy = jest.spyOn(subscriber, 'emit')
 
         const update = {
@@ -135,8 +118,8 @@ describe('Updates Handlers', () => {
   describe('when handling friendship accepted updates', () => {
     describe('and the action is accept', () => {
       it('should emit friend connectivity updates to both users with ONLINE status', () => {
-        const subscriber123 = subscribersContext.getOrAddSubscriber('0x123')
-        const subscriber456 = subscribersContext.getOrAddSubscriber('0x456')
+        const subscriber123 = emitterFor(subscribersContext, '0x123')
+        const subscriber456 = emitterFor(subscribersContext, '0x456')
         const emitSpy123 = jest.spyOn(subscriber123, 'emit')
         const emitSpy456 = jest.spyOn(subscriber456, 'emit')
 
@@ -212,8 +195,8 @@ describe('Updates Handlers', () => {
   describe('when handling friend connectivity updates', () => {
     describe('and there are online friends', () => {
       it('should emit connectivity update to all online friends', async () => {
-        const subscriber456 = subscribersContext.getOrAddSubscriber('0x456')
-        const subscriber789 = subscribersContext.getOrAddSubscriber('0x789')
+        const subscriber456 = emitterFor(subscribersContext, '0x456')
+        const subscriber789 = emitterFor(subscribersContext, '0x789')
         const emitSpy456 = jest.spyOn(subscriber456, 'emit')
         const emitSpy789 = jest.spyOn(subscriber789, 'emit')
 
@@ -293,8 +276,8 @@ describe('Updates Handlers', () => {
     let emitSpy789: jest.SpyInstance
 
     beforeEach(() => {
-      subscriber456 = subscribersContext.getOrAddSubscriber('0x456')
-      subscriber789 = subscribersContext.getOrAddSubscriber('0x789')
+      subscriber456 = emitterFor(subscribersContext, '0x456')
+      subscriber789 = emitterFor(subscribersContext, '0x789')
 
       emitSpy456 = jest.spyOn(subscriber456, 'emit')
       emitSpy789 = jest.spyOn(subscriber789, 'emit')
@@ -409,7 +392,7 @@ describe('Updates Handlers', () => {
 
           // Add the third subscriber for the test (online so the handlers consider it)
           subscribersContext.addConnection('0x999', 'conn-999')
-          const subscriber999 = subscribersContext.getOrAddSubscriber('0x999')
+          const subscriber999 = emitterFor(subscribersContext, '0x999')
           const emitSpy999 = jest.spyOn(subscriber999, 'emit')
 
           await updateHandler.communityMemberConnectivityUpdateHandler(JSON.stringify(update))
@@ -493,9 +476,9 @@ describe('Updates Handlers', () => {
       // 0x456/0x789 are marked online by the top-level beforeEach; mark 0x123 online too so
       // it is included in the Redis online set the handlers consult.
       subscribersContext.addConnection('0x123', 'conn-123')
-      subscriber456 = subscribersContext.getOrAddSubscriber('0x456')
-      subscriber789 = subscribersContext.getOrAddSubscriber('0x789')
-      subscriber123 = subscribersContext.getOrAddSubscriber('0x123')
+      subscriber456 = emitterFor(subscribersContext, '0x456')
+      subscriber789 = emitterFor(subscribersContext, '0x789')
+      subscriber123 = emitterFor(subscribersContext, '0x123')
 
       emitSpy456 = jest.spyOn(subscriber456, 'emit')
       emitSpy789 = jest.spyOn(subscriber789, 'emit')
@@ -624,7 +607,7 @@ describe('Updates Handlers', () => {
 
             // Add the third subscriber for the test (online so the handlers consider it)
             subscribersContext.addConnection('0x999', 'conn-999')
-            const subscriber999 = subscribersContext.getOrAddSubscriber('0x999')
+            const subscriber999 = emitterFor(subscribersContext, '0x999')
             const emitSpy999 = jest.spyOn(subscriber999, 'emit')
 
             await updateHandler.communityMemberStatusHandler(JSON.stringify(update))
@@ -668,7 +651,7 @@ describe('Updates Handlers', () => {
 
             // Add the third subscriber for the test (online so the handlers consider it)
             subscribersContext.addConnection('0x999', 'conn-999')
-            const subscriber999 = subscribersContext.getOrAddSubscriber('0x999')
+            const subscriber999 = emitterFor(subscribersContext, '0x999')
             const emitSpy999 = jest.spyOn(subscriber999, 'emit')
 
             await updateHandler.communityMemberStatusHandler(JSON.stringify(update))
@@ -749,7 +732,7 @@ describe('Updates Handlers', () => {
   describe('when handling block updates', () => {
     describe('and the blocked user is subscribed', () => {
       it('should emit block update to the blocked user', () => {
-        const subscriber = subscribersContext.getOrAddSubscriber('0x456')
+        const subscriber = emitterFor(subscribersContext, '0x456')
         const emitSpy = jest.spyOn(subscriber, 'emit')
 
         const update = {
@@ -805,8 +788,8 @@ describe('Updates Handlers', () => {
       calleeAddress = '0x456'
       callId = 'voice-call-1'
 
-      const caller = subscribersContext.getOrAddSubscriber(callerAddress)
-      const callee = subscribersContext.getOrAddSubscriber(calleeAddress)
+      const caller = emitterFor(subscribersContext, callerAddress)
+      const callee = emitterFor(subscribersContext, calleeAddress)
       callerEmitSpy = jest.spyOn(caller, 'emit')
       calleeEmitSpy = jest.spyOn(callee, 'emit')
 
@@ -993,9 +976,9 @@ describe('Updates Handlers', () => {
       // 0x456/0x789 are marked online by the top-level beforeEach; mark 0x123 online too so
       // it is included in the Redis online set the handlers consult.
       subscribersContext.addConnection('0x123', 'conn-123')
-      subscriber456 = subscribersContext.getOrAddSubscriber('0x456')
-      subscriber789 = subscribersContext.getOrAddSubscriber('0x789')
-      subscriber123 = subscribersContext.getOrAddSubscriber('0x123')
+      subscriber456 = emitterFor(subscribersContext, '0x456')
+      subscriber789 = emitterFor(subscribersContext, '0x789')
+      subscriber123 = emitterFor(subscribersContext, '0x123')
 
       emitSpy456 = jest.spyOn(subscriber456, 'emit')
       emitSpy789 = jest.spyOn(subscriber789, 'emit')
@@ -1198,28 +1181,7 @@ describe('Updates Handlers', () => {
 
       mockRegistry.getProfile.mockResolvedValue(mockProfile)
 
-      // Set up Redis mock with state tracking (reuse the outer scope mockRedis/mockLogs)
-      const addressesSet = new Set<string>()
-      mockRedis.sAdd.mockImplementation(async (_key: string, address: string) => {
-        addressesSet.add(address)
-        return 1
-      })
-      mockRedis.sRem.mockImplementation(async (_key: string, addresses: string | string[]) => {
-        const toRemove = Array.isArray(addresses) ? addresses : [addresses]
-        toRemove.forEach((addr) => addressesSet.delete(addr))
-        return toRemove.length
-      })
-      mockRedis.sMembers.mockImplementation(async () => Array.from(addressesSet))
-      ;(mockRedis.client as any).sScanIterator = jest.fn().mockImplementation(() => {
-        const addresses = Array.from(addressesSet)
-        return (async function* () {
-          for (const addr of addresses) {
-            yield addr
-          }
-        })()
-      })
-
-      subscribersContext = createSubscribersContext({ redis: mockRedis, logs: mockLogs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
+      subscribersContext = createSubscribersContext({ logs: mockLogs, metrics: mockMetrics, config: mockConfig }, createWsPoolMockedComponent())
       subscribersContext.addConnection('0x123', 'conn-123')
 
       rpcContext = {
@@ -1309,7 +1271,7 @@ describe('Updates Handlers', () => {
       })
 
       it('should deliver an emitted update to both connections', async () => {
-        rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
+        emitterFor(rpcContext.subscribersContext, '0x123').emit('friendshipUpdate', friendshipUpdate)
 
         expect((await resultPromiseA).value).toEqual({ parsed: true })
         expect((await resultPromiseB).value).toEqual({ parsed: true })
@@ -1330,7 +1292,7 @@ describe('Updates Handlers', () => {
         })
 
         const resultPromise = generator.next()
-        rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
+        emitterFor(rpcContext.subscribersContext, '0x123').emit('friendshipUpdate', friendshipUpdate)
 
         const result = await resultPromise
         expect(result.value).toEqual({ parsed: true })
@@ -1351,7 +1313,7 @@ describe('Updates Handlers', () => {
         })
 
         const resultPromise = generator.next()
-        rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
+        emitterFor(rpcContext.subscribersContext, '0x123').emit('friendshipUpdate', friendshipUpdate)
 
         const result = await resultPromise
         expect(result.value).toEqual({ parsed: true })
@@ -1371,7 +1333,7 @@ describe('Updates Handlers', () => {
         for (let i = 0; i < 2; i++) {
           parser.mockResolvedValueOnce({ parsed: i })
           const resultPromise = generator.next()
-          rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
+          emitterFor(rpcContext.subscribersContext, '0x123').emit('friendshipUpdate', friendshipUpdate)
           const result = await resultPromise
           expect(result.value).toEqual({ parsed: i })
           expect(parser).toHaveBeenCalledWith(friendshipUpdate, mockProfile)
@@ -1392,7 +1354,7 @@ describe('Updates Handlers', () => {
         })
 
         generator.next()
-        rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
+        emitterFor(rpcContext.subscribersContext, '0x123').emit('friendshipUpdate', friendshipUpdate)
 
         await sleep(100)
 
@@ -1416,7 +1378,7 @@ describe('Updates Handlers', () => {
         })
 
         const resultPromise = generator.next()
-        rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
+        emitterFor(rpcContext.subscribersContext, '0x123').emit('friendshipUpdate', friendshipUpdate)
 
         await sleep(100)
 
@@ -1439,7 +1401,7 @@ describe('Updates Handlers', () => {
         })
 
         const resultPromise = generator.next()
-        rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
+        emitterFor(rpcContext.subscribersContext, '0x123').emit('friendshipUpdate', friendshipUpdate)
 
         await expect(resultPromise).rejects.toThrow('Test error')
       })
@@ -1459,7 +1421,7 @@ describe('Updates Handlers', () => {
         })
 
         const resultPromise = generator.next()
-        rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('blockUpdate', blockUpdate)
+        emitterFor(rpcContext.subscribersContext, '0x123').emit('blockUpdate', blockUpdate)
 
         const result = await resultPromise
         expect(result.value).toEqual({ parsed: true })
@@ -1502,7 +1464,7 @@ describe('Updates Handlers', () => {
         const resultPromise = generator.next()
 
         // Emit the update twice to test the skip logic
-        const subscriber = rpcContext.subscribersContext.getOrAddSubscriber('0x123')
+        const subscriber = emitterFor(rpcContext.subscribersContext, '0x123')
         subscriber.emit('blockUpdate', blockUpdateWithoutProfile)
         subscriber.emit('blockUpdate', blockUpdateWithProfile)
 
@@ -1532,7 +1494,7 @@ describe('Updates Handlers', () => {
         const resultPromise = generator.next()
         expect(registerSpy).toHaveBeenCalledWith('conn-123', expect.objectContaining({ destroy: expect.any(Function) }))
 
-        rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
+        emitterFor(rpcContext.subscribersContext, '0x123').emit('friendshipUpdate', friendshipUpdate)
         await resultPromise
 
         // Return the generator to trigger finally block
@@ -1556,7 +1518,7 @@ describe('Updates Handlers', () => {
         })
 
         const resultPromise = generator.next()
-        rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
+        emitterFor(rpcContext.subscribersContext, '0x123').emit('friendshipUpdate', friendshipUpdate)
 
         await expect(resultPromise).rejects.toThrow('parser error')
         expect(unregisterSpy).toHaveBeenCalled()
@@ -1589,9 +1551,9 @@ describe('Updates Handlers', () => {
       })
 
       it('should notify all online community members about the deletion', async () => {
-        const member1Emitter = subscribersContext.getOrAddSubscriber('0xmember1')
-        const member2Emitter = subscribersContext.getOrAddSubscriber('0xmember2')
-        const member3Emitter = subscribersContext.getOrAddSubscriber('0xmember3')
+        const member1Emitter = emitterFor(subscribersContext, '0xmember1')
+        const member2Emitter = emitterFor(subscribersContext, '0xmember2')
+        const member3Emitter = emitterFor(subscribersContext, '0xmember3')
 
         const emitSpy1 = jest.spyOn(member1Emitter, 'emit')
         const emitSpy2 = jest.spyOn(member2Emitter, 'emit')

--- a/test/unit/logic/updates.spec.ts
+++ b/test/unit/logic/updates.spec.ts
@@ -407,7 +407,8 @@ describe('Updates Handlers', () => {
             status: ConnectivityStatus.ONLINE
           }
 
-          // Add the third subscriber for the test
+          // Add the third subscriber for the test (online so the handlers consider it)
+          subscribersContext.addConnection('0x999', 'conn-999')
           const subscriber999 = subscribersContext.getOrAddSubscriber('0x999')
           const emitSpy999 = jest.spyOn(subscriber999, 'emit')
 
@@ -489,6 +490,9 @@ describe('Updates Handlers', () => {
     let emitSpy123: jest.SpyInstance
 
     beforeEach(() => {
+      // 0x456/0x789 are marked online by the top-level beforeEach; mark 0x123 online too so
+      // it is included in the Redis online set the handlers consult.
+      subscribersContext.addConnection('0x123', 'conn-123')
       subscriber456 = subscribersContext.getOrAddSubscriber('0x456')
       subscriber789 = subscribersContext.getOrAddSubscriber('0x789')
       subscriber123 = subscribersContext.getOrAddSubscriber('0x123')
@@ -618,7 +622,8 @@ describe('Updates Handlers', () => {
               status
             }
 
-            // Add the third subscriber for the test
+            // Add the third subscriber for the test (online so the handlers consider it)
+            subscribersContext.addConnection('0x999', 'conn-999')
             const subscriber999 = subscribersContext.getOrAddSubscriber('0x999')
             const emitSpy999 = jest.spyOn(subscriber999, 'emit')
 
@@ -661,7 +666,8 @@ describe('Updates Handlers', () => {
               status
             }
 
-            // Add the third subscriber for the test
+            // Add the third subscriber for the test (online so the handlers consider it)
+            subscribersContext.addConnection('0x999', 'conn-999')
             const subscriber999 = subscribersContext.getOrAddSubscriber('0x999')
             const emitSpy999 = jest.spyOn(subscriber999, 'emit')
 
@@ -984,6 +990,9 @@ describe('Updates Handlers', () => {
     let emitSpy123: jest.SpyInstance
 
     beforeEach(() => {
+      // 0x456/0x789 are marked online by the top-level beforeEach; mark 0x123 online too so
+      // it is included in the Redis online set the handlers consult.
+      subscribersContext.addConnection('0x123', 'conn-123')
       subscriber456 = subscribersContext.getOrAddSubscriber('0x456')
       subscriber789 = subscribersContext.getOrAddSubscriber('0x789')
       subscriber123 = subscribersContext.getOrAddSubscriber('0x123')
@@ -1258,6 +1267,53 @@ describe('Updates Handlers', () => {
 
       it('should not clear the existing active subscription', () => {
         expect(clearActiveSubscriptionSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('and the same address is connected from two different connections', () => {
+      let resultPromiseA: Promise<IteratorResult<unknown, unknown>>
+      let resultPromiseB: Promise<IteratorResult<unknown, unknown>>
+
+      beforeEach(() => {
+        mockMetrics.increment.mockClear()
+        parser.mockResolvedValue({ parsed: true })
+
+        const contextA: RpcServerContext = { address: '0x123', wsConnectionId: 'conn-A', subscribersContext }
+        const contextB: RpcServerContext = { address: '0x123', wsConnectionId: 'conn-B', subscribersContext }
+
+        const generatorA = updateHandler.handleSubscriptionUpdates({
+          rpcContext: contextA,
+          eventName: 'friendshipUpdate',
+          getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
+          shouldHandleUpdate: () => true,
+          parser
+        })
+        const generatorB = updateHandler.handleSubscriptionUpdates({
+          rpcContext: contextB,
+          eventName: 'friendshipUpdate',
+          getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
+          shouldHandleUpdate: () => true,
+          parser
+        })
+
+        // Starting both generators runs the dedup guard and registers each connection's
+        // listener on the shared per-address emitter. The returned promises resolve once an
+        // update is emitted.
+        resultPromiseA = generatorA.next()
+        resultPromiseB = generatorB.next()
+      })
+
+      it('should not reject the second connection as a duplicate', () => {
+        expect(mockMetrics.increment).not.toHaveBeenCalledWith('subscription_duplicates_total', {
+          event: 'friendshipUpdate'
+        })
+      })
+
+      it('should deliver an emitted update to both connections', async () => {
+        rpcContext.subscribersContext.getOrAddSubscriber('0x123').emit('friendshipUpdate', friendshipUpdate)
+
+        expect((await resultPromiseA).value).toEqual({ parsed: true })
+        expect((await resultPromiseB).value).toEqual({ parsed: true })
       })
     })
 

--- a/test/unit/logic/updates.spec.ts
+++ b/test/unit/logic/updates.spec.ts
@@ -1278,6 +1278,55 @@ describe('Updates Handlers', () => {
       })
     })
 
+    describe('and the connection identity is missing', () => {
+      it('should not start the subscription and should log an error', async () => {
+        const contextWithoutConnId: RpcServerContext = { address: '0x123', subscribersContext }
+
+        const generator = updateHandler.handleSubscriptionUpdates({
+          rpcContext: contextWithoutConnId,
+          eventName: 'friendshipUpdate',
+          getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
+          shouldHandleUpdate: () => true,
+          parser
+        })
+
+        const result = await generator.next()
+
+        expect(result.done).toBe(true)
+        expect(logger.error).toHaveBeenCalledWith('Cannot handle subscription without a wsConnectionId', {
+          address: '0x123',
+          event: 'friendshipUpdate'
+        })
+      })
+    })
+
+    describe('and the address has no emitter (connection no longer attached)', () => {
+      it('should not start the subscription and should log a warning', async () => {
+        const contextWithoutEmitter: RpcServerContext = {
+          address: '0xnoemitter',
+          wsConnectionId: 'conn-detached',
+          subscribersContext
+        }
+
+        const generator = updateHandler.handleSubscriptionUpdates({
+          rpcContext: contextWithoutEmitter,
+          eventName: 'friendshipUpdate',
+          getAddressFromUpdate: (update: SubscriptionEventsEmitter['friendshipUpdate']) => update.from,
+          shouldHandleUpdate: () => true,
+          parser
+        })
+
+        const result = await generator.next()
+
+        expect(result.done).toBe(true)
+        expect(logger.warn).toHaveBeenCalledWith('No subscriber emitter for address; connection no longer attached', {
+          address: '0xnoemitter',
+          event: 'friendshipUpdate',
+          wsConnectionId: 'conn-detached'
+        })
+      })
+    })
+
     describe('and the emitter exists in context', () => {
       it('should use existing emitter from context', async () => {
         parser.mockResolvedValueOnce({ parsed: true })


### PR DESCRIPTION
Follow-up to #422 (merged). #422 turned the duplicate-subscription flood into a metric + debug log and threaded `wsConnectionId`; this PR removes the underlying cause and the fragile shared presence state.

## Problem

Users authenticate with a wallet address and can be connected from **two places at once** — the website and the in-world client. The subscription layer keyed everything by **address**, so two concurrent connections for one address collided:

1. **The second connection got no updates** — `handleSubscriptionUpdates` rejected its subscribe as a duplicate (the main source of the "Duplicate subscription detected" floods, since each rejected stream is retried).
2. **The first disconnect tore down the other session** — `removeLocalSubscriber(address)` destroyed all of the address's generators and cleared the shared emitter.
3. **The global `online_subscribers` Redis set was fragile** — managed per-instance with no fleet-wide refcount, it both *flapped* (one instance `sRem`ing an address another instance still served → missed fan-out) and accumulated stale "online" **ghosts on hard crashes** (the cleanup `sRem` only runs on graceful shutdown; the per-instance reconciliation can't reclaim another instance's ghosts).

## Fix — part 1: per-connection subscription state

Keep **one shared emitter per address**, but make bookkeeping **connection-scoped**:
- **`subscribers-context`**: `activeSubscriptions` + `subscriberGenerators` keyed by `wsConnectionId`; `connectionsByAddress` refcount; `addConnection` / `removeConnection` (destroys only that connection's generators behind a tracked-membership check; clears the shared emitter on the **last** connection; returns whether it was the last).
- **`handleSubscriptionUpdates`**: requires `wsConnectionId` (**fails loud** if missing); keys dedup/generators by it (the #407 OOM guard now blocks only the **same** connection from double-subscribing); resolves the emitter via `getSubscriber` and bails if the connection is no longer attached (never resurrects an orphan).
- **`rpc-server`**: `attachUser`→`addConnection`; `detachUser(address, wsConnectionId)`→`removeConnection`, ending the user's voice chat only on their **last** connection.
- **`ws-handler`**: thread `wsConnectionId` into both `detachUser` call sites.

## Fix — part 2: drop the global presence set

The `online_subscribers` set turned out to be **redundant**: every update is broadcast to every instance via pub/sub, and delivery is local-only (`getSubscriber`), so each instance fans out to its **own** local subscribers. The five fan-out handlers now use **`getLocalSubscribersAddresses()`** instead of `getSubscribersAddresses()`, and the set + all its Redis machinery (`sAdd`/`sRem`/`SSCAN`/`sCard`, the size warning, the `subscribers_redis_set_size` metric) is removed.

This deletes the entire stale-presence failure class:
- a hard **crash leaves no stale "online" ghosts** (there's no set to leave behind);
- **no cross-instance flapping**;
- no set bloat / `SSCAN` cost, and **no Redis writes on the connect/disconnect hot path**.

It's also cheaper (smaller per-instance filter returning exactly the deliverable recipients) and net-removes code.

## Follow-up cleanups

Now that `subscribers-context` holds no shared/Redis state:
- **`redis` dropped from its DI** — removed from the factory `Pick` and both prod call sites, and the now-dead Redis test mocks (`sAdd`/`sRem`/`sMembers`/`SSCAN` state tracking) stripped from the 8 specs that still wired them.
- **`getOrAddSubscriber` removed** from the interface + impl — it was dead in production (emitters are created via `addConnection` and read via `getSubscriber`). Specs now create emitters the way production does: through a connection.

## Result

- Website + client for the same wallet each get independent, working subscriptions; both receive updates; closing one never disrupts the other.
- Presence is **crash-safe and fleet-correct by construction** — each instance authoritatively serves only its own connections.

## Hardening from self-review

A multi-angle review of the per-connection change (no happy-path bug found) produced these, included here:
- `removeConnection` guards its per-connection teardown behind the tracked-membership check (a double/spurious detach is a true no-op).
- A missing `wsConnectionId` fails loud rather than silently address-keying.
- Subscribe resolves the emitter via `getSubscriber` (bails if absent); the unused `getOrAddSubscriber` accessor was removed entirely.
- Removed the `addSubscriber`/`removeSubscriber` compatibility helpers; tests use `addConnection`/`removeConnection`.

## ⚠️ Metrics & dashboards

This PR changes the metric surface — **dashboards/alerts referencing the old metric will go stale**:
- **Removed:** `subscribers_redis_set_size` (the global set is gone).
- **Added:** `subscription_duplicates_total` (counter, label `event`), `subscribers_local_count`, `subscribers_generators_count` (gauges), `subscribers_stale_cleaned` (counter, from the reconciliation sweep).

## Known limitation (minor, bounded)

A half-open "zombie" connection keeps its (now purely local) emitter + generators on its instance until uWS reaps the socket at `WS_IDLE_TIMEOUT_IN_SECONDS` (~5 min). With the global set gone this no longer affects fleet presence or fan-out correctness (delivery is guarded by the live local emitter) — it's only bounded local memory.

## Verification

- `yarn build` ✓, `eslint` ✓, full unit suite ✓ (**106 suites / 1613 tests**).
- **Unit:**
  - `subscribers-context.spec`: two connections for one address are independent; last-connection teardown; untracked-connection no-op; and the interval-driven `reconcileStaleSubscribers` removes a stale address (destroying its generators) while keeping the live one.
  - `updates.spec`: two connections both subscribe without a duplicate and both receive an emitted update; the two `handleSubscriptionUpdates` fail-loud guards (missing `wsConnectionId`; detached connection with no emitter).
  - `rpc-server.spec`: voice chat is **not** ended when a non-last connection detaches, and ended only once the **last** connection detaches.
- **Integration** (`test/integration/rpc-subscriptions-controller.spec.ts`, real WebSocket + `@dcl/rpc` + Redis pub/sub): two connections for one address both receive a fan-out block update; closing one connection keeps the other receiving. (Adds a `connectAuthenticatedRpcClient` helper to connect multiple connections with one identity.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
