### PR TITLE
fix: harden the subscription path (non-fatal snapshot, no-emitter backoff, drop metric)

### DIFF
--- a/src/controllers/handlers/rpc/subscribe-to-friend-connectivity-updates.ts
+++ b/src/controllers/handlers/rpc/subscribe-to-friend-connectivity-updates.ts
@@ -12,6 +12,9 @@ export function subscribeToFriendConnectivityUpdatesService({
   const logger = logs.getLogger('subscribe-to-friend-connectivity-updates-service')
 
   return async function* (_request: Empty, context: RpcServerContext): AsyncGenerator<FriendConnectivityUpdate> {
+    // Initial online-friends snapshot. Best-effort: a DB/registry hiccup here must NOT tear down
+    // the whole subscription — otherwise the client just reconnects and retries, churning (and
+    // re-running these queries every time). Log and fall through to live updates instead.
     try {
       const onlinePeers = await peersStats.getConnectedPeers()
       const onlineFriends = await friendsDb.getOnlineFriends(context.address, onlinePeers)
@@ -23,7 +26,14 @@ export function subscribeToFriendConnectivityUpdatesService({
       }))
 
       yield* parsedProfiles
+    } catch (error: any) {
+      logger.warn('Failed to deliver initial friend connectivity snapshot; continuing with live updates', {
+        address: context.address,
+        error: error?.message ?? String(error)
+      })
+    }
 
+    try {
       yield* updateHandler.handleSubscriptionUpdates<
         FriendConnectivityUpdate,
         SubscriptionEventsEmitter['friendConnectivityUpdate']

--- a/src/logic/updates.ts
+++ b/src/logic/updates.ts
@@ -376,9 +376,11 @@ export function createUpdateHandlerComponent(
     // Guard against the SAME connection opening the same stream twice — each extra generator
     // allocates another value queue and doubles that connection's memory.
     if (rpcContext.subscribersContext.hasActiveSubscription(connectionId, eventNameString)) {
-      // Expected, benign outcome — the guard is doing its job. But it can fire at very high
-      // frequency during reconnect/re-subscribe churn, so count it as a metric (for alerting
-      // and graphing) and keep the per-occurrence line at debug so it never floods the logs.
+      // A connection re-subscribing to an event it is already subscribed to is expected and
+      // benign — the guard is the #407 OOM protection (it prevents a second generator/value-queue
+      // for the same connection+event). We both count it (the subscription_duplicates_total metric,
+      // labelled by event) and log it at debug for per-connection visibility; a sustained high
+      // rate/volume for a single connection indicates a client stuck in a re-subscribe loop.
       metrics.increment('subscription_duplicates_total', { event: eventNameString })
       logger.debug('Duplicate subscription detected, ignoring', {
         address: normalizedAddress,
@@ -398,12 +400,18 @@ export function createUpdateHandlerComponent(
         event: eventNameString,
         wsConnectionId: connectionId
       })
-      return
+      // Throw rather than return: a clean completion here invites the client to immediately
+      // re-open the stream and hit this same path again — a hot loop. Erroring out makes a
+      // (well-behaved) client back off instead. Reaching here means the RPC call is live but the
+      // per-address emitter is gone, which is an abnormal/racy state, not a normal stream end.
+      throw new Error('No subscriber emitter for address; connection no longer attached')
     }
 
     rpcContext.subscribersContext.setActiveSubscription(connectionId, eventNameString)
 
-    const updatesGenerator = emitterToAsyncGenerator(eventEmitter, eventName)
+    const updatesGenerator = emitterToAsyncGenerator(eventEmitter, eventName, () =>
+      metrics.increment('subscription_updates_dropped_total', { event: eventNameString })
+    )
     rpcContext.subscribersContext.registerGenerator(connectionId, updatesGenerator)
 
     try {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -116,6 +116,11 @@ export const metricDeclarations = {
     help: 'Number of duplicate stream subscriptions rejected by the per-(address, event) guard',
     labelNames: ['event']
   },
+  subscription_updates_dropped_total: {
+    type: IMetricsComponent.CounterType,
+    help: "Number of subscription updates dropped because a connection's value queue overflowed (slow consumer)",
+    labelNames: ['event']
+  },
   ai_compliance_validation_duration_seconds: {
     type: IMetricsComponent.HistogramType,
     help: 'Duration of AI compliance validation in seconds',

--- a/src/utils/emitterToGenerator.ts
+++ b/src/utils/emitterToGenerator.ts
@@ -13,7 +13,8 @@ export type DestroyableAsyncGenerator<T> = AsyncGenerator<T> & { destroy(): void
  */
 export default function emitterToAsyncGenerator<Events extends Record<EventType, unknown>, T extends keyof Events>(
   emitter: Emitter<Events>,
-  event: T
+  event: T,
+  onOverflowDrop?: () => void
 ): DestroyableAsyncGenerator<Events[T]> {
   let isDone = false
   const nextQueue: {
@@ -34,9 +35,11 @@ export default function emitterToAsyncGenerator<Events extends Record<EventType,
     }
 
     if (valueQueue.length >= MAX_VALUE_QUEUE_SIZE) {
-      // Drop oldest event silently to prevent unbounded memory growth.
-      // TODO: Add metrics/logging here once a logger is available in this utility.
+      // Drop the oldest event to prevent unbounded memory growth for a slow consumer. Surface it
+      // via the optional hook so callers can track how often (and for which event) updates are
+      // being lost — a sustained rate means a client isn't keeping up with the stream.
       valueQueue.shift()
+      onOverflowDrop?.()
     }
     valueQueue.push(value)
   }

--- a/test/unit/adapters/rpc-server/services/subscribe-to-friend-connectivity-updates.spec.ts
+++ b/test/unit/adapters/rpc-server/services/subscribe-to-friend-connectivity-updates.spec.ts
@@ -106,17 +106,51 @@ describe('when subscribing to friend connectivity updates', () => {
     })
   })
 
-  describe('when the subscription encounters an error', () => {
+  describe('when the initial snapshot fails', () => {
     let testError: Error
 
     beforeEach(() => {
       testError = new Error('Test error')
       mockFriendsDB.getOnlineFriends.mockRejectedValue(testError)
+      // The subscription must still continue to live updates despite the snapshot failure.
+      mockUpdateHandler.handleSubscriptionUpdates.mockImplementationOnce(async function* () {})
     })
 
-    it('should propagate the error', async () => {
+    it('should not tear down the subscription, log a warning, and continue to live updates', async () => {
       const generator = subscribeToFriendConnectivityUpdates({} as Empty, rpcContext)
-      await expect(generator.next()).rejects.toThrow(testError)
+
+      const result = await generator.next()
+
+      expect(result.done).toBe(true)
+      expect(logs.getLogger('subscribe-to-friend-connectivity-updates-service').warn).toHaveBeenCalledWith(
+        'Failed to deliver initial friend connectivity snapshot; continuing with live updates',
+        expect.objectContaining({ address: '0x123' })
+      )
+      expect(mockUpdateHandler.handleSubscriptionUpdates).toHaveBeenCalled()
+    })
+  })
+
+  describe('when the live update stream errors', () => {
+    let streamError: Error
+
+    beforeEach(() => {
+      streamError = new Error('stream boom')
+      // Snapshot succeeds (empty) so we reach the live-update stream, which then errors.
+      mockFriendsDB.getOnlineFriends.mockResolvedValueOnce([])
+      mockRegistry.getProfiles.mockResolvedValueOnce([])
+      mockUpdateHandler.handleSubscriptionUpdates.mockImplementationOnce(async function* () {
+        throw streamError
+      })
+    })
+
+    it('should log the error and propagate it', async () => {
+      const generator = subscribeToFriendConnectivityUpdates({} as Empty, rpcContext)
+
+      await expect(generator.next()).rejects.toThrow(streamError)
+      expect(logs.getLogger('subscribe-to-friend-connectivity-updates-service').error).toHaveBeenCalledWith(
+        'Error in friend connectivity updates subscription:',
+        streamError
+      )
     })
   })
 

--- a/test/unit/logic/updates.spec.ts
+++ b/test/unit/logic/updates.spec.ts
@@ -1222,6 +1222,14 @@ describe('Updates Handlers', () => {
         })
       })
 
+      it('should log the duplicate at debug for per-connection visibility', () => {
+        expect(logger.debug).toHaveBeenCalledWith('Duplicate subscription detected, ignoring', {
+          address: '0x123',
+          event: 'friendshipUpdate',
+          wsConnectionId: 'conn-123'
+        })
+      })
+
       it('should not parse any update', () => {
         expect(parser).not.toHaveBeenCalled()
       })
@@ -1301,7 +1309,7 @@ describe('Updates Handlers', () => {
     })
 
     describe('and the address has no emitter (connection no longer attached)', () => {
-      it('should not start the subscription and should log a warning', async () => {
+      it('should throw so the client backs off instead of hot-looping, and should log a warning', async () => {
         const contextWithoutEmitter: RpcServerContext = {
           address: '0xnoemitter',
           wsConnectionId: 'conn-detached',
@@ -1316,9 +1324,9 @@ describe('Updates Handlers', () => {
           parser
         })
 
-        const result = await generator.next()
-
-        expect(result.done).toBe(true)
+        await expect(generator.next()).rejects.toThrow(
+          'No subscriber emitter for address; connection no longer attached'
+        )
         expect(logger.warn).toHaveBeenCalledWith('No subscriber emitter for address; connection no longer attached', {
           address: '0xnoemitter',
           event: 'friendshipUpdate',

--- a/test/unit/utils/emitterToGenerator.spec.ts
+++ b/test/unit/utils/emitterToGenerator.spec.ts
@@ -238,6 +238,19 @@ describe('emitterToAsyncGenerator', () => {
       expect(result.value).toBe('event-10')
     })
 
+    it('should invoke onOverflowDrop once per dropped event', async () => {
+      const onOverflowDrop = jest.fn()
+      const generator = emitterToAsyncGenerator(emitter, 'testEvent', onOverflowDrop)
+      const overflow = 7
+
+      for (let i = 0; i < MAX_VALUE_QUEUE_SIZE + overflow; i++) {
+        emitter.emit('testEvent', `event-${i}`)
+      }
+
+      expect(onOverflowDrop).toHaveBeenCalledTimes(overflow)
+      generator.destroy()
+    })
+
     it('should keep exactly MAX_VALUE_QUEUE_SIZE items when overflowing', async () => {
       const generator = emitterToAsyncGenerator(emitter, 'testEvent')
       const overflow = 5


### PR DESCRIPTION
Server-side robustness for the subscription streams, complementing the client-side re-subscribe fixes in unity-explorer (#9104 / #9105). None of these are the *root* cause of the flood (that was the client re-opening a completed stream), but they harden the paths that can trigger or amplify it.

## Changes

**1. Non-fatal initial snapshot** (`subscribe-to-friend-connectivity-updates.ts`)
It's the only subscribe handler that does a pre-subscription snapshot (`getConnectedPeers` → `getOnlineFriends` → `getProfiles`). It previously re-threw on any failure, tearing down the whole subscription — so a DB/registry hiccup made the client reconnect and re-run those queries, churning. Now the snapshot is best-effort: on failure it logs a warning and **continues to live updates**. (`peersStats.getConnectedPeers` already swallows its own errors, so the real risk was `getOnlineFriends` / `getProfiles`.)

**2. No-emitter path throws instead of returning** (`handleSubscriptionUpdates`)
The emitter is created only at `attachUser` and never re-created on re-subscribe. If a re-subscribe arrives on a still-live socket whose emitter is gone (an abnormal/racy state), returning a clean completion invited the client to instantly re-open and hit the same path again — a hot loop. It now **throws**, so a well-behaved client backs off instead.

**3. Value-queue drop metric** (`emitterToGenerator` + `metrics`)
Queue overflow (a slow consumer) silently dropped the oldest update. Added an `onOverflowDrop` hook wired to a new `subscription_updates_dropped_total{event}` counter so lost updates are observable.

**4. Duplicate-subscription logging** (`handleSubscriptionUpdates`)
**Keeps** the per-occurrence `Duplicate subscription detected` **debug** log (with `address` / `event` / `wsConnectionId`) alongside the `subscription_duplicates_total{event}` metric, for per-connection visibility into re-subscribe churn — with the comment corrected to explain both. (The client-side fixes remove the flood at its source, so this debug line is a useful per-connection breadcrumb, not noise.)

## Metrics
- **Added:** `subscription_updates_dropped_total{event}`.
- `subscription_duplicates_total{event}` (existing) + the debug log both track duplicate re-subscribes.

## Fetch / catalyst audit (context)
While investigating "failing requests cancelling subscriptions" I verified the outbound HTTP paths the subscribe flow touches:
- **They use native fetch (undici) via `@dcl/fetch-component`** — `peersStats` → `archipelago-stats` (fetch) + `worlds-stats` (Redis); `registry.getProfiles` (fetch); catalyst-client (`createLambdasClient({ fetcher })`).
- **Response bodies are released** — `registry.ts` and `archipelago-stats.ts` go through the `fetchJson` helper (consumes on ok, `discardResponseBody` on !ok) added in #421; `rewards.ts` consumes on both paths. (The catalyst-client library and the fetch timeout are hardened separately — see the `fix/http-client-hardening` PR and catalyst-client #490.)

## Verification
`yarn build` ✓, `eslint` ✓, full unit suite **106 suites / 1615 tests** ✓. Tests: no-emitter now asserts a throw; friend-connectivity asserts the snapshot failure is non-fatal + continues; the duplicate case asserts both the metric and the debug log; added an `onOverflowDrop` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
