### PR TITLE
feat: add a kill switch feature flag for referral registration

### DIFF
--- a/src/adapters/feature-flags.ts
+++ b/src/adapters/feature-flags.ts
@@ -15,7 +15,15 @@ export enum FeatureFlag {
    * @example
    * Variant value: "0x1234567890123456789012345678901234567890,0x1234567890123456789012345678901234567891"
    */
-  COMMUNITIES_GLOBAL_MODERATORS = 'communities_global_moderators'
+  COMMUNITIES_GLOBAL_MODERATORS = 'communities_global_moderators',
+  /*
+   * Kill switch for referral registration. INVERTED on purpose: the feature works
+   * while this flag is absent/off (the adapter defaults missing flags to false),
+   * so deploys don't depend on the flag existing. Turn it ON to stop accepting
+   * new referral registrations; clients treat the rejection as best-effort and
+   * degrade gracefully. Referrals already created keep finalizing normally.
+   */
+  REFERRAL_REGISTRATION_DISABLED = 'referral_registration_disabled'
 }
 
 export type IFeatureFlagsAdapter = IBaseComponent & {
@@ -37,19 +45,25 @@ export async function createFeatureFlagsAdapter(
 
   async function refresh() {
     try {
-      const [isEnabled, isDevEnabled] = await Promise.all([
+      // The third fetch (COMMUNITIES_GLOBAL_MODERATORS) is intentionally not stored:
+      // that flag is consumed live through getVariants. The hole in the destructuring
+      // keeps the positions aligned with the Promise.all array.
+      const [isEnabled, isDevEnabled, , isReferralRegistrationDisabled] = await Promise.all([
         features.getIsFeatureEnabled(ApplicationName.DAPPS, FeatureFlag.COMMUNITIES_AI_COMPLIANCE),
         features.getIsFeatureEnabled(ApplicationName.DAPPS, FeatureFlag.DEV_COMMUNITIES_AI_COMPLIANCE),
-        features.getIsFeatureEnabled(ApplicationName.DAPPS, FeatureFlag.COMMUNITIES_GLOBAL_MODERATORS)
+        features.getIsFeatureEnabled(ApplicationName.DAPPS, FeatureFlag.COMMUNITIES_GLOBAL_MODERATORS),
+        features.getIsFeatureEnabled(ApplicationName.DAPPS, FeatureFlag.REFERRAL_REGISTRATION_DISABLED)
       ])
 
       logger.debug(`Refreshed feature flags`, {
         [FeatureFlag.COMMUNITIES_AI_COMPLIANCE]: String(isEnabled),
-        [FeatureFlag.DEV_COMMUNITIES_AI_COMPLIANCE]: String(isDevEnabled)
+        [FeatureFlag.DEV_COMMUNITIES_AI_COMPLIANCE]: String(isDevEnabled),
+        [FeatureFlag.REFERRAL_REGISTRATION_DISABLED]: String(isReferralRegistrationDisabled)
       })
 
       featuresFlagMap.set(FeatureFlag.COMMUNITIES_AI_COMPLIANCE, isEnabled)
       featuresFlagMap.set(FeatureFlag.DEV_COMMUNITIES_AI_COMPLIANCE, isDevEnabled)
+      featuresFlagMap.set(FeatureFlag.REFERRAL_REGISTRATION_DISABLED, isReferralRegistrationDisabled)
     } catch (error) {
       logger.error('Failed to refresh feature flags', {
         error: error instanceof Error ? error.message : String(error)

--- a/src/controllers/handlers/http/create-referral-handler.ts
+++ b/src/controllers/handlers/http/create-referral-handler.ts
@@ -1,5 +1,6 @@
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import { InvalidRequestError } from '@dcl/platform-server-commons'
+import { FeatureFlag } from '../../../adapters/feature-flags'
 import { errorMessageOrDefault } from '../../../utils/errors'
 import {
   ReferralInvalidInputError,
@@ -11,10 +12,10 @@ import type { CreateReferralWithInvitedUser } from '../../../types/create-referr
 import type { CreateReferralRequestBody } from './schemas'
 
 export async function createReferralHandler(
-  ctx: Pick<HandlerContextWithPath<'logs' | 'referral'>, 'components' | 'request' | 'verification'>
+  ctx: Pick<HandlerContextWithPath<'logs' | 'referral' | 'featureFlags'>, 'components' | 'request' | 'verification'>
 ): Promise<IHttpServerComponent.IResponse> {
   const {
-    components: { logs, referral },
+    components: { logs, referral, featureFlags },
     request,
     verification
   } = ctx
@@ -22,6 +23,22 @@ export async function createReferralHandler(
 
   if (!verification?.auth) {
     throw new InvalidRequestError('Authentication required')
+  }
+
+  // Kill switch: when the flag is ON no new referral is registered. 503 (not 400)
+  // so clients and dashboards can tell "temporarily disabled" apart from a bad
+  // request; every client treats this as best-effort and degrades silently.
+  if (featureFlags.isEnabled(FeatureFlag.REFERRAL_REGISTRATION_DISABLED)) {
+    logger.info('Referral registration is disabled by feature flag; rejecting create', {
+      invitedUser: verification.auth
+    })
+    return {
+      status: 503,
+      body: {
+        error: 'Service Unavailable',
+        message: 'Referral registration is temporarily disabled'
+      }
+    }
   }
 
   const rawBody: CreateReferralRequestBody = await request.json()

--- a/test/integration/create-referral-handler.spec.ts
+++ b/test/integration/create-referral-handler.spec.ts
@@ -4,7 +4,7 @@ import { createTestIdentity, Identity, createAuthHeaders } from './utils/auth'
 import { TestCleanup } from '../db-cleanup'
 import { makeAuthenticatedRequest } from './utils/auth'
 
-test('POST /v1/referral-progress', ({ components }) => {
+test('POST /v1/referral-progress', ({ components, spyComponents }) => {
   const makeRequest = makeAuthenticatedRequest(components)
   let cleanup: TestCleanup
   const endpoint = '/v1/referral-progress'
@@ -25,6 +25,26 @@ test('POST /v1/referral-progress', ({ components }) => {
   afterEach(async () => {
     await cleanup.cleanup()
     jest.restoreAllMocks()
+  })
+
+  describe('when referral registration is disabled by the kill switch', () => {
+    beforeEach(() => {
+      body = {
+        referrer: referrer.realAccount.address.toLowerCase()
+      }
+      spyComponents.featureFlags.isEnabled.mockReturnValue(true)
+    })
+
+    it('should reject the create with 503 and register nothing', async () => {
+      const response = await makeRequest(invited_user, endpoint, 'POST', body)
+
+      expect(response.status).toBe(503)
+      const json = await response.json()
+      expect(json).toEqual({
+        error: 'Service Unavailable',
+        message: 'Referral registration is temporarily disabled'
+      })
+    })
   })
 
   describe('when creating a new referral progress entry', () => {


### PR DESCRIPTION
Adds `referral_registration_disabled` to the feature flags adapter and gates `POST /v1/referral-progress` with it.

- Kill-switch semantics on purpose: the flag is inverted so the feature keeps working while the flag is absent or off (the adapter defaults missing flags to false) — deploys don't depend on the flag existing in the flags service. Turning it ON stops accepting new referral registrations within one refresh cycle (~4 minutes by default).
- The rejection is a 503 with an explicit message so it is distinguishable from a bad request in logs and dashboards. Every client treats referral registration as best-effort, so nothing user-facing breaks while the switch is on.
- Scope: only the create endpoint. Referrals already registered keep progressing and finalizing normally.

Verified: typecheck and build pass, referral unit suite green (73 tests). The integration spec gained a kill-switch case (requires the DB harness to run).