### PR TITLE
fix: harden access control, referral integrity and adapter robustness

### DIFF
--- a/src/adapters/catalyst-client.ts
+++ b/src/adapters/catalyst-client.ts
@@ -33,7 +33,8 @@ export async function createCatalystClient({
 
     return (attempt: number): Promise<T> => {
       if (attempt > 1 && catalystServers.length > 0) {
-        const [catalystServerUrl] = catalystServers.splice(attempt % catalystServers.length, 1)
+        // Index without mutating the shared array so the modulo doesn't skew as the list shrinks.
+        const catalystServerUrl = catalystServers[(attempt - 2) % catalystServers.length]
         lambdasClientToUse = getLambdasClientOrDefault(`${catalystServerUrl}/lambdas`)
       }
 

--- a/src/adapters/communities-db.ts
+++ b/src/adapters/communities-db.ts
@@ -21,7 +21,8 @@ import {
   GetCommunityPostsOptions,
   CommunityVisibilityEnum,
   CommunityRankingMetrics,
-  CommunityRankingMetricsDB
+  CommunityRankingMetricsDB,
+  CommunityNotFoundError
 } from '../logic/community'
 
 import { normalizeAddress } from '../utils/address'
@@ -30,6 +31,7 @@ import {
   useCTEs,
   getUserFriendsCTE,
   searchCommunitiesQuery,
+  escapeLikePattern,
   getCommunitiesWithMembersCountCTE,
   withSearchAndPagination,
   getLatestFriendshipActionCTE,
@@ -704,10 +706,14 @@ export function createCommunitiesDBComponent(
           FOR UPDATE
         `)
 
+        if (!lockResult.rows[0]) {
+          throw new CommunityNotFoundError(communityId)
+        }
+
         const oldOwner = lockResult.rows[0].owner_address
 
         await client.query(SQL`
-          UPDATE communities 
+          UPDATE communities
           SET owner_address = ${normalizedNewOwner}, updated_at = now() 
           WHERE id = ${communityId}
         `)
@@ -933,18 +939,43 @@ export function createCommunitiesDBComponent(
       await pg.query(query)
     },
 
+    async removeMemberRequests(communityId: string, memberAddress: EthAddress): Promise<void> {
+      const query = SQL`
+        DELETE FROM community_requests
+        WHERE community_id = ${communityId} AND member_address = ${normalizeAddress(memberAddress)}
+      `
+      await pg.query(query)
+    },
+
     async acceptAllRequestsToJoin(communityId: string): Promise<string[]> {
       return pg.withTransaction(async (client) => {
         const addMembersQuery = SQL`
           INSERT INTO community_members (community_id, member_address, role)
-          SELECT community_id, member_address, ${CommunityRole.Member}
-          FROM community_requests
-          WHERE community_id = ${communityId} AND type = ${CommunityRequestType.RequestToJoin}
+          SELECT cr.community_id, cr.member_address, ${CommunityRole.Member}
+          FROM community_requests cr
+          WHERE cr.community_id = ${communityId} AND cr.type = ${CommunityRequestType.RequestToJoin}
+            AND NOT EXISTS (
+              SELECT 1 FROM community_bans cb
+              WHERE cb.community_id = cr.community_id
+                AND cb.banned_address = cr.member_address
+                AND cb.active = true
+            )
+          ON CONFLICT (community_id, member_address) DO NOTHING
         `
         await client.query(addMembersQuery.text, addMembersQuery.values)
 
+        // Only remove (and report as accepted) the requests that were actually accepted above, i.e.
+        // from non-banned users. A banned user's pending request is left untouched; it cannot be
+        // accepted while the ban is active (see updateRequestStatus).
         const removeRequestsToJoinQuery = SQL`
-          DELETE FROM community_requests WHERE community_id = ${communityId} AND type = ${CommunityRequestType.RequestToJoin}
+          DELETE FROM community_requests cr
+          WHERE cr.community_id = ${communityId} AND cr.type = ${CommunityRequestType.RequestToJoin}
+            AND NOT EXISTS (
+              SELECT 1 FROM community_bans cb
+              WHERE cb.community_id = cr.community_id
+                AND cb.banned_address = cr.member_address
+                AND cb.active = true
+            )
           RETURNING id
         `
 
@@ -998,7 +1029,7 @@ export function createCommunitiesDBComponent(
         WHERE c.active = true`
 
       if (search) {
-        query = query.append(SQL` AND (c.name ILIKE ${`%${search}%`} OR c.description ILIKE ${`%${search}%`})`)
+        query = query.append(searchCommunitiesQuery(search))
       }
 
       query = query.append(
@@ -1358,7 +1389,8 @@ export function createCommunitiesDBComponent(
       countQuery.append(countBaseCondition)
 
       if (search) {
-        const searchCondition = SQL` AND (c.name ILIKE ${search + '%'} OR c.name ILIKE ${'% ' + search + '%'})`
+        const escapedSearch = escapeLikePattern(search)
+        const searchCondition = SQL` AND (c.name ILIKE ${escapedSearch + '%'} ESCAPE '\\' OR c.name ILIKE ${'% ' + escapedSearch + '%'} ESCAPE '\\')`
         mainQuery.append(searchCondition)
         countQuery.append(searchCondition)
       }

--- a/src/adapters/feature-flags.ts
+++ b/src/adapters/feature-flags.ts
@@ -37,7 +37,7 @@ export async function createFeatureFlagsAdapter(
 
   async function refresh() {
     try {
-      const [isEnabled, isDevEnabled] = await Promise.all([
+      const [isEnabled, isDevEnabled, isGlobalModeratorsEnabled] = await Promise.all([
         features.getIsFeatureEnabled(ApplicationName.DAPPS, FeatureFlag.COMMUNITIES_AI_COMPLIANCE),
         features.getIsFeatureEnabled(ApplicationName.DAPPS, FeatureFlag.DEV_COMMUNITIES_AI_COMPLIANCE),
         features.getIsFeatureEnabled(ApplicationName.DAPPS, FeatureFlag.COMMUNITIES_GLOBAL_MODERATORS)
@@ -45,11 +45,13 @@ export async function createFeatureFlagsAdapter(
 
       logger.debug(`Refreshed feature flags`, {
         [FeatureFlag.COMMUNITIES_AI_COMPLIANCE]: String(isEnabled),
-        [FeatureFlag.DEV_COMMUNITIES_AI_COMPLIANCE]: String(isDevEnabled)
+        [FeatureFlag.DEV_COMMUNITIES_AI_COMPLIANCE]: String(isDevEnabled),
+        [FeatureFlag.COMMUNITIES_GLOBAL_MODERATORS]: String(isGlobalModeratorsEnabled)
       })
 
       featuresFlagMap.set(FeatureFlag.COMMUNITIES_AI_COMPLIANCE, isEnabled)
       featuresFlagMap.set(FeatureFlag.DEV_COMMUNITIES_AI_COMPLIANCE, isDevEnabled)
+      featuresFlagMap.set(FeatureFlag.COMMUNITIES_GLOBAL_MODERATORS, isGlobalModeratorsEnabled)
     } catch (error) {
       logger.error('Failed to refresh feature flags', {
         error: error instanceof Error ? error.message : String(error)
@@ -65,7 +67,7 @@ export async function createFeatureFlagsAdapter(
 
     if (variant?.payload?.value) {
       const values = variant.payload.value
-        .replace('\n', '')
+        .replace(/\r?\n/g, '')
         .split(',')
         .map((domain) => domain.toLowerCase().trim())
 
@@ -80,6 +82,12 @@ export async function createFeatureFlagsAdapter(
    */
   async function start() {
     logger.info('Starting feature flags adapter')
+
+    // Guard against a double start orphaning a previous interval.
+    if (refreshInterval) {
+      clearInterval(refreshInterval)
+      refreshInterval = null
+    }
 
     // Do initial refresh
     await refresh()

--- a/src/adapters/friends-db.ts
+++ b/src/adapters/friends-db.ts
@@ -192,13 +192,13 @@ export function createFriendsDBComponent(components: Pick<AppComponents, 'pg' | 
     },
     async getSocialSettings(userAddresses: string[]): Promise<SocialSettings[]> {
       const query = SQL`
-        SELECT * FROM social_settings WHERE address = ANY(${userAddresses})
+        SELECT * FROM social_settings WHERE address = ANY(${userAddresses.map(normalizeAddress)})
       `
       const results = await pg.query<{ private_messages_privacy: string }>(query)
       return results.rows as SocialSettings[]
     },
     async deleteSocialSettings(userAddress: string): Promise<void> {
-      const query = SQL`DELETE FROM social_settings WHERE address = ${userAddress}`
+      const query = SQL`DELETE FROM social_settings WHERE address = ${normalizeAddress(userAddress)}`
       await pg.query(query)
     },
     async upsertSocialSettings(
@@ -225,7 +225,7 @@ export function createFriendsDBComponent(components: Pick<AppComponents, 'pg' | 
         .append(values)
         .append(`) ON CONFLICT (address) DO UPDATE SET `)
         .append(update)
-        .append(SQL` WHERE social_settings.address = ${userAddress} RETURNING *`)
+        .append(SQL` WHERE social_settings.address = ${normalizeAddress(userAddress)} RETURNING *`)
       const results = await pg.query<SocialSettings>(query)
       return results.rows[0]
     },
@@ -260,6 +260,10 @@ export function createFriendsDBComponent(components: Pick<AppComponents, 'pg' | 
       }
     },
     async blockUsers(blockerAddress, blockedAddresses) {
+      if (blockedAddresses.length === 0) {
+        return
+      }
+
       const query = SQL`INSERT INTO blocks (id, blocker_address, blocked_address) VALUES `
 
       blockedAddresses.forEach((blockedAddress, index) => {

--- a/src/adapters/memory-cache.ts
+++ b/src/adapters/memory-cache.ts
@@ -17,7 +17,8 @@ export function createInMemoryCacheComponent(): ICacheComponent {
   }
 
   async function mGet<T>(keys: string[]): Promise<T[]> {
-    return keys.map((key) => get(key)).filter((value) => value !== null) as T[]
+    const values = await Promise.all(keys.map((key) => get<T>(key)))
+    return values.filter((value) => value !== null) as T[]
   }
 
   return {

--- a/src/adapters/memory-cache.ts
+++ b/src/adapters/memory-cache.ts
@@ -9,7 +9,8 @@ export function createInMemoryCacheComponent(): ICacheComponent {
 
   async function get<T>(key: string): Promise<T | null> {
     const value = cache.get(key)
-    return value || null
+    // Use nullish coalescing so legitimately falsy cached values (false, 0, '') aren't treated as a miss.
+    return value ?? null
   }
 
   async function put<T>(key: string, value: T): Promise<void> {

--- a/src/adapters/peer-tracking.ts
+++ b/src/adapters/peer-tracking.ts
@@ -46,6 +46,11 @@ export async function createPeerTrackingComponent({
   const PEER_STATUS_KEY_PREFIX = 'peer-status:'
 
   async function notifyPeerStatusChange(peerId: string, status: ConnectivityStatus) {
+    if (!peerId) {
+      logger.warn('Ignoring peer status change with empty peerId')
+      return
+    }
+
     const key = PEER_STATUS_KEY_PREFIX + peerId
     const currentStatus = await redis.get<ConnectivityStatus>(key)
 

--- a/src/adapters/peers-synchronizer.ts
+++ b/src/adapters/peers-synchronizer.ts
@@ -29,6 +29,11 @@ export async function createPeersSynchronizerComponent({
 
   return {
     async syncPeers() {
+      // Guard against being started twice, which would orphan the previous interval.
+      if (intervalId) {
+        clearInterval(intervalId)
+        intervalId = null
+      }
       await syncPeers()
       intervalId = setInterval(syncPeers, syncIntervalMs)
     },

--- a/src/adapters/redis.ts
+++ b/src/adapters/redis.ts
@@ -40,10 +40,16 @@ export async function createRedisComponent(
   async function get<T>(key: string): Promise<T | null> {
     try {
       const serializedValue = await client.get(key)
-      if (serializedValue) {
-        return JSON.parse(serializedValue) as T
+      if (!serializedValue) {
+        return null
       }
-      return null
+      try {
+        return JSON.parse(serializedValue) as T
+      } catch (parseErr: any) {
+        // A corrupted/legacy value must not break callers that expect a value-or-null contract.
+        logger.error(`Error parsing value for key "${key}"`, parseErr)
+        return null
+      }
     } catch (err: any) {
       logger.error(`Error getting key "${key}"`, err)
       throw err
@@ -68,8 +74,10 @@ export async function createRedisComponent(
   async function put<T>(key: string, value: T, options?: SetOptions & { noTTL?: boolean }): Promise<void> {
     try {
       const serializedValue = JSON.stringify(value)
+      // Use nullish coalescing so an explicit EX is honored; `|| TWO_HOURS` would silently
+      // override a caller-provided value of 0.
       await client.set(key, serializedValue, {
-        EX: options?.noTTL ? undefined : options?.EX || TWO_HOURS_IN_SECONDS
+        EX: options?.noTTL ? undefined : (options?.EX ?? TWO_HOURS_IN_SECONDS)
       })
     } catch (err: any) {
       logger.error(`Error setting key "${key}"`, err)

--- a/src/adapters/rewards.ts
+++ b/src/adapters/rewards.ts
@@ -20,8 +20,9 @@ export async function createRewardComponent(
     })
 
     if (response.ok) {
-      const { data: rewards } = await response.json()
-      return rewards
+      const body = await response.json()
+      const rewards = body?.data
+      return Array.isArray(rewards) ? rewards : []
     }
 
     throw new Error(`Failed to fetch ${url}: ${response.status} ${await response.text()}`)

--- a/src/adapters/rewards.ts
+++ b/src/adapters/rewards.ts
@@ -2,9 +2,10 @@ import { AppComponents, IRewardComponent } from '../types'
 import { RewardAttributes } from '../logic/referral/types'
 
 export async function createRewardComponent(
-  components: Pick<AppComponents, 'fetcher' | 'config'>
+  components: Pick<AppComponents, 'fetcher' | 'config' | 'logs'>
 ): Promise<IRewardComponent> {
-  const { fetcher, config } = components
+  const { fetcher, config, logs } = components
+  const logger = logs.getLogger('rewards-component')
 
   const rewardUrl = new URL(await config.requireString('REWARD_SERVER_URL'))
 
@@ -22,7 +23,14 @@ export async function createRewardComponent(
     if (response.ok) {
       const body = await response.json()
       const rewards = body?.data
-      return Array.isArray(rewards) ? rewards : []
+      if (!Array.isArray(rewards)) {
+        logger.warn('Reward server response did not contain a data array; returning no rewards', {
+          campaignKey,
+          beneficiary
+        })
+        return []
+      }
+      return rewards
     }
 
     throw new Error(`Failed to fetch ${url}: ${response.status} ${await response.text()}`)

--- a/src/adapters/voice-db.ts
+++ b/src/adapters/voice-db.ts
@@ -16,7 +16,7 @@ export async function createVoiceDBComponent(
 
       const query = SQL`
         SELECT EXISTS (
-          SELECT 1 FROM private_voice_chats WHERE caller_address IN (${normalizedUserAddresses}) OR callee_address IN (${normalizedUserAddresses})
+          SELECT 1 FROM private_voice_chats WHERE caller_address = ANY(${normalizedUserAddresses}) OR callee_address = ANY(${normalizedUserAddresses})
         )
       `
       return pg.exists(query, 'exists')

--- a/src/components.ts
+++ b/src/components.ts
@@ -107,7 +107,10 @@ export async function initComponents(): Promise<AppComponents> {
   const uwsServer = await createUWsComponent({ config: uwsHttpServerConfig, logs })
   const statusChecks = await createStatusCheckComponent({ server: httpServer, config })
 
-  const fetcher = createFetchComponent()
+  // Bound every outbound HTTP request so a stalled upstream can't pin handlers indefinitely.
+  // Per-call options passed by adapters still override this default.
+  const httpFetchTimeoutMs = (await config.getNumber('HTTP_FETCH_TIMEOUT_MS')) ?? 30000
+  const fetcher = createFetchComponent({ defaultFetcherOptions: { timeout: httpFetchTimeoutMs } })
   const memoryCache = createInMemoryCacheComponent()
   const schemaValidator = createSchemaValidatorComponent({ ensureJsonContentType: false })
 

--- a/src/components.ts
+++ b/src/components.ts
@@ -148,7 +148,7 @@ export async function initComponents(): Promise<AppComponents> {
   const featureFlags = await createFeatureFlagsAdapter({ config, logs, features })
 
   const email = await createEmailComponent({ fetcher, config })
-  const rewards = await createRewardComponent({ fetcher, config })
+  const rewards = await createRewardComponent({ fetcher, config, logs })
 
   const placesApi = await createPlacesApiAdapter({ fetcher, config })
   const redis = await createRedisComponent({ logs, config })

--- a/src/controllers/handlers/http/get-community-invites-handler.ts
+++ b/src/controllers/handlers/http/get-community-invites-handler.ts
@@ -25,16 +25,17 @@ export async function getCommunityInvitesHandler(
 
   try {
     const inviterAddress = verification!.auth.toLowerCase()
+    const normalizedInviteeAddress = inviteeAddress.toLowerCase()
 
-    if (inviterAddress === inviteeAddress) {
-      throw new InvalidRequestError('Users cannot invite themselves')
-    }
-
-    if (!EthAddress.validate(inviterAddress) || !EthAddress.validate(inviteeAddress)) {
+    if (!EthAddress.validate(inviterAddress) || !EthAddress.validate(normalizedInviteeAddress)) {
       throw new InvalidRequestError('Invalid addresses')
     }
 
-    const invites = await communities.getCommunityInvites(inviterAddress, inviteeAddress)
+    if (inviterAddress === normalizedInviteeAddress) {
+      throw new InvalidRequestError('Users cannot invite themselves')
+    }
+
+    const invites = await communities.getCommunityInvites(inviterAddress, normalizedInviteeAddress)
 
     return {
       status: 200,

--- a/src/controllers/handlers/http/schemas.ts
+++ b/src/controllers/handlers/http/schemas.ts
@@ -68,9 +68,11 @@ export const AddCommunityPlacesSchema: Schema = {
     placeIds: {
       type: 'array',
       items: {
-        type: 'string'
+        type: 'string',
+        maxLength: 256
       },
-      minItems: 1
+      minItems: 1,
+      maxItems: 100
     }
   }
 }

--- a/src/controllers/handlers/rpc/block-user.ts
+++ b/src/controllers/handlers/rpc/block-user.ts
@@ -7,6 +7,7 @@ import { RpcServerContext, RPCServiceContext } from '../../../types'
 import { parseProfileToBlockedUser } from '../../../logic/friends'
 import { InvalidRequestError } from '../../errors/rpc.errors'
 import { ProfileNotFoundError } from '../../../logic/friends/errors'
+import { normalizeAddress } from '../../../utils/address'
 
 export function blockUserService({ components: { logs, friends } }: RPCServiceContext<'logs' | 'friends'>) {
   const logger = logs.getLogger('block-user-service')
@@ -16,7 +17,8 @@ export function blockUserService({ components: { logs, friends } }: RPCServiceCo
       const { address: blockerAddress } = context
       const blockedAddress = request.user?.address
 
-      if (blockerAddress === blockedAddress) {
+      // Compare normalized addresses so a checksummed/mixed-case self-address can't bypass the guard.
+      if (blockedAddress && blockerAddress === normalizeAddress(blockedAddress)) {
         throw new InvalidRequestError('Cannot block yourself')
       }
 

--- a/src/controllers/handlers/rpc/block-user.ts
+++ b/src/controllers/handlers/rpc/block-user.ts
@@ -17,13 +17,13 @@ export function blockUserService({ components: { logs, friends } }: RPCServiceCo
       const { address: blockerAddress } = context
       const blockedAddress = request.user?.address
 
-      // Compare normalized addresses so a checksummed/mixed-case self-address can't bypass the guard.
-      if (blockedAddress && blockerAddress === normalizeAddress(blockedAddress)) {
-        throw new InvalidRequestError('Cannot block yourself')
-      }
-
       if (!EthAddress.validate(blockedAddress)) {
         throw new InvalidRequestError('Invalid user address in the request payload')
+      }
+
+      // Compare normalized addresses so a checksummed/mixed-case self-address can't bypass the guard.
+      if (blockerAddress === normalizeAddress(blockedAddress)) {
+        throw new InvalidRequestError('Cannot block yourself')
       }
 
       const { profile, blockedAt } = await friends.blockUser(blockerAddress, blockedAddress)

--- a/src/controllers/handlers/rpc/unblock-user.ts
+++ b/src/controllers/handlers/rpc/unblock-user.ts
@@ -7,6 +7,7 @@ import { RpcServerContext, RPCServiceContext } from '../../../types'
 import { parseProfileToBlockedUser } from '../../../logic/friends'
 import { InvalidRequestError } from '../../errors/rpc.errors'
 import { ProfileNotFoundError } from '../../../logic/friends/errors'
+import { normalizeAddress } from '../../../utils/address'
 
 export function unblockUserService({ components: { logs, friends } }: RPCServiceContext<'logs' | 'friends'>) {
   const logger = logs.getLogger('unblock-user-service')
@@ -16,7 +17,8 @@ export function unblockUserService({ components: { logs, friends } }: RPCService
       const { address: blockerAddress } = context
       const blockedAddress = request.user?.address
 
-      if (blockerAddress === blockedAddress) {
+      // Compare normalized addresses so a checksummed/mixed-case self-address can't bypass the guard.
+      if (blockedAddress && blockerAddress === normalizeAddress(blockedAddress)) {
         throw new InvalidRequestError('Cannot unblock yourself')
       }
 

--- a/src/controllers/handlers/rpc/unblock-user.ts
+++ b/src/controllers/handlers/rpc/unblock-user.ts
@@ -17,13 +17,13 @@ export function unblockUserService({ components: { logs, friends } }: RPCService
       const { address: blockerAddress } = context
       const blockedAddress = request.user?.address
 
-      // Compare normalized addresses so a checksummed/mixed-case self-address can't bypass the guard.
-      if (blockedAddress && blockerAddress === normalizeAddress(blockedAddress)) {
-        throw new InvalidRequestError('Cannot unblock yourself')
-      }
-
       if (!EthAddress.validate(blockedAddress)) {
         throw new InvalidRequestError('Invalid user address in the request payload')
+      }
+
+      // Compare normalized addresses so a checksummed/mixed-case self-address can't bypass the guard.
+      if (blockerAddress === normalizeAddress(blockedAddress)) {
+        throw new InvalidRequestError('Cannot unblock yourself')
       }
 
       const unblockedUserProfile = await friends.unblockUser(blockerAddress, blockedAddress)

--- a/src/controllers/handlers/uws/ws-handler.ts
+++ b/src/controllers/handlers/uws/ws-handler.ts
@@ -195,7 +195,8 @@ export async function registerWsHandler(
         hasEventEmitter: String(!!data.eventEmitter)
       })
       metrics.increment('ws_errors')
-      ws.send(JSON.stringify({ error: 'Error processing message', message: error.message }))
+      // Do not leak internal error details to the client.
+      ws.send(JSON.stringify({ error: 'Error processing message' }))
       tracing.captureException(error as Error, {
         address: getAddress(data),
         wsConnectionId: data.wsConnectionId
@@ -206,6 +207,8 @@ export async function registerWsHandler(
   uwsServer.app.ws<WsUserData>('/', {
     idleTimeout: (await config.getNumber('WS_IDLE_TIMEOUT_IN_SECONDS')) ?? FIVE_MINUTES_IN_SECONDS,
     sendPingsAutomatically: true,
+    // Bound inbound frame size so a client can't force large per-message buffering (uWS default is 16 MB).
+    maxPayloadLength: (await config.getNumber('WS_MAX_PAYLOAD_LENGTH')) ?? 1024 * 1024,
     maxBackpressure: (await config.getNumber('WS_MAX_BACKPRESSURE')) ?? 128 * 1024, // should be adjusted based on metrics
     drain: (ws) => {
       const data = ws.getUserData()

--- a/src/logic/community/bans.ts
+++ b/src/logic/community/bans.ts
@@ -91,6 +91,9 @@ export async function createCommunityBansComponent(
 
       await communitiesDb.banMemberFromCommunity(communityId, bannerAddress, targetAddress)
 
+      // Remove any pending join requests/invites so the ban cannot be circumvented by later accepting them.
+      await communitiesDb.removeMemberRequests(communityId, targetAddress)
+
       // For private communities, also kick user from voice chat if they are in one
       if (community.privacy === CommunityPrivacyEnum.Private) {
         // Only for private communities

--- a/src/logic/community/members.ts
+++ b/src/logic/community/members.ts
@@ -286,10 +286,17 @@ export async function createCommunityMembersComponent(
     },
 
     joinCommunity: async (communityId: string, memberAddress: EthAddress): Promise<void> => {
-      const communityExists = await communitiesDb.communityExists(communityId)
+      const community = await communitiesDb.getCommunity(communityId)
 
-      if (!communityExists) {
+      if (!community) {
         throw new CommunityNotFoundError(communityId)
+      }
+
+      // Private communities can only be joined through the request/invite approval flow.
+      if (community.privacy === CommunityPrivacyEnum.Private) {
+        throw new NotAuthorizedError(
+          `Cannot join private community ${communityId} directly; a join request or invite is required`
+        )
       }
 
       const isAlreadyMember = await communitiesDb.isMemberOfCommunity(communityId, memberAddress)

--- a/src/logic/community/requests.ts
+++ b/src/logic/community/requests.ts
@@ -112,6 +112,11 @@ export function createCommunityRequestsComponent(
       throw new CommunityNotFoundError(communityId)
     }
 
+    const isBanned = await communitiesDb.isMemberBanned(communityId, memberAddress)
+    if (isBanned) {
+      throw new NotAuthorizedError(`The user ${memberAddress} is banned from the community ${communityId}`)
+    }
+
     if (community.privacy === CommunityPrivacyEnum.Public && type === CommunityRequestType.RequestToJoin) {
       throw new InvalidCommunityRequestError(`Public communities do not accept requests to join`)
     }
@@ -249,6 +254,13 @@ export function createCommunityRequestsComponent(
 
     // User accepts invite or member with privileges accepts request to join
     if (status === CommunityRequestStatus.Accepted) {
+      const isBanned = await communitiesDb.isMemberBanned(request.communityId, request.memberAddress)
+      if (isBanned) {
+        throw new NotAuthorizedError(
+          `The user ${request.memberAddress} is banned from the community ${request.communityId}`
+        )
+      }
+
       await communitiesDb.joinMemberAndRemoveRequests({
         communityId: request.communityId,
         memberAddress: request.memberAddress,

--- a/src/logic/community/roles.ts
+++ b/src/logic/community/roles.ts
@@ -2,6 +2,7 @@ import { NotAuthorizedError } from '@dcl/http-commons'
 import { CommunityRole, CommunityPermission } from '../../types/entities'
 import { AppComponents } from '../../types/system'
 import { ICommunityRolesComponent, CommunityPost } from './types'
+import { normalizeAddress } from '../../utils/address'
 
 export const OWNER_PERMISSIONS: CommunityPermission[] = [
   'edit_info',
@@ -90,8 +91,8 @@ export function createCommunityRolesComponent(
       targetAddress: string
     ): Promise<void> {
       const roles = await communitiesDb.getCommunityMemberRoles(communityId, [ownerAddress, targetAddress])
-      const updaterRole = roles[ownerAddress]
-      const targetRole = roles[targetAddress]
+      const updaterRole = roles[normalizeAddress(ownerAddress)]
+      const targetRole = roles[normalizeAddress(targetAddress)]
 
       // Only current owners can transfer; target must be an existing member (not None)
       if (updaterRole !== CommunityRole.Owner) {
@@ -110,8 +111,8 @@ export function createCommunityRolesComponent(
       targetAddress: string
     ): Promise<void> {
       const roles = await communitiesDb.getCommunityMemberRoles(communityId, [kickerAddress, targetAddress])
-      const kickerRole = roles[kickerAddress]
-      const targetRole = roles[targetAddress]
+      const kickerRole = roles[normalizeAddress(kickerAddress)]
+      const targetRole = roles[normalizeAddress(targetAddress)]
 
       if (!canActOnMember(kickerRole, targetRole)) {
         throw new NotAuthorizedError(
@@ -128,8 +129,8 @@ export function createCommunityRolesComponent(
       targetAddress: string
     ): Promise<void> {
       const roles = await communitiesDb.getCommunityMemberRoles(communityId, [bannerAddress, targetAddress])
-      const bannerRole = roles[bannerAddress]
-      const targetRole = roles[targetAddress]
+      const bannerRole = roles[normalizeAddress(bannerAddress)]
+      const targetRole = roles[normalizeAddress(targetAddress)]
 
       if (
         !hasPermission(bannerRole, 'ban_players') ||
@@ -147,8 +148,8 @@ export function createCommunityRolesComponent(
       targetAddress: string
     ): Promise<void> {
       const roles = await communitiesDb.getCommunityMemberRoles(communityId, [unbannerAddress, targetAddress])
-      const unbannerRole = roles[unbannerAddress]
-      const targetRole = roles[targetAddress]
+      const unbannerRole = roles[normalizeAddress(unbannerAddress)]
+      const targetRole = roles[normalizeAddress(targetAddress)]
 
       if (
         !hasPermission(unbannerRole, 'ban_players') ||
@@ -173,8 +174,8 @@ export function createCommunityRolesComponent(
       }
 
       const roles = await communitiesDb.getCommunityMemberRoles(communityId, [updaterAddress, targetAddress])
-      const updaterRole = roles[updaterAddress]
-      const targetRole = roles[targetAddress]
+      const updaterRole = roles[normalizeAddress(updaterAddress)]
+      const targetRole = roles[normalizeAddress(targetAddress)]
 
       if (
         !hasPermission(updaterRole, 'assign_roles') ||

--- a/src/logic/queries.ts
+++ b/src/logic/queries.ts
@@ -206,7 +206,7 @@ export function getFriendshipRequestsBaseQuery(
       baseQuery.append(SQL` LIMIT ${limit}`)
     }
 
-    if (offset) {
+    if (typeof offset === 'number') {
       baseQuery.append(SQL` OFFSET ${offset}`)
     }
   }
@@ -319,7 +319,7 @@ export function withSearchAndPagination(query: SQLStatement, options?: GetCommun
     query.append(SQL` LIMIT ${limit}`)
   }
 
-  if (offset) {
+  if (typeof offset === 'number') {
     query.append(SQL` OFFSET ${offset}`)
   }
 

--- a/src/logic/queries.ts
+++ b/src/logic/queries.ts
@@ -202,7 +202,7 @@ export function getFriendshipRequestsBaseQuery(
   if (!onlyCount) {
     baseQuery.append(SQL` ORDER BY fa.timestamp DESC`)
 
-    if (limit) {
+    if (typeof limit === 'number') {
       baseQuery.append(SQL` LIMIT ${limit}`)
     }
 
@@ -315,7 +315,7 @@ export function withSearchAndPagination(query: SQLStatement, options?: GetCommun
       query.append(SQL` ORDER BY c.name ASC`)
   }
 
-  if (limit) {
+  if (typeof limit === 'number') {
     query.append(SQL` LIMIT ${limit}`)
   }
 
@@ -326,9 +326,18 @@ export function withSearchAndPagination(query: SQLStatement, options?: GetCommun
   return query
 }
 
+/**
+ * Escapes LIKE/ILIKE wildcards (%, _) and the escape character (\) in user-supplied search input
+ * so they are matched literally instead of acting as wildcards. Must be paired with `ESCAPE '\'`.
+ */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (char) => `\\${char}`)
+}
+
 export function searchCommunitiesQuery(search: string) {
   // TODO: enhance the search to include the description using the full text search or pg score
-  return SQL` AND (c.name ILIKE ${`%${search}%`} OR c.description ILIKE ${`%${search}%`})`
+  const pattern = `%${escapeLikePattern(search)}%`
+  return SQL` AND (c.name ILIKE ${pattern} ESCAPE '\\' OR c.description ILIKE ${pattern} ESCAPE '\\')`
 }
 
 export function getMembersCTE(subquery: SQLStatement) {

--- a/src/logic/referral/referral.ts
+++ b/src/logic/referral/referral.ts
@@ -334,7 +334,8 @@ export async function createReferralComponent(
         return
       }
 
-      await redis.put(cacheKey, [], { EX: 0 })
+      // Clear the login-days cache promptly (Redis rejects a 0 TTL, so use a minimal positive one).
+      await redis.put(cacheKey, [], { EX: 1 })
 
       logger.info('Finalizing referral', {
         invitedUser,
@@ -494,15 +495,13 @@ export async function createReferralComponent(
       }
 
       logger.info('Setting referral email', {
-        referrer,
-        email
+        referrer
       })
 
       const referralEmail = await referralDb.setReferralEmail({ referrer, email })
 
       logger.info('Referral email set successfully', {
-        referrer,
-        email
+        referrer
       })
 
       try {
@@ -512,13 +511,11 @@ export async function createReferralComponent(
           `A user has unlocked the IRL Swag Referral Tier and provided the following email for contact: ${email}`
         )
         logger.info('Marketing email sent successfully', {
-          referrer,
-          email
+          referrer
         })
       } catch (error) {
         logger.warn('Failed to send marketing email, but referral email was saved', {
           referrer,
-          email,
           error: error instanceof Error ? error.message : String(error)
         })
       }

--- a/src/logic/settings/settings.ts
+++ b/src/logic/settings/settings.ts
@@ -1,4 +1,5 @@
 import { AppComponents, SocialSettings } from '../../types'
+import { normalizeAddress } from '../../utils/address'
 import { ISettingsComponent } from './types'
 import { getDefaultSettings } from './utils'
 
@@ -8,8 +9,12 @@ export function createSettingsComponent({ friendsDb }: Pick<AppComponents, 'frie
       return []
     }
 
-    const settings = await friendsDb.getSocialSettings(addresses)
-    const settingsMap = addresses.reduce(
+    // Normalize up front so the default map keys match the (normalized) addresses stored in the DB.
+    // Otherwise a checksummed/mixed-case input would never be overridden by its stored row and would
+    // silently fall back to defaults — bypassing the user's real privacy settings.
+    const normalizedAddresses = addresses.map(normalizeAddress)
+    const settings = await friendsDb.getSocialSettings(normalizedAddresses)
+    const settingsMap = normalizedAddresses.reduce(
       (acc, address) => {
         acc[address] = getDefaultSettings(address)
         return acc

--- a/src/logic/voice/voice.ts
+++ b/src/logic/voice/voice.ts
@@ -32,6 +32,18 @@ export async function createVoiceComponent({
   async function startPrivateVoiceChat(callerAddress: string, calleeAddress: string): Promise<string> {
     logger.info(`Starting private voice chat from ${callerAddress} to ${calleeAddress}`)
 
+    // A user cannot start a private voice chat with themselves.
+    if (callerAddress.toLowerCase() === calleeAddress.toLowerCase()) {
+      throw new VoiceChatNotAllowedError()
+    }
+
+    // A voice chat is not allowed if either user has blocked the other (isFriendshipBlocked
+    // normalizes both addresses internally, so it is case-insensitive).
+    const isBlocked = await friendsDb.isFriendshipBlocked(callerAddress, calleeAddress)
+    if (isBlocked) {
+      throw new VoiceChatNotAllowedError()
+    }
+
     // Check privacy settings of the callee and the caller
     const [calleeSettings, callerSettings] = await settings.getUsersSettings([calleeAddress, callerAddress])
     if (

--- a/src/migrations/1782864000000_referral-unique-invited-user.ts
+++ b/src/migrations/1782864000000_referral-unique-invited-user.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+// Enforce the invariant that an invited user can only ever be bound to a single referrer.
+// The application-level check in the referral logic is racy (check-then-insert), so the
+// database must guarantee uniqueness on invited_user.
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Remove any pre-existing duplicate rows, keeping the earliest referral per invited_user
+  // (first legitimate referrer, tie-broken deterministically by id).
+  pgm.sql(`
+    DELETE FROM referral_progress
+    WHERE id IN (
+      SELECT id FROM (
+        SELECT id, ROW_NUMBER() OVER (PARTITION BY invited_user ORDER BY created_at ASC, id ASC) AS rn
+        FROM referral_progress
+      ) ranked
+      WHERE ranked.rn > 1
+    )
+  `)
+
+  // Replace the non-unique index with a unique one (it still serves invited_user lookups).
+  pgm.dropIndex('referral_progress', ['invited_user'], {
+    name: 'idx_referral_progress_invited_user',
+    ifExists: true
+  })
+  pgm.createIndex('referral_progress', ['invited_user'], {
+    name: 'unique_referral_progress_invited_user',
+    unique: true
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('referral_progress', ['invited_user'], {
+    name: 'unique_referral_progress_invited_user',
+    ifExists: true
+  })
+  pgm.createIndex('referral_progress', ['invited_user'], {
+    name: 'idx_referral_progress_invited_user'
+  })
+}

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -230,6 +230,7 @@ export interface ICommunitiesDatabaseComponent {
   ): Promise<number>
   getCommunityRequest(requestId: string): Promise<MemberRequest | undefined>
   removeCommunityRequest(requestId: string): Promise<void>
+  removeMemberRequests(communityId: string, memberAddress: EthAddress): Promise<void>
   joinMemberAndRemoveRequests(member: Omit<CommunityMember, 'joinedAt'>): Promise<string | undefined>
   getCommunityInvites(inviter: EthAddress, invitee: EthAddress): Promise<Community[]>
   acceptAllRequestsToJoin(communityId: string): Promise<string[]>

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -5,7 +5,7 @@ export function getPage(limit: number, offset: number = 0) {
 }
 
 export function getPages(total: number, limit: number): number {
-  return Math.ceil(total / limit)
+  return limit > 0 ? Math.ceil(total / limit) : 0
 }
 
 export function getPaginationResultProperties(

--- a/src/utils/retrier.ts
+++ b/src/utils/retrier.ts
@@ -10,7 +10,8 @@ export async function retry<T>(
       return await action(attempt)
     } catch (error: any) {
       if (attempt === retries) {
-        throw new Error(`Failed after ${retries} attempts: ${error.message}`)
+        // Preserve the original error's type and stack so callers can discriminate (instanceof).
+        throw error
       }
       await sleep(waitTime)
     }

--- a/test/components.ts
+++ b/test/components.ts
@@ -309,7 +309,7 @@ async function initComponents(): Promise<TestComponents> {
 
   const referralDb = await createReferralDBComponent({ pg, logs, config })
 
-  const rewards = await createRewardComponent({ fetcher, config })
+  const rewards = await createRewardComponent({ fetcher, config, logs })
 
   const email = await createEmailComponent({ fetcher, config })
 

--- a/test/integration/add-referral-email-controller.spec.ts
+++ b/test/integration/add-referral-email-controller.spec.ts
@@ -21,6 +21,9 @@ test('POST /v1/referral-email', function ({ components }) {
 
     afterEach(async () => {
       await cleanup.cleanup()
+      // These tests seed referrals directly with fixed invited-user ids and don't track them for
+      // cleanup; clear the table so reused ids don't collide with the unique(invited_user) constraint.
+      await components.pg.query('DELETE FROM referral_progress')
     })
 
     describe('and the request is not signed', () => {

--- a/test/integration/update-community-controller.spec.ts
+++ b/test/integration/update-community-controller.spec.ts
@@ -1,4 +1,4 @@
-import { CommunityPrivacyEnum, CommunityVisibilityEnum } from '../../src/logic/community'
+import { CommunityPrivacyEnum, CommunityVisibilityEnum, CommunityRequestType } from '../../src/logic/community'
 import { CommunityRole } from '../../src/types'
 import { test } from '../components'
 import {
@@ -483,6 +483,52 @@ test('Update Community Controller', async function ({ components, stubComponents
                 )
 
                 expect(response.status).toBe(401)
+              })
+            })
+
+            describe('and flipping a private community with pending join requests to public', () => {
+              const bannedRequester = '0x1111111111111111111111111111111111111111'
+              const allowedRequester = '0x2222222222222222222222222222222222222222'
+
+              beforeEach(async () => {
+                await components.communitiesDb.updateCommunity(communityId, { private: true })
+                await components.communitiesDb.createCommunityRequest(
+                  communityId,
+                  bannedRequester,
+                  CommunityRequestType.RequestToJoin
+                )
+                await components.communitiesDb.createCommunityRequest(
+                  communityId,
+                  allowedRequester,
+                  CommunityRequestType.RequestToJoin
+                )
+                await components.communitiesDb.banMemberFromCommunity(
+                  communityId,
+                  identity.realAccount.address,
+                  bannedRequester
+                )
+              })
+
+              afterEach(async () => {
+                await components.communitiesDbHelper.forceCommunityMemberRemoval(communityId, [
+                  bannedRequester,
+                  allowedRequester
+                ])
+              })
+
+              it('should admit the non-banned requester as a member but not the banned one', async () => {
+                const response = await makeMultipartRequest(
+                  identity,
+                  `/v1/communities/${communityId}`,
+                  {
+                    privacy: CommunityPrivacyEnum.Public
+                  },
+                  'PUT'
+                )
+
+                expect(response.status).toBe(200)
+                expect(await components.communitiesDb.isMemberOfCommunity(communityId, allowedRequester)).toBe(true)
+                expect(await components.communitiesDb.isMemberOfCommunity(communityId, bannedRequester)).toBe(false)
               })
             })
           })

--- a/test/mocks/components/communities-db.ts
+++ b/test/mocks/components/communities-db.ts
@@ -41,6 +41,7 @@ export const mockCommunitiesDB: jest.Mocked<ICommunitiesDatabaseComponent> = {
   getMemberRequests: jest.fn(),
   getMemberRequestsCount: jest.fn(),
   removeCommunityRequest: jest.fn(),
+  removeMemberRequests: jest.fn(),
   joinMemberAndRemoveRequests: jest.fn(),
   getCommunityInvites: jest.fn(),
   acceptAllRequestsToJoin: jest.fn(),

--- a/test/unit/adapters/rewards.spec.ts
+++ b/test/unit/adapters/rewards.spec.ts
@@ -2,7 +2,7 @@ import { createRewardComponent } from '../../../src/adapters/rewards'
 import { ChainId, Rarity } from '@dcl/schemas'
 import { RewardAttributes, RewardStatus } from '../../../src/logic/referral/types'
 import { IRewardComponent } from '../../../src/types'
-import { mockConfig, mockFetcher } from '../../mocks/components'
+import { mockConfig, mockFetcher, createLogsMockedComponent } from '../../mocks/components'
 
 const mockRewardData = {
   id: '550e8400-e29b-41d4-a716-446655440000',
@@ -39,14 +39,17 @@ const mockRewardTestData = {
 describe('RewardComponent', () => {
   let rewardComponent: IRewardComponent
   let mockRewardUrl: string
+  let mockWarn: jest.Mock
 
   beforeEach(async () => {
     mockRewardUrl = mockRewardTestData.rewardUrl
     mockConfig.requireString.mockResolvedValue(mockRewardUrl)
+    mockWarn = jest.fn()
 
     rewardComponent = await createRewardComponent({
       fetcher: mockFetcher,
-      config: mockConfig
+      config: mockConfig,
+      logs: createLogsMockedComponent({ warn: mockWarn })
     })
   })
 
@@ -122,6 +125,27 @@ describe('RewardComponent', () => {
           })
         )
         expect(result).toEqual([])
+      })
+    })
+
+    describe('when the response is ok but the data field is missing or not an array', () => {
+      beforeEach(() => {
+        mockFetcher.fetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: jest.fn().mockResolvedValue({ ok: true }),
+          text: jest.fn().mockResolvedValue('')
+        } as any)
+      })
+
+      it('should return an empty array and log a warning', async () => {
+        const result = await rewardComponent.sendReward(campaignKey, beneficiary)
+
+        expect(result).toEqual([])
+        expect(mockWarn).toHaveBeenCalledWith(
+          'Reward server response did not contain a data array; returning no rewards',
+          { campaignKey, beneficiary }
+        )
       })
     })
 

--- a/test/unit/adapters/rpc-server/services/block-user.spec.ts
+++ b/test/unit/adapters/rpc-server/services/block-user.spec.ts
@@ -17,7 +17,7 @@ describe('when blocking a user', () => {
   let rpcContext: RpcServerContext
 
   beforeEach(async () => {
-    userAddress = '0x123'
+    userAddress = '0x1111111111111111111111111111111111111111'
     blockedAddress = '0x12356abC4078a0Cc3b89b419928b857B8AF826ef'
     rpcContext = {
       address: userAddress,

--- a/test/unit/adapters/rpc-server/services/unblock-user.spec.ts
+++ b/test/unit/adapters/rpc-server/services/unblock-user.spec.ts
@@ -26,7 +26,7 @@ describe('when unblocking a user', () => {
   let userAddress: EthAddress
 
   beforeEach(async () => {
-    userAddress = '0x123'
+    userAddress = '0x1111111111111111111111111111111111111111'
     rpcContext = {
       address: userAddress,
       subscribersContext: undefined

--- a/test/unit/controllers/handlers/ws/ws-handler.spec.ts
+++ b/test/unit/controllers/handlers/ws/ws-handler.spec.ts
@@ -179,8 +179,7 @@ describe('ws-handler', () => {
 
         expect(mockWs.send).toHaveBeenCalledWith(
           JSON.stringify({
-            error: 'Error processing message',
-            message: error.message
+            error: 'Error processing message'
           })
         )
       })

--- a/test/unit/logic/community-bans.spec.ts
+++ b/test/unit/logic/community-bans.spec.ts
@@ -125,6 +125,7 @@ describe('Community Bans Component', () => {
               bannerAddress,
               targetAddress
             )
+            expect(mockCommunitiesDB.removeMemberRequests).toHaveBeenCalledWith(communityId, targetAddress)
           })
 
           it('should publish member status update to pubsub', async () => {
@@ -181,6 +182,9 @@ describe('Community Bans Component', () => {
               bannerAddress,
               targetAddress
             )
+            // Even a non-member's pending requests/invites must be cleared so the ban can't be
+            // circumvented by later accepting them.
+            expect(mockCommunitiesDB.removeMemberRequests).toHaveBeenCalledWith(communityId, targetAddress)
           })
 
           it('should publish member status update to pubsub', async () => {

--- a/test/unit/logic/community-members.spec.ts
+++ b/test/unit/logic/community-members.spec.ts
@@ -775,85 +775,114 @@ describe('Community Members Component', () => {
     const memberAddress = '0x1234567890123456789012345678901234567890'
     let isMember: boolean
     let isBanned: boolean
+    let publicCommunity: any
 
     beforeEach(() => {
       isMember = false
       isBanned = false
-      mockCommunitiesDB.communityExists.mockResolvedValue(false)
+      publicCommunity = {
+        id: communityId,
+        name: 'Test Community',
+        description: 'Test Description',
+        privacy: CommunityPrivacyEnum.Public,
+        active: true,
+        ownerAddress: '0xowner',
+        role: CommunityRole.None
+      }
+      mockCommunitiesDB.getCommunity.mockResolvedValue(undefined as any)
       mockCommunitiesDB.isMemberOfCommunity.mockResolvedValue(isMember)
       mockCommunitiesDB.isMemberBanned.mockResolvedValue(isBanned)
       mockCommunitiesDB.addCommunityMember.mockResolvedValue()
     })
 
     describe('and the community exists', () => {
-      beforeEach(() => {
-        mockCommunitiesDB.communityExists.mockResolvedValue(true)
-      })
-
-      describe('and the user is not already a member', () => {
+      describe('and the community is public', () => {
         beforeEach(() => {
-          isMember = false
-          mockCommunitiesDB.isMemberOfCommunity.mockResolvedValue(isMember)
+          mockCommunitiesDB.getCommunity.mockResolvedValue(publicCommunity)
         })
 
-        describe('and the user is not banned', () => {
+        describe('and the user is not already a member', () => {
           beforeEach(() => {
-            isBanned = false
-            mockCommunitiesDB.isMemberBanned.mockResolvedValue(isBanned)
+            isMember = false
+            mockCommunitiesDB.isMemberOfCommunity.mockResolvedValue(isMember)
           })
 
-          it('should add the member to the community', async () => {
+          describe('and the user is not banned', () => {
+            beforeEach(() => {
+              isBanned = false
+              mockCommunitiesDB.isMemberBanned.mockResolvedValue(isBanned)
+            })
+
+            it('should add the member to the community', async () => {
+              await communityMembersComponent.joinCommunity(communityId, memberAddress)
+
+              expect(mockCommunitiesDB.getCommunity).toHaveBeenCalledWith(communityId)
+              expect(mockCommunitiesDB.isMemberOfCommunity).toHaveBeenCalledWith(communityId, memberAddress)
+              expect(mockCommunitiesDB.isMemberBanned).toHaveBeenCalledWith(communityId, memberAddress)
+              expect(mockCommunitiesDB.joinMemberAndRemoveRequests).toHaveBeenCalledWith({
+                communityId,
+                memberAddress,
+                role: CommunityRole.Member
+              })
+              expect(mockPubSub.publishInChannel).toHaveBeenCalledWith(COMMUNITY_MEMBER_STATUS_UPDATES_CHANNEL, {
+                communityId,
+                memberAddress,
+                status: ConnectivityStatus.ONLINE
+              })
+            })
+          })
+
+          describe('and the user is banned', () => {
+            beforeEach(() => {
+              isBanned = true
+              mockCommunitiesDB.isMemberBanned.mockResolvedValue(isBanned)
+            })
+
+            it('should throw NotAuthorizedError', async () => {
+              await expect(communityMembersComponent.joinCommunity(communityId, memberAddress)).rejects.toThrow(
+                new NotAuthorizedError(`The user ${memberAddress} is banned from community ${communityId}`)
+              )
+
+              expect(mockCommunitiesDB.getCommunity).toHaveBeenCalledWith(communityId)
+              expect(mockCommunitiesDB.isMemberOfCommunity).toHaveBeenCalledWith(communityId, memberAddress)
+              expect(mockCommunitiesDB.isMemberBanned).toHaveBeenCalledWith(communityId, memberAddress)
+              expect(mockCommunitiesDB.addCommunityMember).not.toHaveBeenCalled()
+              expect(mockPubSub.publishInChannel).not.toHaveBeenCalled()
+            })
+          })
+        })
+
+        describe('and the user is already a member', () => {
+          beforeEach(() => {
+            isMember = true
+            mockCommunitiesDB.isMemberOfCommunity.mockResolvedValue(isMember)
+          })
+
+          it('should return without adding', async () => {
             await communityMembersComponent.joinCommunity(communityId, memberAddress)
 
-            expect(mockCommunitiesDB.communityExists).toHaveBeenCalledWith(communityId)
+            expect(mockCommunitiesDB.getCommunity).toHaveBeenCalledWith(communityId)
             expect(mockCommunitiesDB.isMemberOfCommunity).toHaveBeenCalledWith(communityId, memberAddress)
-            expect(mockCommunitiesDB.isMemberBanned).toHaveBeenCalledWith(communityId, memberAddress)
-            expect(mockCommunitiesDB.joinMemberAndRemoveRequests).toHaveBeenCalledWith({
-              communityId,
-              memberAddress,
-              role: CommunityRole.Member
-            })
-            expect(mockPubSub.publishInChannel).toHaveBeenCalledWith(COMMUNITY_MEMBER_STATUS_UPDATES_CHANNEL, {
-              communityId,
-              memberAddress,
-              status: ConnectivityStatus.ONLINE
-            })
-          })
-        })
-
-        describe('and the user is banned', () => {
-          beforeEach(() => {
-            isBanned = true
-            mockCommunitiesDB.isMemberBanned.mockResolvedValue(isBanned)
-          })
-
-          it('should throw NotAuthorizedError', async () => {
-            await expect(communityMembersComponent.joinCommunity(communityId, memberAddress)).rejects.toThrow(
-              new NotAuthorizedError(`The user ${memberAddress} is banned from community ${communityId}`)
-            )
-
-            expect(mockCommunitiesDB.communityExists).toHaveBeenCalledWith(communityId)
-            expect(mockCommunitiesDB.isMemberOfCommunity).toHaveBeenCalledWith(communityId, memberAddress)
-            expect(mockCommunitiesDB.isMemberBanned).toHaveBeenCalledWith(communityId, memberAddress)
+            expect(mockCommunitiesDB.isMemberBanned).not.toHaveBeenCalled()
             expect(mockCommunitiesDB.addCommunityMember).not.toHaveBeenCalled()
             expect(mockPubSub.publishInChannel).not.toHaveBeenCalled()
           })
         })
       })
 
-      describe('and the user is already a member', () => {
+      describe('and the community is private', () => {
         beforeEach(() => {
-          isMember = true
-          mockCommunitiesDB.isMemberOfCommunity.mockResolvedValue(isMember)
+          mockCommunitiesDB.getCommunity.mockResolvedValue({ ...publicCommunity, privacy: CommunityPrivacyEnum.Private })
         })
 
-        it('should return without adding', async () => {
-          await communityMembersComponent.joinCommunity(communityId, memberAddress)
+        it('should throw NotAuthorizedError without joining, since private communities require a request', async () => {
+          await expect(communityMembersComponent.joinCommunity(communityId, memberAddress)).rejects.toThrow(
+            NotAuthorizedError
+          )
 
-          expect(mockCommunitiesDB.communityExists).toHaveBeenCalledWith(communityId)
-          expect(mockCommunitiesDB.isMemberOfCommunity).toHaveBeenCalledWith(communityId, memberAddress)
-          expect(mockCommunitiesDB.isMemberBanned).not.toHaveBeenCalled()
-          expect(mockCommunitiesDB.addCommunityMember).not.toHaveBeenCalled()
+          expect(mockCommunitiesDB.getCommunity).toHaveBeenCalledWith(communityId)
+          expect(mockCommunitiesDB.isMemberOfCommunity).not.toHaveBeenCalled()
+          expect(mockCommunitiesDB.joinMemberAndRemoveRequests).not.toHaveBeenCalled()
           expect(mockPubSub.publishInChannel).not.toHaveBeenCalled()
         })
       })
@@ -861,7 +890,7 @@ describe('Community Members Component', () => {
 
     describe('and the community does not exist', () => {
       beforeEach(() => {
-        mockCommunitiesDB.communityExists.mockResolvedValue(false)
+        mockCommunitiesDB.getCommunity.mockResolvedValue(undefined as any)
       })
 
       it('should throw CommunityNotFoundError', async () => {
@@ -869,7 +898,7 @@ describe('Community Members Component', () => {
           new CommunityNotFoundError(communityId)
         )
 
-        expect(mockCommunitiesDB.communityExists).toHaveBeenCalledWith(communityId)
+        expect(mockCommunitiesDB.getCommunity).toHaveBeenCalledWith(communityId)
         expect(mockCommunitiesDB.isMemberOfCommunity).not.toHaveBeenCalled()
         expect(mockCommunitiesDB.isMemberBanned).not.toHaveBeenCalled()
         expect(mockCommunitiesDB.addCommunityMember).not.toHaveBeenCalled()

--- a/test/unit/logic/community-requests.spec.ts
+++ b/test/unit/logic/community-requests.spec.ts
@@ -108,6 +108,38 @@ describe('Community Requests Component', () => {
       })
     })
 
+    describe('when the target user is banned from the community', () => {
+      let community: Community & { role: CommunityRole }
+      let userAddress: string
+      let callerAddress: string
+      let type: CommunityRequestType
+
+      beforeEach(() => {
+        userAddress = '0x1234567890123456789012345678901234567890'
+        callerAddress = userAddress
+        type = CommunityRequestType.RequestToJoin
+        community = {
+          id: randomUUID(),
+          name: 'Mock Community',
+          description: 'Mock Description',
+          ownerAddress: '0x1234567890123456789012345678901234567891',
+          privacy: CommunityPrivacyEnum.Private,
+          active: true,
+          role: CommunityRole.None,
+          visibility: CommunityVisibilityEnum.All
+        }
+        mockCommunitiesDB.getCommunity.mockResolvedValueOnce(community)
+        mockCommunitiesDB.isMemberBanned.mockResolvedValueOnce(true)
+      })
+
+      it('should throw a NotAuthorizedError and not create the request', async () => {
+        await expect(
+          communityRequestsComponent.createCommunityRequest(community.id, userAddress, type, callerAddress)
+        ).rejects.toThrow(NotAuthorizedError)
+        expect(mockCommunitiesDB.createCommunityRequest).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when community exists and is public', () => {
       let community: Community & { role: CommunityRole }
       let userAddress: string
@@ -995,6 +1027,32 @@ describe('Community Requests Component', () => {
           await expect(
             communityRequestsComponent.updateRequestStatus(requestId, status, { callerAddress })
           ).rejects.toThrow(CommunityRequestNotFoundError)
+        })
+      })
+
+      describe('and the invited user is banned from the community', () => {
+        let bannedUserAddress: string
+        let pendingInvite: MemberRequest
+
+        beforeEach(() => {
+          bannedUserAddress = '0x1111111111111111111111111111111111111111'
+          callerAddress = bannedUserAddress
+          pendingInvite = {
+            id: requestId,
+            communityId: community.id,
+            memberAddress: bannedUserAddress,
+            type: CommunityRequestType.Invite,
+            status: CommunityRequestStatus.Pending
+          }
+          mockCommunitiesDB.getCommunityRequest.mockResolvedValueOnce(pendingInvite)
+          mockCommunitiesDB.isMemberBanned.mockResolvedValueOnce(true)
+        })
+
+        it('should throw NotAuthorizedError and not add the banned user as a member when accepting', async () => {
+          await expect(
+            communityRequestsComponent.updateRequestStatus(requestId, CommunityRequestStatus.Accepted, { callerAddress })
+          ).rejects.toThrow(NotAuthorizedError)
+          expect(mockCommunitiesDB.joinMemberAndRemoveRequests).not.toHaveBeenCalled()
         })
       })
 

--- a/test/unit/logic/community-roles.spec.ts
+++ b/test/unit/logic/community-roles.spec.ts
@@ -10,13 +10,13 @@ describe('Community Roles Component', () => {
   let roles: ICommunityRolesComponent
 
   const communityId = 'test-community'
-  const ownerAddress = '0xOwner'
-  const moderatorAddress = '0xModerator'
-  const memberAddress = '0xMember'
-  const anotherOwnerAddress = '0xAnotherOwner'
-  const anotherModeratorAddress = '0xAnotherModerator'
-  const anotherMemberAddress = '0xAnotherMember'
-  const nonMemberAddress = '0xNonMember'
+  const ownerAddress = '0xowner'
+  const moderatorAddress = '0xmoderator'
+  const memberAddress = '0xmember'
+  const anotherOwnerAddress = '0xanotherowner'
+  const anotherModeratorAddress = '0xanothermoderator'
+  const anotherMemberAddress = '0xanothermember'
+  const nonMemberAddress = '0xnonmember'
 
   beforeEach(() => {
     roles = createCommunityRolesComponent({ communitiesDb: mockCommunitiesDB, logs: mockLogs })
@@ -582,9 +582,9 @@ describe('Community Roles Component', () => {
 
   describe('when validating permission to transfer ownership', () => {
     const communityId = 'test-community'
-    const ownerAddress = '0xOwner'
-    const memberAddress = '0xMember'
-    const nonMemberAddress = '0xNonMember'
+    const ownerAddress = '0xowner'
+    const memberAddress = '0xmember'
+    const nonMemberAddress = '0xnonmember'
 
     describe('and the updater is owner and target is member', () => {
       beforeEach(() => {

--- a/test/unit/logic/notifications.spec.ts
+++ b/test/unit/logic/notifications.spec.ts
@@ -183,7 +183,7 @@ describe('Notifications', () => {
         expect(logger.error).toHaveBeenCalledWith(
           'Error sending notification for action request',
           expect.objectContaining({
-            error: expect.stringContaining('Failed after 3 attempts'),
+            error: expect.stringContaining('Persistent failure'),
             action: Action.REQUEST
           })
         )

--- a/test/unit/logic/queries.spec.ts
+++ b/test/unit/logic/queries.spec.ts
@@ -1,0 +1,37 @@
+import { escapeLikePattern } from '../../../src/logic/queries'
+
+describe('when escaping a LIKE/ILIKE search pattern', () => {
+  describe('and the input contains no wildcard characters', () => {
+    it('should return the input unchanged', () => {
+      expect(escapeLikePattern('decentraland')).toBe('decentraland')
+    })
+
+    it('should return an empty string unchanged', () => {
+      expect(escapeLikePattern('')).toBe('')
+    })
+  })
+
+  describe('and the input contains LIKE wildcards', () => {
+    it('should escape percent signs so they match literally', () => {
+      expect(escapeLikePattern('50%')).toBe('50\\%')
+    })
+
+    it('should escape underscores so they match literally', () => {
+      expect(escapeLikePattern('a_b')).toBe('a\\_b')
+    })
+
+    it('should escape a lone wildcard so it does not match everything', () => {
+      expect(escapeLikePattern('%')).toBe('\\%')
+    })
+  })
+
+  describe('and the input contains the escape character itself', () => {
+    it('should escape backslashes before other characters', () => {
+      expect(escapeLikePattern('a\\b')).toBe('a\\\\b')
+    })
+
+    it('should escape a mix of backslashes, percent signs and underscores', () => {
+      expect(escapeLikePattern('a\\%_b')).toBe('a\\\\\\%\\_b')
+    })
+  })
+})

--- a/test/unit/logic/referral.spec.ts
+++ b/test/unit/logic/referral.spec.ts
@@ -825,7 +825,7 @@ describe('referral-component', () => {
           newStatus: ReferralProgressStatus.TIER_GRANTED
         })
         expect(mockRedis.get).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`)
-        expect(mockRedis.put).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`, [], { EX: 0 })
+        expect(mockRedis.put).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`, [], { EX: 1 })
       })
     })
 
@@ -903,7 +903,7 @@ describe('referral-component', () => {
         await referralComponent.finalizeReferral(validInvitedUser)
 
         expect(mockRedis.get).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`)
-        expect(mockRedis.put).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`, [], { EX: 0 })
+        expect(mockRedis.put).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`, [], { EX: 1 })
         expect(mockReferralDb.updateReferralProgress).toHaveBeenCalledWith(
           validInvitedUser.toLowerCase(),
           ReferralProgressStatus.TIER_GRANTED
@@ -935,7 +935,7 @@ describe('referral-component', () => {
         await referralComponent.finalizeReferral(validInvitedUser)
 
         expect(mockRedis.get).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`)
-        expect(mockRedis.put).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`, [], { EX: 0 })
+        expect(mockRedis.put).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`, [], { EX: 1 })
         expect(mockReferralDb.updateReferralProgress).toHaveBeenCalledWith(
           validInvitedUser.toLowerCase(),
           ReferralProgressStatus.TIER_GRANTED
@@ -990,7 +990,7 @@ describe('referral-component', () => {
           await referralComponent.finalizeReferral(validInvitedUser)
 
           expect(mockRedis.get).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`)
-          expect(mockRedis.put).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`, [], { EX: 0 })
+          expect(mockRedis.put).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`, [], { EX: 1 })
           expect(mockRewards.sendReward).toHaveBeenCalledWith(rewardKey, validReferrer.toLowerCase())
           expect(mockReferralDb.setReferralRewardImage).toHaveBeenCalledWith({
             referrer: validReferrer.toLowerCase(),
@@ -1066,7 +1066,7 @@ describe('referral-component', () => {
           await referralComponent.finalizeReferral(validInvitedUser)
 
           expect(mockRedis.get).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`)
-          expect(mockRedis.put).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`, [], { EX: 0 })
+          expect(mockRedis.put).toHaveBeenCalledWith(`referral:invited-user:${validInvitedUser}`, [], { EX: 1 })
           expect(mockRewards.sendReward).not.toHaveBeenCalled()
           expect(mockReferralDb.setReferralRewardImage).not.toHaveBeenCalled()
           expect(mockSns.publishMessage).toHaveBeenCalledWith(
@@ -1434,16 +1434,13 @@ describe('referral-component', () => {
             `A user has unlocked the IRL Swag Referral Tier and provided the following email for contact: ${validEmail}`
           )
           expect(mockLogger.info).toHaveBeenCalledWith('Setting referral email', {
-            referrer: validReferrer.toLowerCase(),
-            email: validEmail
+            referrer: validReferrer.toLowerCase()
           })
           expect(mockLogger.info).toHaveBeenCalledWith('Marketing email sent successfully', {
-            referrer: validReferrer.toLowerCase(),
-            email: validEmail
+            referrer: validReferrer.toLowerCase()
           })
           expect(mockLogger.info).toHaveBeenCalledWith('Referral email set successfully', {
-            referrer: validReferrer.toLowerCase(),
-            email: validEmail
+            referrer: validReferrer.toLowerCase()
           })
           expect(result).toEqual({
             id: 'test-id',
@@ -1472,12 +1469,10 @@ describe('referral-component', () => {
           })
           expect(mockLogger.warn).toHaveBeenCalledWith('Failed to send marketing email, but referral email was saved', {
             referrer: validReferrer.toLowerCase(),
-            email: validEmail,
             error: 'Email service unavailable'
           })
           expect(mockLogger.info).toHaveBeenCalledWith('Referral email set successfully', {
-            referrer: validReferrer.toLowerCase(),
-            email: validEmail
+            referrer: validReferrer.toLowerCase()
           })
           expect(result).toEqual({
             id: 'test-id',

--- a/test/unit/logic/voice-logic.spec.ts
+++ b/test/unit/logic/voice-logic.spec.ts
@@ -40,6 +40,7 @@ let areUsersBeingCalledOrCallingSomeoneMock: jest.MockedFn<
 let createPrivateVoiceChatMock: jest.MockedFn<IVoiceDatabaseComponent['createPrivateVoiceChat']>
 let getUsersSettingsMock: jest.MockedFn<ISettingsComponent['getUsersSettings']>
 let getFriendshipMock: jest.MockedFn<IFriendsDatabaseComponent['getFriendship']>
+let isFriendshipBlockedMock: jest.MockedFn<IFriendsDatabaseComponent['isFriendshipBlocked']>
 let isUserInAVoiceChatMock: jest.MockedFn<ICommsGatekeeperComponent['isUserInAVoiceChat']>
 let getPrivateVoiceChatCredentialsMock: jest.MockedFn<ICommsGatekeeperComponent['getPrivateVoiceChatCredentials']>
 let getPrivateVoiceChatMock: jest.MockedFn<IVoiceDatabaseComponent['getPrivateVoiceChat']>
@@ -56,6 +57,7 @@ beforeEach(async () => {
   getPrivateVoiceChatMock = jest.fn()
   getUsersSettingsMock = jest.fn()
   getFriendshipMock = jest.fn()
+  isFriendshipBlockedMock = jest.fn()
   isUserInAVoiceChatMock = jest.fn()
   publishInChannelMock = jest.fn()
   areUsersBeingCalledOrCallingSomeoneMock = jest.fn()
@@ -84,7 +86,8 @@ beforeEach(async () => {
     getUsersSettings: getUsersSettingsMock
   })
   const friendsDb = createFriendsDBMockedComponent({
-    getFriendship: getFriendshipMock
+    getFriendship: getFriendshipMock,
+    isFriendshipBlocked: isFriendshipBlockedMock
   })
   const commsGatekeeper = createCommsGatekeeperMockedComponent({
     isUserInAVoiceChat: isUserInAVoiceChatMock,
@@ -114,6 +117,33 @@ describe('when starting a private voice chat', () => {
   beforeEach(() => {
     callerAddress = '0xBceaD48696C30eBfF0725D842116D334aAd585C1'
     calleeAddress = '0x2B72b8d597c553b3173bca922B9ad871da751dA5'
+  })
+
+  describe('and the caller and callee are the same user', () => {
+    it('should reject with a voice chat not allowed error without hitting any downstream calls', async () => {
+      await expect(voice.startPrivateVoiceChat(callerAddress, callerAddress)).rejects.toThrow(VoiceChatNotAllowedError)
+      expect(isFriendshipBlockedMock).not.toHaveBeenCalled()
+      expect(getUsersSettingsMock).not.toHaveBeenCalled()
+      expect(createPrivateVoiceChatMock).not.toHaveBeenCalled()
+    })
+
+    it('should treat differently-cased addresses of the same user as self', async () => {
+      await expect(voice.startPrivateVoiceChat(callerAddress, callerAddress.toLowerCase())).rejects.toThrow(
+        VoiceChatNotAllowedError
+      )
+      expect(createPrivateVoiceChatMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and one of the users has blocked the other', () => {
+    beforeEach(() => {
+      isFriendshipBlockedMock.mockResolvedValueOnce(true)
+    })
+
+    it('should reject with a voice chat not allowed error and not create the chat', async () => {
+      await expect(voice.startPrivateVoiceChat(callerAddress, calleeAddress)).rejects.toThrow(VoiceChatNotAllowedError)
+      expect(createPrivateVoiceChatMock).not.toHaveBeenCalled()
+    })
   })
 
   describe('and the caller is not accepting voice calls from users that are not friends', () => {

--- a/test/unit/utils/retrier.spec.ts
+++ b/test/unit/utils/retrier.spec.ts
@@ -36,7 +36,7 @@ describe('retry', () => {
   it('should throw an error after exhausting all retries', async () => {
     mockAction.mockRejectedValue(new Error('Fail on every attempt'))
 
-    await expect(retry(mockAction, 3, 100)).rejects.toThrowError('Failed after 3 attempts')
+    await expect(retry(mockAction, 3, 100)).rejects.toThrowError('Fail on every attempt')
 
     expect(mockAction).toHaveBeenCalledTimes(3)
     expect(mockSleep).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
## What

Hardening pass from a security/correctness review of the service. Groups a set of access-control fixes, one referral-integrity fix, and a batch of adapter/robustness fixes, with added test coverage.

## Access control
- **Private-community join gate** — `joinCommunity` now rejects direct joins of private communities; they must go through the request/invite approval flow.
- **Ban enforcement on request paths** — `createCommunityRequest` and `updateRequestStatus` (accept) now check `isMemberBanned`, and `banMember` deletes the target's pending requests so a ban can't be circumvented by later accepting a stale invite/request.
- **Ban enforcement on private→public flip** — `acceptAllRequestsToJoin` excludes banned users from bulk membership (and only reports genuinely-accepted requests).
- **Private voice chat** — enforce block (`isFriendshipBlocked`) and reject self-calls; normalize the callee in the settings lookup so a checksummed address can't fall back to default `ALL` privacy and bypass an `ONLY_FRIENDS` setting.
- **Address normalization** on role-permission lookups and block/unblock self-checks.

## Referral integrity
- Add a `unique(invited_user)` index (migration includes a dedupe of any pre-existing duplicates) so an invited user maps to exactly one referrer, closing a reward-inflation race that the app-level check alone couldn't.

## Robustness / hardening
- Fix the voice-db "user is busy" guard: `IN (${array})` → `= ANY(${array})` (it silently never matched).
- Default timeout on outbound HTTP requests; bound inbound WebSocket payload size.
- Escape LIKE/ILIKE wildcards (`%`, `_`) in community search.
- Bound `placeIds` array size; clamp falsy pagination limits.
- Fixes to `memory-cache.mGet`, redis `get` JSON resilience + `EX` handling, retrier error propagation, feature-flag refresh (dropped flag + interval-leak guard), peers-synchronizer interval-leak guard, catalyst server rotation, and rewards response validation.
- Stop leaking internal error details over the WS transport; stop logging referral email PII.

## ⚠️ Migration note
`1782864000000_referral-unique-invited-user.ts` **deletes duplicate `invited_user` rows** (keeping the earliest per user) before adding the unique index. This is irreversible for the dropped rows — please review against production data before running.

## Testing
- `yarn build`, `yarn lint:check`: clean
- Unit: **1618 passing** (added coverage for ban enforcement on create/accept, ban-request removal on ban, voice block + self-call, private-community join, and `escapeLikePattern`)
- Integration: full suite green, including a new case asserting a banned requester is excluded when a private community flips to public

## Not included (follow-ups)
- `upsertFriendship` read→write race (belongs with the state-machine work; needs a transaction lock)
- peer-tracking read-modify-write atomicity
- The pervasive raw-`error.message` in HTTP 500 bodies (best done centrally)
- The MEDIUM findings (private-community metadata leaks, WS scene-signer check, referral IP-header spoofing) — can be separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
