### PR TITLE
fix: enforce friendship state machine in upsertFriendship

### DIFF
--- a/src/controllers/errors/rpc.errors.ts
+++ b/src/controllers/errors/rpc.errors.ts
@@ -3,9 +3,3 @@ export class InvalidRequestError extends Error {
     super(message)
   }
 }
-
-export class InvalidFriendshipActionError extends Error {
-  constructor(message: string) {
-    super(message)
-  }
-}

--- a/src/controllers/handlers/rpc/upsert-friendship.ts
+++ b/src/controllers/handlers/rpc/upsert-friendship.ts
@@ -6,9 +6,8 @@ import {
 } from '@dcl/protocol/out-js/decentraland/social_service/v2/social_service_v2.gen'
 import { Action, RpcServerContext, RPCServiceContext } from '../../../types'
 import { parseUpsertFriendshipRequest, parseFriendshipRequestToFriendshipRequestResponse } from '../../../logic/friends'
-import { InvalidFriendshipActionError } from '../../errors/rpc.errors'
 import { isErrorWithMessage } from '../../../utils/errors'
-import { BlockedUserError } from '../../../logic/friends/errors'
+import { BlockedUserError, InvalidFriendshipActionError } from '../../../logic/friends/errors'
 
 export function upsertFriendshipService({ components: { logs, friends } }: RPCServiceContext<'logs' | 'friends'>) {
   const logger = logs.getLogger('upsert-friendship-service')

--- a/src/logic/friends/component.ts
+++ b/src/logic/friends/component.ts
@@ -12,8 +12,8 @@ import {
 import { BLOCK_UPDATES_CHANNEL, FRIENDSHIP_UPDATES_CHANNEL } from '../../adapters/pubsub'
 import { getProfileUserId } from '../profiles'
 import { sendNotification, shouldNotify } from '../notifications'
-import { BlockedUserError, ProfileNotFoundError } from './errors'
-import { getNewFriendshipStatus } from './friendships'
+import { BlockedUserError, InvalidFriendshipActionError, ProfileNotFoundError } from './errors'
+import { getNewFriendshipStatus, validateNewFriendshipAction } from './friendships'
 import { BlockedUser, IFriendsComponent } from './types'
 
 export async function createFriendsComponent(
@@ -215,6 +215,14 @@ export async function createFriendsComponent(
       }
 
       const lastAction = await friendsDb.getLastFriendshipActionByUsers(userAddress, friendAddress)
+
+      // Enforce the friendship state machine before mutating any state. Without this guard an action
+      // like ACCEPT with no pending request would be applied blindly, letting a user forge another
+      // user's friendship (setting is_active = true) with no consent and defeat privacy gates that
+      // key on that flag (e.g. the ONLY_FRIENDS private-voice check).
+      if (!validateNewFriendshipAction(userAddress, { action, user: friendAddress }, lastAction)) {
+        throw new InvalidFriendshipActionError()
+      }
 
       const friendshipStatus = getNewFriendshipStatus(action)
       const isActive = friendshipStatus === FriendshipStatus.Friends

--- a/src/logic/friends/errors.ts
+++ b/src/logic/friends/errors.ts
@@ -9,3 +9,9 @@ export class BlockedUserError extends Error {
     super('This action is not allowed because either you blocked this user or this user blocked you')
   }
 }
+
+export class InvalidFriendshipActionError extends Error {
+  constructor(message = 'The friendship action is not valid for the current friendship status') {
+    super(message)
+  }
+}

--- a/test/unit/adapters/rpc-server/services/upsert-friendship.spec.ts
+++ b/test/unit/adapters/rpc-server/services/upsert-friendship.spec.ts
@@ -8,8 +8,8 @@ import { upsertFriendshipService } from '../../../../../src/controllers/handlers
 import { FriendshipRequest, RpcServerContext } from '../../../../../src/types'
 import { IFriendsComponent, parseFriendshipRequestToFriendshipRequestResponse } from '../../../../../src/logic/friends'
 import { createMockProfile } from '../../../../mocks/profile'
-import { InvalidFriendshipActionError, InvalidRequestError } from '../../../../../src/controllers/errors/rpc.errors'
-import { BlockedUserError } from '../../../../../src/logic/friends/errors'
+import { InvalidRequestError } from '../../../../../src/controllers/errors/rpc.errors'
+import { BlockedUserError, InvalidFriendshipActionError } from '../../../../../src/logic/friends/errors'
 
 describe('when upserting a friendship', () => {
   let upsertFriendship: ReturnType<typeof upsertFriendshipService>

--- a/test/unit/logic/friends-logic.spec.ts
+++ b/test/unit/logic/friends-logic.spec.ts
@@ -11,7 +11,7 @@ import { createLogsMockedComponent, createMockedPubSubComponent } from '../../mo
 import { createSNSMockedComponent } from '../../mocks/components/sns'
 import { Action, Friendship, User, BlockedUserWithDate, FriendshipRequest, FriendshipAction } from '../../../src/types'
 import { BLOCK_UPDATES_CHANNEL, FRIENDSHIP_UPDATES_CHANNEL } from '../../../src/adapters/pubsub'
-import { BlockedUserError } from '../../../src/logic/friends/errors'
+import { BlockedUserError, InvalidFriendshipActionError } from '../../../src/logic/friends/errors'
 import { sendNotification } from '../../../src/logic/notifications'
 
 jest.mock('../../../src/logic/notifications', () => ({
@@ -1114,28 +1114,57 @@ describe('Friends Component', () => {
       beforeEach(() => {
         friendshipId = 'existing-friendship-id'
         actionId = 'new-action-id'
-        mockLastAction = {
-          id: 'last-action-id',
-          friendship_id: friendshipId,
-          acting_user: userAddress,
-          action: Action.REQUEST,
-          timestamp: new Date().toISOString()
-        }
-
-        mockFriendsDB.getLastFriendshipActionByUsers.mockResolvedValue(mockLastAction)
         mockFriendsDB.updateFriendshipStatus.mockResolvedValue({ id: friendshipId, created_at: mockCreatedAt })
         mockFriendsDB.recordFriendshipAction.mockResolvedValue(actionId)
       })
 
+      // Only legal state-machine transitions are exercised here. `actingUserMarker` is who performed the
+      // previous action ('user' = the caller, 'friend' = the other user); it determines whether the new
+      // action is allowed (e.g. a user may ACCEPT a request they received, but not one they sent).
       describe.each([
-        [Action.REQUEST, false, 'inactive'],
-        [Action.ACCEPT, true, 'active'],
-        [Action.REJECT, false, 'inactive'],
-        [Action.CANCEL, false, 'inactive'],
-        [Action.DELETE, false, 'inactive']
-      ])('and the action is %s', (actionType, expectedActiveStatus, statusDescription) => {
+        {
+          description: 'accepting a request received from the friend',
+          actingUserMarker: 'friend',
+          lastActionType: Action.REQUEST,
+          actionType: Action.ACCEPT,
+          expectedActiveStatus: true,
+          statusDescription: 'active'
+        },
+        {
+          description: 'rejecting a request received from the friend',
+          actingUserMarker: 'friend',
+          lastActionType: Action.REQUEST,
+          actionType: Action.REJECT,
+          expectedActiveStatus: false,
+          statusDescription: 'inactive'
+        },
+        {
+          description: 'cancelling a request the caller sent to the friend',
+          actingUserMarker: 'user',
+          lastActionType: Action.REQUEST,
+          actionType: Action.CANCEL,
+          expectedActiveStatus: false,
+          statusDescription: 'inactive'
+        },
+        {
+          description: 'deleting an already-accepted friendship',
+          actingUserMarker: 'friend',
+          lastActionType: Action.ACCEPT,
+          actionType: Action.DELETE,
+          expectedActiveStatus: false,
+          statusDescription: 'inactive'
+        }
+      ])('and the action is $description', ({ actingUserMarker, lastActionType, actionType, expectedActiveStatus, statusDescription }) => {
         beforeEach(() => {
           action = actionType
+          mockLastAction = {
+            id: 'last-action-id',
+            friendship_id: friendshipId,
+            acting_user: actingUserMarker === 'user' ? userAddress : friendAddress,
+            action: lastActionType,
+            timestamp: new Date().toISOString()
+          }
+          mockFriendsDB.getLastFriendshipActionByUsers.mockResolvedValue(mockLastAction)
         })
 
         it(`should update the existing friendship status to ${statusDescription}`, async () => {
@@ -1222,32 +1251,25 @@ describe('Friends Component', () => {
       beforeEach(() => {
         friendshipId = 'new-friendship-id'
         actionId = 'new-action-id'
+        action = Action.REQUEST
 
         mockFriendsDB.getLastFriendshipActionByUsers.mockResolvedValue(null)
         mockFriendsDB.createFriendship.mockResolvedValue({ id: friendshipId, created_at: mockCreatedAt })
         mockFriendsDB.recordFriendshipAction.mockResolvedValue(actionId)
       })
 
-      describe.each([
-        [Action.REQUEST, false, 'inactive'],
-        [Action.ACCEPT, true, 'active'],
-        [Action.REJECT, false, 'inactive'],
-        [Action.CANCEL, false, 'inactive'],
-        [Action.DELETE, false, 'inactive']
-      ])('and the action is %s', (actionType, expectedActiveStatus, statusDescription) => {
+      // With no prior action the only legal transition is a REQUEST. Every other action (ACCEPT, REJECT,
+      // CANCEL, DELETE) is an illegal transition and is covered by the invalid-transition block below.
+      describe('and the action is a REQUEST', () => {
         beforeEach(() => {
-          action = actionType
+          action = Action.REQUEST
         })
 
-        it(`should create a new friendship with ${statusDescription} status`, async () => {
+        it('should create a new inactive friendship', async () => {
           await friendsComponent.upsertFriendship(userAddress, friendAddress, action, metadata)
 
           expect(mockFriendsDB.getLastFriendshipActionByUsers).toHaveBeenCalledWith(userAddress, friendAddress)
-          expect(mockFriendsDB.createFriendship).toHaveBeenCalledWith(
-            [userAddress, friendAddress],
-            expectedActiveStatus,
-            mockClient
-          )
+          expect(mockFriendsDB.createFriendship).toHaveBeenCalledWith([userAddress, friendAddress], false, mockClient)
           expect(mockFriendsDB.updateFriendshipStatus).not.toHaveBeenCalled()
         })
 
@@ -1257,7 +1279,7 @@ describe('Friends Component', () => {
           expect(mockFriendsDB.recordFriendshipAction).toHaveBeenCalledWith(
             friendshipId,
             userAddress,
-            actionType,
+            Action.REQUEST,
             metadata,
             mockClient
           )
@@ -1270,7 +1292,7 @@ describe('Friends Component', () => {
             id: actionId,
             from: userAddress,
             to: friendAddress,
-            action: actionType,
+            action: Action.REQUEST,
             timestamp: expect.any(Number),
             metadata
           })
@@ -1290,28 +1312,92 @@ describe('Friends Component', () => {
           })
         })
 
-        it('should send notification for the friendship action when appropriate', async () => {
+        it('should send a notification for the friendship request', async () => {
           await friendsComponent.upsertFriendship(userAddress, friendAddress, action, metadata)
 
           // Execute setImmediate callback
           jest.runOnlyPendingTimers()
 
-          if (actionType === Action.REQUEST || actionType === Action.ACCEPT) {
-            expect(mockSendNotification).toHaveBeenCalledWith(
-              actionType,
-              {
-                requestId: actionId,
-                senderAddress: userAddress,
-                receiverAddress: friendAddress,
-                senderProfile: mockUserProfile,
-                receiverProfile: mockFriendProfile,
-                message: metadata?.message
-              },
-              { sns: mockSNS, logs: expect.any(Object) }
-            )
-          } else {
-            expect(mockSendNotification).not.toHaveBeenCalled()
-          }
+          expect(mockSendNotification).toHaveBeenCalledWith(
+            Action.REQUEST,
+            {
+              requestId: actionId,
+              senderAddress: userAddress,
+              receiverAddress: friendAddress,
+              senderProfile: mockUserProfile,
+              receiverProfile: mockFriendProfile,
+              message: metadata?.message
+            },
+            { sns: mockSNS, logs: expect.any(Object) }
+          )
+        })
+      })
+    })
+
+    // Regression coverage for the friendship state machine: an action that is not a legal transition
+    // from the current state must be rejected before any state is written. The canonical case is
+    // ACCEPT with no pending request, which previously forged an active friendship without consent.
+    describe('and the action is not a valid transition for the current friendship state', () => {
+      beforeEach(() => {
+        mockFriendsDB.createFriendship.mockResolvedValue({ id: 'friendship-id', created_at: mockCreatedAt })
+        mockFriendsDB.updateFriendshipStatus.mockResolvedValue({ id: 'friendship-id', created_at: mockCreatedAt })
+        mockFriendsDB.recordFriendshipAction.mockResolvedValue('action-id')
+      })
+
+      describe.each([
+        { description: 'accepting when no request exists', actionType: Action.ACCEPT, lastActor: null, lastActionType: null },
+        { description: 'rejecting when no request exists', actionType: Action.REJECT, lastActor: null, lastActionType: null },
+        { description: 'cancelling when no request exists', actionType: Action.CANCEL, lastActor: null, lastActionType: null },
+        { description: 'deleting when no friendship exists', actionType: Action.DELETE, lastActor: null, lastActionType: null },
+        {
+          description: 'accepting a request the caller sent themselves',
+          actionType: Action.ACCEPT,
+          lastActor: 'user',
+          lastActionType: Action.REQUEST
+        },
+        {
+          description: 'cancelling a request the friend sent',
+          actionType: Action.CANCEL,
+          lastActor: 'friend',
+          lastActionType: Action.REQUEST
+        },
+        {
+          description: 'accepting when the friendship is already active',
+          actionType: Action.ACCEPT,
+          lastActor: 'friend',
+          lastActionType: Action.ACCEPT
+        }
+      ])('and the action is $description', ({ actionType, lastActor, lastActionType }) => {
+        beforeEach(() => {
+          action = actionType
+          const lastAction =
+            lastActor === null
+              ? null
+              : {
+                  id: 'last-action-id',
+                  friendship_id: 'existing-friendship-id',
+                  acting_user: lastActor === 'user' ? userAddress : friendAddress,
+                  action: lastActionType as Action,
+                  timestamp: new Date().toISOString()
+                }
+          mockFriendsDB.getLastFriendshipActionByUsers.mockResolvedValue(lastAction)
+        })
+
+        it('should throw an InvalidFriendshipActionError', async () => {
+          await expect(
+            friendsComponent.upsertFriendship(userAddress, friendAddress, action, metadata)
+          ).rejects.toThrow(InvalidFriendshipActionError)
+        })
+
+        it('should not open a transaction or write any friendship state', async () => {
+          await expect(
+            friendsComponent.upsertFriendship(userAddress, friendAddress, action, metadata)
+          ).rejects.toThrow(InvalidFriendshipActionError)
+
+          expect(mockFriendsDB.executeTx).not.toHaveBeenCalled()
+          expect(mockFriendsDB.createFriendship).not.toHaveBeenCalled()
+          expect(mockFriendsDB.updateFriendshipStatus).not.toHaveBeenCalled()
+          expect(mockFriendsDB.recordFriendshipAction).not.toHaveBeenCalled()
         })
       })
     })
@@ -1399,6 +1485,9 @@ describe('Friends Component', () => {
       let mockLastAction: FriendshipAction
 
       beforeEach(() => {
+        // Caller previously sent a request (valid `REQUEST` by the caller), now cancels it — a legal
+        // transition that reaches updateFriendshipStatus, where the database error is triggered.
+        action = Action.CANCEL
         mockLastAction = {
           id: 'last-action-id',
           friendship_id: 'existing-friendship-id',

--- a/test/unit/logic/friends-logic.spec.ts
+++ b/test/unit/logic/friends-logic.spec.ts
@@ -1251,7 +1251,6 @@ describe('Friends Component', () => {
       beforeEach(() => {
         friendshipId = 'new-friendship-id'
         actionId = 'new-action-id'
-        action = Action.REQUEST
 
         mockFriendsDB.getLastFriendshipActionByUsers.mockResolvedValue(null)
         mockFriendsDB.createFriendship.mockResolvedValue({ id: friendshipId, created_at: mockCreatedAt })


### PR DESCRIPTION
## summary

`upsertFriendship` — the single code path behind every friendship action — applied the requested action without validating the friendship state machine. an authenticated user could send an `ACCEPT` targeting an arbitrary address for which no prior request existed and create an active friendship (`is_active = true`) on both accounts without the other user's consent or interaction.

because the private-voice authorization gate keys on `friendship.is_active`, the forged friendship also bypassed a user's `ONLY_FRIENDS` privacy setting, enabling an unsolicited private voice call.

## root cause

`validateNewFriendshipAction` (with `isFriendshipActionValid` / `isUserActionValid`) already encodes the legal transitions and is unit-tested, but its only call site was dropped during the upsert-friendship refactor (#214), leaving it as dead code — so no transition validation ran.

## fix

- wire `validateNewFriendshipAction` back into `upsertFriendship`, before any state is written. illegal transitions (e.g. `ACCEPT` with no pending request, accepting your own request, accepting an already-active friendship) now throw `InvalidFriendshipActionError` and no row is created or updated.
- move `InvalidFriendshipActionError` into the friends logic `errors.ts`, since a logic component must not import from `controllers/`. the controller still maps it to the existing `invalidFriendshipAction` response, so the wire protocol is unchanged.

## tests

- rewrote the `upsertFriendship` component tests that had encoded the old unvalidated behavior into valid-transition tests.
- added a regression block asserting illegal transitions throw `InvalidFriendshipActionError` and perform no database writes (no transaction opened, no create / update / record).
- full unit suite passes (1605 tests).
