### PR TITLE
fix: stop logging "Duplicate subscription detected" per occurrence; keep the metric

### DIFF
--- a/src/logic/updates.ts
+++ b/src/logic/updates.ts
@@ -378,15 +378,12 @@ export function createUpdateHandlerComponent(
     if (rpcContext.subscribersContext.hasActiveSubscription(connectionId, eventNameString)) {
       // A connection re-subscribing to an event it is already subscribed to is expected and
       // benign — the guard is the #407 OOM protection (it prevents a second generator/value-queue
-      // for the same connection+event). We both count it (the subscription_duplicates_total metric,
-      // labelled by event) and log it at debug for per-connection visibility; a sustained high
-      // rate/volume for a single connection indicates a client stuck in a re-subscribe loop.
+      // for the same connection+event). It can fire hundreds of times per minute for a single
+      // connection stuck in a re-subscribe loop, so we track it ONLY via the
+      // subscription_duplicates_total metric (labelled by event) and do not log per occurrence —
+      // at DEBUG level (production) that line floods the logs. A sustained high rate on the metric
+      // indicates a client stuck re-subscribing.
       metrics.increment('subscription_duplicates_total', { event: eventNameString })
-      logger.debug('Duplicate subscription detected, ignoring', {
-        address: normalizedAddress,
-        event: eventNameString,
-        wsConnectionId: connectionId
-      })
       return
     }
 

--- a/test/unit/logic/updates.spec.ts
+++ b/test/unit/logic/updates.spec.ts
@@ -1222,12 +1222,11 @@ describe('Updates Handlers', () => {
         })
       })
 
-      it('should log the duplicate at debug for per-connection visibility', () => {
-        expect(logger.debug).toHaveBeenCalledWith('Duplicate subscription detected, ignoring', {
-          address: '0x123',
-          event: 'friendshipUpdate',
-          wsConnectionId: 'conn-123'
-        })
+      it('should not log per occurrence (tracked only via the metric to avoid flooding)', () => {
+        expect(logger.debug).not.toHaveBeenCalledWith(
+          'Duplicate subscription detected, ignoring',
+          expect.anything()
+        )
       })
 
       it('should not parse any update', () => {


### PR DESCRIPTION
## Problem
The per-occurrence `logger.debug('Duplicate subscription detected, ignoring', …)` line floods the logs — **hundreds/min at DEBUG** for a single connection stuck re-subscribing to the same event (address `0xaca5bc79…` in the current incident). That's the server-side symptom of the client-side re-subscribe loop, whose fixes (unity-explorer #9104 / #9105) aren't deployed yet.

## Change
The duplicate is **expected and benign** — the guard is the #407 OOM protection (it prevents a second generator/value-queue for the same connection+event). So `handleSubscriptionUpdates` now tracks it **only via the `subscription_duplicates_total{event}` metric** (already present) and **drops the per-occurrence log line**. A sustained high rate on that metric flags a looping client without flooding the logs.

## Context / history
The log was introduced in #407 (first released in **1.11.1**, at `WARNING`); `main` had turned it into `DEBUG` + `wsConnectionId` (#422) and kept it (#424). This PR removes the per-occurrence line while retaining the metric. (Note: rolling back to 1.11.0 would silence it too, but 1.11.0 predates the #407 guard entirely, so it would reintroduce the OOM risk — this keeps the guard + metric, just not the log.)

## Verification
`yarn build` ✓, `eslint` ✓, full unit suite **106 suites / 1616 tests** ✓. The duplicate-subscription test now asserts the metric is incremented **and** that the debug line is *not* emitted (locks in the silence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)