### PR TITLE
fix: add error listeners to redis pub/sub clients

### DIFF
--- a/src/adapters/pubsub.ts
+++ b/src/adapters/pubsub.ts
@@ -16,6 +16,15 @@ export function createPubSubComponent(components: Pick<AppComponents, 'logs' | '
   const subClient = redis.client.duplicate()
   const pubClient = redis.client.duplicate()
 
+  // duplicate() copies options but not listeners, so these clients do not inherit the main
+  // client's 'error' handler. Without one, an emitted 'error' is unhandled and aborts the process.
+  subClient.on('error', (error: Error) => {
+    logger.error(`Redis sub client error: ${error.message}`)
+  })
+  pubClient.on('error', (error: Error) => {
+    logger.error(`Redis pub client error: ${error.message}`)
+  })
+
   return {
     async start() {
       if (!subClient.isReady) {

--- a/src/adapters/pubsub.ts
+++ b/src/adapters/pubsub.ts
@@ -19,10 +19,10 @@ export function createPubSubComponent(components: Pick<AppComponents, 'logs' | '
   // duplicate() copies options but not listeners, so these clients do not inherit the main
   // client's 'error' handler. Without one, an emitted 'error' is unhandled and aborts the process.
   subClient.on('error', (error: Error) => {
-    logger.error(`Redis sub client error: ${error.message}`)
+    logger.error(error, { client: 'sub' })
   })
   pubClient.on('error', (error: Error) => {
-    logger.error(`Redis pub client error: ${error.message}`)
+    logger.error(error, { client: 'pub' })
   })
 
   return {

--- a/test/unit/adapters/pubsub.spec.ts
+++ b/test/unit/adapters/pubsub.spec.ts
@@ -141,4 +141,27 @@ describe('PubSubComponent', () => {
       expect(mockPubClient.disconnect).not.toHaveBeenCalled()
     })
   })
+
+  describe('client error handling', () => {
+    const errorRegistrations = () =>
+      (mockSubClient.on as unknown as jest.Mock).mock.calls.filter(([event]: [string]) => event === 'error')
+
+    it('should register an error listener on both duplicated clients', () => {
+      expect(errorRegistrations()).toHaveLength(2)
+    })
+
+    it('should log client errors instead of leaving them unhandled', () => {
+      const error = new Error('Socket closed unexpectedly')
+      const handlers = errorRegistrations().map(([, handler]: [string, (error: Error) => void]) => handler)
+
+      handlers.forEach((handler) => expect(() => handler(error)).not.toThrow())
+
+      expect(mockLogs.getLogger('pubsub-component').error).toHaveBeenCalledWith(
+        `Redis sub client error: ${error.message}`
+      )
+      expect(mockLogs.getLogger('pubsub-component').error).toHaveBeenCalledWith(
+        `Redis pub client error: ${error.message}`
+      )
+    })
+  })
 })

--- a/test/unit/adapters/pubsub.spec.ts
+++ b/test/unit/adapters/pubsub.spec.ts
@@ -156,12 +156,8 @@ describe('PubSubComponent', () => {
 
       handlers.forEach((handler) => expect(() => handler(error)).not.toThrow())
 
-      expect(mockLogs.getLogger('pubsub-component').error).toHaveBeenCalledWith(
-        `Redis sub client error: ${error.message}`
-      )
-      expect(mockLogs.getLogger('pubsub-component').error).toHaveBeenCalledWith(
-        `Redis pub client error: ${error.message}`
-      )
+      expect(mockLogs.getLogger('pubsub-component').error).toHaveBeenCalledWith(error, { client: 'sub' })
+      expect(mockLogs.getLogger('pubsub-component').error).toHaveBeenCalledWith(error, { client: 'pub' })
     })
   })
 })


### PR DESCRIPTION
The pub/sub component builds its clients with `redis.client.duplicate()`. node-redis'
duplicate() constructs a new client from options only and copies no event listeners, so
neither client inherits the main client's 'error' handler from src/adapters/redis.ts.

A Node EventEmitter that emits 'error' with no listener throws, and the service runs with
--abort-on-uncaught-exception, so any Redis disconnect aborted the process.

Observed in dev on 2026-08-04 during an ElastiCache node-type change:

  13:53:31Z  Uncaught Error: Socket closed unexpectedly
             task exited 133, StopCode=EssentialContainerExited
  13:54:54Z  replacement task RUNNING

That was ~80-100s of downtime with all WebSocket connections dropped, on a task that had
been up since 2026-07-30. This is not specific to resizes: any failover, engine patch, or
network blip triggers it.

Adds an 'error' listener to both duplicated clients so disconnects are logged and node-redis
reconnects (and auto-resubscribes) instead of killing the process. Adds two regression tests,
both verified to fail without the src change.
