### PR TITLE
fix: give outbound HTTP a timeout + make catalyst/registry failures observable

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -28,6 +28,12 @@ CATALYST_URL=<URL>
 COMMS_GATEKEEPER_URL=<URL>
 PEER_SYNC_INTERVAL_MS=<MS>
 PEERS_SYNC_CACHE_TTL_MS=<MS>
+
+# Per-request timeout and idempotent-retry count for all outbound HTTP (catalyst, registry,
+# archipelago, …). Without a timeout, undici falls back to multi-minute defaults on a stalled
+# upstream. Defaults if unset: 10000ms timeout, 3 attempts.
+HTTP_FETCH_TIMEOUT_MS=10000
+HTTP_FETCH_ATTEMPTS=3
 SENTRY_DSN=<URL>
 SENTRY_TRACES_SAMPLE_RATE=0.001
 SENTRY_PROFILE_SESSION_SAMPLE_RATE=0.1

--- a/src/adapters/catalyst-client.ts
+++ b/src/adapters/catalyst-client.ts
@@ -11,11 +11,13 @@ const L1_TESTNET = 'sepolia'
 
 export async function createCatalystClient({
   fetcher,
-  config
-}: Pick<AppComponents, 'fetcher' | 'config'>): Promise<ICatalystClientComponent> {
+  config,
+  logs
+}: Pick<AppComponents, 'fetcher' | 'config' | 'logs'>): Promise<ICatalystClientComponent> {
   const loadBalancer = await config.requireString('CATALYST_LAMBDAS_URL_LOADBALANCER')
   const env = await config.getString('ENV')
   const contractNetwork = env === 'prd' ? L1_MAINNET : L1_TESTNET
+  const logger = logs.getLogger('catalyst-client')
 
   function getLambdasClientOrDefault(lambdasServerUrl?: string): LambdasClient {
     return createLambdasClient({
@@ -52,13 +54,27 @@ export async function createCatalystClient({
       lambdasServerUrl
     )
 
-    const result = await retry(executeClientRequest, retries, waitTime)
-    return result.elements.map((name) => ({
-      id: name.tokenId,
-      name: name.name,
-      contractAddress: name.contractAddress,
-      tokenId: name.tokenId
-    }))
+    try {
+      const result = await retry(executeClientRequest, retries, waitTime, (error, attempt) =>
+        logger.warn('Retrying owned names fetch after a failed attempt', {
+          address,
+          attempt,
+          error: error.message
+        })
+      )
+      return result.elements.map((name) => ({
+        id: name.tokenId,
+        name: name.name,
+        contractAddress: name.contractAddress,
+        tokenId: name.tokenId
+      }))
+    } catch (error: any) {
+      logger.error('Failed to fetch owned names from catalyst', {
+        address,
+        error: error?.message ?? String(error)
+      })
+      throw error
+    }
   }
 
   return { getOwnedNames }

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -33,6 +33,28 @@ export async function createRegistryComponent({
     }
   }
 
+  // Single place that talks to the registry, so a fetch failure (network error or non-ok
+  // response) is always logged with context at the source — not left to whichever caller
+  // happens to catch it. Rethrows so callers keep their existing control flow.
+  async function fetchProfilesFromRegistry(ids: string[]): Promise<Profile[]> {
+    try {
+      return await fetchJson<Profile[]>(
+        () =>
+          fetcher.fetch(`${registryUrl}/profiles`, {
+            method: 'POST',
+            body: JSON.stringify({ ids })
+          }),
+        (r) => new Error(`Failed to fetch profiles from registry: ${r.statusText}`)
+      )
+    } catch (error: any) {
+      logger.error('Failed to fetch profiles from registry', {
+        error: error?.message ?? String(error),
+        count: ids.length
+      })
+      throw error
+    }
+  }
+
   async function getProfiles(ids: string[]): Promise<Profile[]> {
     if (ids.length === 0) return []
 
@@ -56,14 +78,7 @@ export async function createRegistryComponent({
     let validProfiles: Profile[] = []
 
     if (idsToFetch.length > 0) {
-      const registryResults = await fetchJson<Profile[]>(
-        () =>
-          fetcher.fetch(`${registryUrl}/profiles`, {
-            method: 'POST',
-            body: JSON.stringify({ ids: idsToFetch })
-          }),
-        (r) => new Error(`Failed to fetch profiles from registry: ${r.statusText}`)
-      )
+      const registryResults = await fetchProfilesFromRegistry(idsToFetch)
 
       const minimalProfiles = registryResults.map(extractMinimalProfile).filter(Boolean) as Profile[]
       validProfiles = minimalProfiles
@@ -94,14 +109,7 @@ export async function createRegistryComponent({
       return cachedProfile
     }
 
-    const registryResults = await fetchJson<Profile[]>(
-      () =>
-        fetcher.fetch(`${registryUrl}/profiles`, {
-          method: 'POST',
-          body: JSON.stringify({ ids: [id] })
-        }),
-      (r) => new Error(`Failed to fetch profile from registry: ${r.statusText}`)
-    )
+    const registryResults = await fetchProfilesFromRegistry([id])
 
     if (registryResults.length === 0) {
       throw new Error(`Profile not found: ${id}`)

--- a/src/components.ts
+++ b/src/components.ts
@@ -107,7 +107,23 @@ export async function initComponents(): Promise<AppComponents> {
   const uwsServer = await createUWsComponent({ config: uwsHttpServerConfig, logs })
   const statusChecks = await createStatusCheckComponent({ server: httpServer, config })
 
-  const fetcher = createFetchComponent()
+  // Without an explicit timeout, undici falls back to multi-minute header/body defaults, so a
+  // stalled upstream (catalyst / registry / archipelago) pins a keep-alive socket and blocks the
+  // caller for minutes. Give every request a timeout so it fails fast instead; the component
+  // retries only idempotent methods (GET/HEAD/OPTIONS/PUT/DELETE) and cancels discarded bodies.
+  const httpFetchTimeoutMs = (await config.getNumber('HTTP_FETCH_TIMEOUT_MS')) ?? 10000
+  const fetcher = createFetchComponent({
+    defaultFetcherOptions: {
+      timeout: httpFetchTimeoutMs,
+      attempts: (await config.getNumber('HTTP_FETCH_ATTEMPTS')) ?? 3
+    }
+  })
+  // The catalyst client runs its own retry that rotates across catalyst servers on each attempt,
+  // so its fetcher must NOT also retry the same host — otherwise attempts multiply (rotation ×
+  // per-host retries). One attempt per request lets the rotation be the single retry layer.
+  const catalystFetcher = createFetchComponent({
+    defaultFetcherOptions: { timeout: httpFetchTimeoutMs, attempts: 1 }
+  })
   const memoryCache = createInMemoryCacheComponent()
   const schemaValidator = createSchemaValidatorComponent({ ensureJsonContentType: false })
 
@@ -155,7 +171,7 @@ export async function initComponents(): Promise<AppComponents> {
   const nats = await createNatsComponent({ logs, config })
   const commsGatekeeper = await createCommsGatekeeperComponent({ logs, config, fetcher })
   const registry = await createRegistryComponent({ fetcher, config, redis, logs })
-  const catalystClient = await createCatalystClient({ config, fetcher })
+  const catalystClient = await createCatalystClient({ config, fetcher: catalystFetcher, logs })
   const cdnCacheInvalidator = await createCdnCacheInvalidatorComponent({ config, fetcher })
   const settings = await createSettingsComponent({ friendsDb })
   const voiceDb = await createVoiceDBComponent({ pg, config })

--- a/src/utils/retrier.ts
+++ b/src/utils/retrier.ts
@@ -3,7 +3,8 @@ import { sleep } from './timer'
 export async function retry<T>(
   action: (attempt: number) => Promise<T>,
   retries: number = 3,
-  waitTime: number = 300
+  waitTime: number = 300,
+  onRetry?: (error: Error, attempt: number) => void
 ): Promise<T> {
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {
@@ -12,6 +13,9 @@ export async function retry<T>(
       if (attempt === retries) {
         throw new Error(`Failed after ${retries} attempts: ${error.message}`)
       }
+      // Surface the transient failure so callers can log it — otherwise retries are silent and a
+      // flaky upstream is invisible until the final attempt throws.
+      onRetry?.(error, attempt)
       await sleep(waitTime)
     }
   }

--- a/test/components.ts
+++ b/test/components.ts
@@ -155,7 +155,7 @@ async function initComponents(): Promise<TestComponents> {
   const redis = await createRedisComponent({ logs, config })
   const pubsub = createPubSubComponent({ logs, redis })
   const nats = await createNatsComponent({ logs, config })
-  const catalystClient = await createCatalystClient({ config, fetcher })
+  const catalystClient = await createCatalystClient({ config, fetcher, logs })
   const registry = await createRegistryComponent({ fetcher, config, redis, logs })
   const sns = createSNSMockedComponent({})
   const storage = await createS3Adapter({ config })

--- a/test/unit/adapters/catalyst-client.spec.ts
+++ b/test/unit/adapters/catalyst-client.spec.ts
@@ -1,7 +1,7 @@
 import { createCatalystClient } from '../../../src/adapters/catalyst-client'
 import { ICatalystClientComponent } from '../../../src/types'
 import { createLambdasClient, LambdasClient } from 'dcl-catalyst-client'
-import { mockConfig, mockFetcher } from '../../mocks/components'
+import { mockConfig, mockFetcher, mockLogs } from '../../mocks/components'
 import { GetNamesParams, Profile } from 'dcl-catalyst-client/dist/client/specs/lambdas-client'
 
 jest.mock('dcl-catalyst-client', () => ({
@@ -41,7 +41,8 @@ describe('catalyst-client', () => {
 
     catalystClient = await createCatalystClient({
       fetcher: mockFetcher,
-      config: mockConfig
+      config: mockConfig,
+      logs: mockLogs
     })
     lambdasClientMock = createLambdasClient({
       fetcher: mockFetcher,

--- a/test/unit/adapters/registry.spec.ts
+++ b/test/unit/adapters/registry.spec.ts
@@ -525,7 +525,7 @@ describe('registry', () => {
       })
 
       it('should throw an error', async () => {
-        await expect(registry.getProfile(profileId)).rejects.toThrow('Failed to fetch profile from registry')
+        await expect(registry.getProfile(profileId)).rejects.toThrow('Failed to fetch profiles from registry')
       })
     })
   })

--- a/test/unit/utils/retrier.spec.ts
+++ b/test/unit/utils/retrier.spec.ts
@@ -65,4 +65,30 @@ describe('retry', () => {
     expect(mockSleep).toHaveBeenCalledTimes(2)
     expect(mockSleep).toHaveBeenCalledWith(500)
   })
+
+  it('should invoke onRetry with the error and attempt number on each retried failure', async () => {
+    mockAction.mockReset()
+    const firstError = new Error('fail 1')
+    const secondError = new Error('fail 2')
+    mockAction.mockRejectedValueOnce(firstError).mockRejectedValueOnce(secondError).mockResolvedValueOnce('ok')
+    const onRetry = jest.fn()
+
+    const result = await retry(mockAction, 3, 100, onRetry)
+
+    expect(result).toBe('ok')
+    expect(onRetry).toHaveBeenCalledTimes(2)
+    expect(onRetry).toHaveBeenNthCalledWith(1, firstError, 1)
+    expect(onRetry).toHaveBeenNthCalledWith(2, secondError, 2)
+  })
+
+  it('should not invoke onRetry on the final exhausting attempt', async () => {
+    mockAction.mockReset()
+    mockAction.mockRejectedValue(new Error('always fails'))
+    const onRetry = jest.fn()
+
+    await expect(retry(mockAction, 2, 100, onRetry)).rejects.toThrow('Failed after 2 attempts')
+
+    // With 2 attempts only the first failure is a "retry"; the last one throws instead.
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
Hardens the outbound-HTTP paths behind the subscribe flow (catalyst, registry, archipelago). Complements the subscription-path PR (#424) and the client-side re-subscribe fixes.

## Problem
- **No request timeout.** We built the fetch component as `createFetchComponent()` with no options, so `@dcl/fetch-component` never arms its abort timer and every call falls back to **undici's multi-minute header/body defaults**. A stalled catalyst/registry/archipelago pins a keep-alive socket and blocks the caller (e.g. the friend-connectivity snapshot's `getProfiles`) for minutes.
- **Failures were largely invisible.** `retrier.ts` logged nothing (silent retries); `registry.ts` threw its fetch errors without logging, so they were only visible if a caller happened to log them.

## Changes
- **`components.ts`** — build the fetcher with `defaultFetcherOptions: { timeout, attempts }`, config-driven (`HTTP_FETCH_TIMEOUT_MS` default **10000**, `HTTP_FETCH_ATTEMPTS` default **3**). The component already retries only idempotent methods and cancels discarded response bodies; it just wasn't being given a timeout. **Blast radius: every outbound HTTP call** — tune via config if 10s is too tight for any endpoint.
- **`components.ts`** — the catalyst client gets a **dedicated fetcher with `attempts: 1`** (see *Retry layering* below).
- **`retrier.ts`** — optional `onRetry(error, attempt)` hook (non-breaking) so transient failures can be logged.
- **`catalyst-client.ts`** — takes `logs`; logs each retried `getOwnedNames` attempt (`warn`) and the final failure (`error`).
- **`registry.ts`** — `getProfiles`/`getProfile` now go through one `fetchProfilesFromRegistry` helper that logs the failure (network *or* non-ok) at the source before rethrowing (also DRYs the two duplicated fetch sites).
- `.env.default` documents the two new keys.

## Retry layering (why keep the repo's `retry()`)
The fetcher now retries, so: is the repo's `retry()` redundant? **No** — the two `retry()` sites do something the fetcher's same-URL retry can't:
- `notifications.ts` retries an **SNS publish** (AWS SDK) — never goes through the fetcher, so the fetcher's retry doesn't apply.
- `catalyst-client.getOwnedNames` wraps `rotateLambdasServerClient`, which targets a **different catalyst host per attempt** (load balancer → specific servers). That's cross-host **failover**; the fetcher only retries the same URL.

They're complementary — but in the catalyst path they *compound*: the fetcher would retry each host up to `attempts` times **inside** each of `retry()`'s host-attempts (rotation × attempts ≈ 9 requests, up to ~90s with the 10s timeout). Fix: give the catalyst client a fetcher with `attempts: 1`, so **rotation is the single retry layer** there (clean 3-host failover), while every other caller keeps the shared fetcher's retry.

## Note on the library
`dcl-catalyst-client`'s `getNames` path reads `.json()` with no `.ok` check and no timeout of its own — the fetcher timeout here mitigates the hang, and the non-ok handling is fixed upstream in **catalyst-client #490**.

## Verification
`yarn build` ✓, `eslint` ✓, full unit suite **106 suites / 1615 tests** ✓ (added retrier `onRetry` tests; updated catalyst-client + registry specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
